### PR TITLE
Rename rustc-guide to rustc-dev-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis CI badge](https://api.travis-ci.com/rust-lang/rustc-guide.svg?branch=master)
+![Travis CI badge](https://api.travis-ci.com/rust-lang/rustc-dev-guide.svg?branch=master)
 
 
 This is a collaborative effort to build a guide that explains how rustc
@@ -6,7 +6,7 @@ works. The aim of the guide is to help new contributors get oriented
 to rustc, as well as to help more experienced folks in figuring out
 some new part of the compiler that they haven't worked on before.
 
-[You can read the latest version of the guide here.](https://rust-lang.github.io/rustc-guide/)
+[You can read the latest version of the guide here.](https://rust-lang.github.io/rustc-dev-guide/)
 
 You may also find the rustdocs [for the compiler itself][rustdocs] useful.
 
@@ -18,7 +18,7 @@ The guide is useful today, but it has a lot of work still go.
 
 If you'd like to help improve the guide, we'd love to have you! You can find
 plenty of issues on the [issue
-tracker](https://github.com/rust-lang/rustc-guide/issues). Just post a
+tracker](https://github.com/rust-lang/rustc-dev-guide/issues). Just post a
 comment on the issue you would like to work on to make sure that we don't
 accidentally duplicate work. If you think something is missing, please open an
 issue about it!
@@ -55,28 +55,28 @@ You will need `mdbook` version `>= 0.3.5` and `mdbook-linkcheck` version `>= 0.5
 
 4. Follow the check-azure link to get to the Azure website for that build: https://dev.azure.com/rust-lang/e71b0ddf-dd27-435a-873c-e30f86eea377/_build/results?buildId=7780
 
-5. There will be approximately 1 billion different jobs for the build. They are for different configurations and platforms. The rustc-guide build only runs on the Linux x86_64-gnu-tools job. So click on that job in the list, which is about 60% down in the list.
+5. There will be approximately 1 billion different jobs for the build. They are for different configurations and platforms. The rustc-dev-guide build only runs on the Linux x86_64-gnu-tools job. So click on that job in the list, which is about 60% down in the list.
 
 6. Click the Run build step in the job to get the console log for the step.
 
 7. Click on the log and Ctrl-f to get a search box in the log
 
-8. Search for rustc-guide. This gets you to the place where the links are checked. It is usually ~11K lines into the log
+8. Search for rustc-dev-guide. This gets you to the place where the links are checked. It is usually ~11K lines into the log
 
 9. Look at the links in the log near that point in the log
 
-10. Fix those links in the rustc-guide (by making a PR in the rustc-guide repo)
+10. Fix those links in the rustc-dev-guide (by making a PR in the rustc-dev-guide repo)
 
-11. Make a PR on the rust-lang/rust repo to update the rustc-guide git submodule in src/docs/rustc-guide.
+11. Make a PR on the rust-lang/rust repo to update the rustc-dev-guide git submodule in src/docs/rustc-dev-guide.
 To make a PR, the following steps are useful.
 
 ```bash
 # Assuming you already cloned the rust-lang/rust repo and you're in the correct directory
-git submodule update --remote src/doc/rustc-guide
+git submodule update --remote src/doc/rustc-dev-guide
 git add -u
-git commit -m "Update rustc-guide"
+git commit -m "Update rustc-dev-guide"
 # Note that you can use -i, which is short for --incremental, in the following command
-./x.py test --incremental --stage 1 src/doc/rustc-guide # This is optional and should succeed anyway
+./x.py test --incremental --stage 1 src/doc/rustc-dev-guide # This is optional and should succeed anyway
 # Open a PR in rust-lang/rust
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ works. The aim of the guide is to help new contributors get oriented
 to rustc, as well as to help more experienced folks in figuring out
 some new part of the compiler that they haven't worked on before.
 
-[You can read the latest version of the guide here.](https://rust-lang.github.io/rustc-dev-guide/)
+[You can read the latest version of the guide here.](https://rustc-dev-guide.rust-lang.org/)
 
 You may also find the rustdocs [for the compiler itself][rustdocs] useful.
 

--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,7 @@ description = "A guide to developing rustc"
 create-missing = false
 
 [output.html]
-git-repository-url = "https://github.com/rust-lang/rustc-guide"
+git-repository-url = "https://github.com/rust-lang/rustc-dev-guide"
 
 [output.html.fold]
 enable = true

--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -25,7 +25,7 @@ You might also find the following sites useful:
 - [compiler-team] -- the home-base for the rust compiler team, with description
   of the team procedures, active working groups, and the team calendar.
 
-[GitHub repository]: https://github.com/rust-lang/rustc-guide/
+[GitHub repository]: https://github.com/rust-lang/rustc-dev-guide/
 [Rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/
 [Forge]: https://forge.rust-lang.org/
 [compiler-team]: https://github.com/rust-lang/compiler-team/

--- a/src/debugging-support-in-rustc.md
+++ b/src/debugging-support-in-rustc.md
@@ -77,13 +77,13 @@ the trait object.
 **TODO**: Figure out if the following should be mentioned in the GDB-Rust document rather than
 this guide page so there is no duplication. This is regarding the following comments:
 
-[This comment by Tom](https://github.com/rust-lang/rustc-guide/pull/316#discussion_r284027340)
+[This comment by Tom](https://github.com/rust-lang/rustc-dev-guide/pull/316#discussion_r284027340)
 > gdb's Rust extensions and limitations are documented in the gdb manual:
 https://sourceware.org/gdb/onlinedocs/gdb/Rust.html -- however, this neglects to mention that
 gdb convenience variables and registers follow the gdb $ convention, and that the Rust parser
 implements the gdb @ extension.
 
-[This question by Aman](https://github.com/rust-lang/rustc-guide/pull/316#discussion_r285401353)
+[This question by Aman](https://github.com/rust-lang/rustc-dev-guide/pull/316#discussion_r285401353)
 > @tromey do you think we should mention this part in the GDB-Rust document rather than this
 document so there is no duplication etc.?
 
@@ -276,7 +276,7 @@ set the breakpoints and what happens when you step it.
 * New demangler in LLVM or LLDB.
 
 **TODO**: Check the location of the demangler source.
-[Question on Github](https://github.com/rust-lang/rustc-guide/pull/316#discussion_r283062536).
+[Question on Github](https://github.com/rust-lang/rustc-dev-guide/pull/316#discussion_r283062536).
 
 #### Reuse Rust compiler for expressions
 

--- a/src/ice-breaker/llvm.md
+++ b/src/ice-breaker/llvm.md
@@ -16,7 +16,7 @@ the result of an LLVM upgrade. The goal here is:
 ## Helpful tips and options
 
 The ["Debugging LLVM"][d] section of the
-rustc-guide gives a step-by-step process for how to help debug bugs
+rustc-dev-guide gives a step-by-step process for how to help debug bugs
 caused by LLVM. In particular, it discusses how to emit LLVM IR, run
 the LLVM IR optimization pipeliness, and so forth. You may also find
 it useful to look at the various codegen options listed under `-Chelp`

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -106,8 +106,8 @@ for stabilization in a checklist, e.g.,
 
 - [ ] Implement the RFC. (CC @rust-lang/compiler -- can anyone write
       up mentoring instructions?)
-- [ ] Adjust the documentation. ([See instructions on rustc-dev-guide.](https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs))
-- [ ] Stabilize the feature. ([See instructions on rustc-dev-guide.](https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr))
+- [ ] Adjust the documentation. ([See instructions on rustc-dev-guide.](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs))
+- [ ] Stabilize the feature. ([See instructions on rustc-dev-guide.](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr))
 ```
 
 <a name="stability-in-code"></a>

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -106,8 +106,8 @@ for stabilization in a checklist, e.g.,
 
 - [ ] Implement the RFC. (CC @rust-lang/compiler -- can anyone write
       up mentoring instructions?)
-- [ ] Adjust the documentation. ([See instructions on rustc-guide.](https://rust-lang.github.io/rustc-guide/stabilization_guide.html#documentation-prs))
-- [ ] Stabilize the feature. ([See instructions on rustc-guide.](https://rust-lang.github.io/rustc-guide/stabilization_guide.html#stabilization-pr))
+- [ ] Adjust the documentation. ([See instructions on rustc-dev-guide.](https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#documentation-prs))
+- [ ] Stabilize the feature. ([See instructions on rustc-dev-guide.](https://rust-lang.github.io/rustc-dev-guide/stabilization_guide.html#stabilization-pr))
 ```
 
 <a name="stability-in-code"></a>

--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -227,7 +227,7 @@ just have a zulip discussion where you tell us (WG-learning) everything you
 know about macros/expansion/hygiene. We were thinking this could be less formal
 (and less work for you) than compiler lecture series lecture... thoughts?
 
-mark-i-m: The goal is to fill out that long-standing gap in the rustc-guide
+mark-i-m: The goal is to fill out that long-standing gap in the rustc-dev-guide
 
 Vadim Petrochenkov: Ok, I'm at UTC+03:00 and generally available in the
 evenings (or weekends).
@@ -628,7 +628,7 @@ Vadim Petrochenkov: A thread for offline questions-answers would be good too.
     A thread for offline questions-answers would be good too.
 
 I don't mind using this thread, since it already has a lot of info in it. We
-also plan to summarize the info from this thread into the rustc-guide.
+also plan to summarize the info from this thread into the rustc-dev-guide.
 
     Sure, why not.
 
@@ -648,7 +648,7 @@ eager expansion...
 Santiago Pastorino: sorry but I couldn't follow that much today, will read it
 when I have some time later
 
-Santiago Pastorino: btw https://github.com/rust-lang/rustc-guide/issues/398
+Santiago Pastorino: btw https://github.com/rust-lang/rustc-dev-guide/issues/398
 
 mark-i-m: @Vadim Petrochenkov Would 7pm UTC on August 21 work for a followup?
 

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -8,8 +8,8 @@ to do, so compilation is faster. Note that since MIR is generic (not
 effective; we can optimize the generic version, so all of the monomorphizations
 are cheaper!
 
-[mir]: https://rust-lang.github.io/rustc-guide/mir/index.html
-[monomorph]: https://rust-lang.github.io/rustc-guide/appendix/glossary.html?highlight=monomorphize#appendix-c-glossary
+[mir]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
+[monomorph]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html?highlight=monomorphize#appendix-c-glossary
 
 MIR optimizations run after borrow checking. We run a series of optimization
 passes over the MIR to improve it. Some passes are required to run on all code,
@@ -22,9 +22,9 @@ run and that some validation has occurred. Then, it [steals][steal] the MIR
 optimizes it, and returns the improved MIR.
 
 [optmir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/transform/fn.optimized_mir.html
-[query]: https://rust-lang.github.io/rustc-guide/query.html
-[defid]: https://rust-lang.github.io/rustc-guide/appendix/glossary.html?highlight=DefId#appendix-c-glossary
-[steal]: https://rust-lang.github.io/rustc-guide/mir/passes.html?highlight=steal#stealing
+[query]: https://rust-lang.github.io/rustc-dev-guide/query.html
+[defid]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html?highlight=DefId#appendix-c-glossary
+[steal]: https://rust-lang.github.io/rustc-dev-guide/mir/passes.html?highlight=steal#stealing
 
 ## Defining optimization passes
 

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -8,8 +8,8 @@ to do, so compilation is faster. Note that since MIR is generic (not
 effective; we can optimize the generic version, so all of the monomorphizations
 are cheaper!
 
-[mir]: https://rust-lang.github.io/rustc-dev-guide/mir/index.html
-[monomorph]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html?highlight=monomorphize#appendix-c-glossary
+[mir]: https://rustc-dev-guide.rust-lang.org/mir/index.html
+[monomorph]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html?highlight=monomorphize#appendix-c-glossary
 
 MIR optimizations run after borrow checking. We run a series of optimization
 passes over the MIR to improve it. Some passes are required to run on all code,
@@ -22,9 +22,9 @@ run and that some validation has occurred. Then, it [steals][steal] the MIR
 optimizes it, and returns the improved MIR.
 
 [optmir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/transform/fn.optimized_mir.html
-[query]: https://rust-lang.github.io/rustc-dev-guide/query.html
-[defid]: https://rust-lang.github.io/rustc-dev-guide/appendix/glossary.html?highlight=DefId#appendix-c-glossary
-[steal]: https://rust-lang.github.io/rustc-dev-guide/mir/passes.html?highlight=steal#stealing
+[query]: https://rustc-dev-guide.rust-lang.org/query.html
+[defid]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html?highlight=DefId#appendix-c-glossary
+[steal]: https://rustc-dev-guide.rust-lang.org/mir/passes.html?highlight=steal#stealing
 
 ## Defining optimization passes
 

--- a/src/part-1-intro.md
+++ b/src/part-1-intro.md
@@ -1,6 +1,6 @@
 # Part 1: Building, debugging, and contributing to Rustc
 
-This section of the rustc-guide contains knowledge that should be useful to you
+This section of the rustc-dev-guide contains knowledge that should be useful to you
 regardless of what part of the compiler you are working on. This includes both
 technical info and tips (e.g. how to compile and debug the compiler) and info
 about processes in the Rust project (e.g. stabilization and info about the

--- a/src/part-2-intro.md
+++ b/src/part-2-intro.md
@@ -7,6 +7,6 @@ compilation works.
 This section should be friendly to both readers interested in the end-to-end
 process of compilation _and_ readers interested in learning about a specific
 system they wish to contribute to. If anything is unclear, feel free to file
-an issue on the [rustc-guide repo](https://github.com/rust-lang/rustc-guide)
+an issue on the [rustc-dev-guide repo](https://github.com/rust-lang/rustc-dev-guide)
 or contact the compiler team, as detailed in [this chapter from Part
 1](./compiler-team.md).

--- a/src/traits/chalk-overview.md
+++ b/src/traits/chalk-overview.md
@@ -226,7 +226,7 @@ Likewise, lowering tests use the [`lowering_success!` and
 
 [ast]: https://en.wikipedia.org/wiki/Abstract_syntax_tree
 [chalk]: https://github.com/rust-lang/chalk
-[rustc-issues]: https://github.com/rust-lang/rustc-guide/issues
+[rustc-issues]: https://github.com/rust-lang/rustc-dev-guide/issues
 [universal quantification]: https://en.wikipedia.org/wiki/Universal_quantification
 
 [`ProgramClause`]: https://rust-lang.github.io/chalk/chalk_ir/enum.ProgramClause.html


### PR DESCRIPTION
This is in preparation for https://github.com/rust-lang/rustc-guide/issues/470
Needs to be merged after we actually rename the guide.

Have used this to rename:

`git grep -l 'rustc-guide' | xargs sed -i 's/rustc-guide/rustc-dev-guide/g'`
`git grep -l 'rustc guide' | xargs sed -i 's/rustc guide/rustc dev guide/g'`