### PR TITLE
Simplify path rustc_interface::interface::run_compiler

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -12,7 +12,6 @@ use rustc::session;
 use rustc::session::config;
 use rustc_errors::registry;
 use rustc_hash::{FxHashMap, FxHashSet};
-use rustc_interface::interface;
 use rustc_span::source_map;
 use std::path;
 use std::process;
@@ -28,7 +27,7 @@ fn main() {
     let filename = "main.rs";
     let contents = "static HELLO: &str = \"Hello, world!\"; fn main() { println!(\"{}\", HELLO); }";
     let errors = registry::Registry::new(&rustc_error_codes::DIAGNOSTICS);
-    let config = interface::Config {
+    let config = rustc_interface::Config {
         // Command line options
         opts: config::Options {
             maybe_sysroot: Some(path::PathBuf::from(sysroot)),
@@ -80,7 +79,7 @@ fn main() {
         // Registry of diagnostics codes.
         registry: errors,
     };
-    interface::run_compiler(config, |compiler| {
+    rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {
             // Parse the program and print the syntax tree.
             let parse = queries.parse().unwrap().take();

--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -9,7 +9,7 @@ for running code at particular times during the compilation process, allowing
 third parties to effectively use `rustc`'s internals as a library for
 analysing a crate or emulating the compiler in-process (e.g. the RLS or rustdoc).
 
-For those using `rustc` as a library, the [`rustc_interface::interface::run_compiler()`][i_rc]
+For those using `rustc` as a library, the [`rustc_interface::run_compiler()`][i_rc]
 function is the main entrypoint to the compiler. It takes a configuration for the compiler
 and a closure that takes a [`Compiler`]. `run_compiler` creates a `Compiler` from the 
 configuration and passes it to the closure. Inside the closure, you can use the `Compiler`
@@ -19,7 +19,7 @@ You can see a minimal example of how to use `rustc_interface` [here][example].
 You can see what queries are currently available through the rustdocs for [`Compiler`].
 You can see an example of how to use them by looking at the `rustc_driver` implementation,
 specifically the [`rustc_driver::run_compiler` function][rd_rc] (not to be confused with
-[`rustc_interface::interface::run_compiler`][i_rc]). The `rustc_driver::run_compiler` function 
+[`rustc_interface::run_compiler`][i_rc]). The `rustc_driver::run_compiler` function 
 takes a bunch of command-line args and some other configurations and
 drives the compilation to completion.
 


### PR DESCRIPTION
It's not necessary to use rustc_interface::interface::run_compiler to get to the run_compiler function---this function is re-exported by the top-level module of the rustc_interface crate. 