### PR TITLE
Add license documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,6 +32,7 @@
     - [ICE-breaker teams](ice-breaker/about.md)
         - ["Cleanup Crew" ICE-breakers](ice-breaker/cleanup-crew.md)
         - [LLVM ICE-breakers](ice-breaker/llvm.md)
+    - [Licenses](./licenses.md)
 - [Part 2: How rustc works](./part-2-intro.md)
     - [High-level overview of the compiler source](./high-level-overview.md)
     - [The Rustc Driver and Interface](./rustc-driver.md)

--- a/src/licenses.md
+++ b/src/licenses.md
@@ -1,0 +1,5 @@
+# Rustc Licenses
+
+The `rustc` compiler source is dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
+
+Detailed licensing information is available in the [COPYRIGHT document](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) of the `rust-lang/rust` repository.

--- a/src/licenses.md
+++ b/src/licenses.md
@@ -1,5 +1,5 @@
 # `rust-lang/rust` Licenses
 
-The `rustc` compiler source and standard library is dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
+The `rustc` compiler source and standard library are dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
 
 Detailed licensing information is available in the [COPYRIGHT document](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) of the `rust-lang/rust` repository.

--- a/src/licenses.md
+++ b/src/licenses.md
@@ -1,5 +1,5 @@
 # Rustc Licenses
 
-The `rustc` compiler source is dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
+The `rustc` compiler source and standard library is dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
 
 Detailed licensing information is available in the [COPYRIGHT document](https://github.com/rust-lang/rust/blob/master/COPYRIGHT) of the `rust-lang/rust` repository.

--- a/src/licenses.md
+++ b/src/licenses.md
@@ -1,4 +1,4 @@
-# Rustc Licenses
+# `rust-lang/rust` Licenses
 
 The `rustc` compiler source and standard library is dual licensed under the [Apache License v2.0](https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE) and the [MIT License](https://github.com/rust-lang/rust/blob/master/LICENSE-MIT) unless otherwise specified.
 


### PR DESCRIPTION
Adds Part 1 documentation of the dual Apache License v2.0 and MIT license structure of the rust-lang/rust source repository, and links to the rust-lang/rust COPYRIGHT document for more information on contributor copyrights and other licenses that apply to areas of the source. This document is placed at the end of the Part 1 ToC.