### PR TITLE
Change ICE-breaker ping to use the new aliases

### DIFF
--- a/src/ice-breaker/about.md
+++ b/src/ice-breaker/about.md
@@ -58,13 +58,21 @@ To tag an issue as appropriate for an ICE-breaker group, you give
 team. For example:
 
 ```text
+@rustbot ping icebreakers-llvm
+@rustbot ping icebreakers-cleanup-crew
+```
+
+To make these commands shorter and easier to remember, there are aliases,
+defined in the [`triagebot.toml`] file. For example:
+
+```text
 @rustbot ping llvm
 @rustbot ping cleanup
 ```
 
-These are aliases that are easier to remember than the full invocation.
-They are declared in the [`triagebot.toml`] file and might be subject to
-changes.
+Keep in mind that these aliases are meant to make humans' life easier.
+They might be subject to change. If you need to ensure that a command
+will always be valid, prefer the full invocations over the aliases.
 
 **Note though that this should only be done by compiler team members
 or contributors, and is typically done as part of compiler team

--- a/src/ice-breaker/about.md
+++ b/src/ice-breaker/about.md
@@ -62,9 +62,14 @@ team. For example:
 @rustbot ping cleanup
 ```
 
+These are aliases that are easier to remember than the full invocation.
+They are declared in the [`triagebot.toml`] file and might be subject to
+changes.
+
 **Note though that this should only be done by compiler team members
 or contributors, and is typically done as part of compiler team
 triage.**
 
 [rustbot]: https://github.com/rust-lang/triagebot/
 [`ping`]: https://github.com/rust-lang/triagebot/wiki/Pinging
+[`triagebot.toml`]: https://github.com/rust-lang/rust/blob/master/triagebot.toml

--- a/src/ice-breaker/about.md
+++ b/src/ice-breaker/about.md
@@ -58,8 +58,8 @@ To tag an issue as appropriate for an ICE-breaker group, you give
 team. For example:
 
 ```text
-@rustbot ping icebreakers-llvm
-@rustbot ping icebreakers-cleanup-crew
+@rustbot ping llvm
+@rustbot ping cleanup
 ```
 
 **Note though that this should only be done by compiler team members


### PR DESCRIPTION
I'm not sure if this is really useful, but I think the "full" invocation is really long and not convenient to learn.

Related to rust-lang/rust#69949