### PR TITLE
Document how to get the type of an expression using rustc_interface

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,6 +37,7 @@
     - [High-level overview of the compiler source](./high-level-overview.md)
     - [The Rustc Driver and Interface](./rustc-driver.md)
         - [Rustdoc](./rustdoc.md)
+        - [Interacting with the AST](./rustc-driver-interacting-with-the-ast.md)
     - [Queries: demand-driven compilation](./query.md)
         - [The Query Evaluation Model in Detail](./queries/query-evaluation-model-in-detail.md)
         - [Incremental compilation](./queries/incremental-compilation.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,7 +37,7 @@
     - [High-level overview of the compiler source](./high-level-overview.md)
     - [The Rustc Driver and Interface](./rustc-driver.md)
         - [Rustdoc](./rustdoc.md)
-        - [Example: Type checking through `rustc_interface`](./rustc-driver-interacting-with-the-ast.md)
+        - [Ex: Type checking through `rustc_interface`](./rustc-driver-interacting-with-the-ast.md)
     - [Queries: demand-driven compilation](./query.md)
         - [The Query Evaluation Model in Detail](./queries/query-evaluation-model-in-detail.md)
         - [Incremental compilation](./queries/incremental-compilation.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,7 +37,7 @@
     - [High-level overview of the compiler source](./high-level-overview.md)
     - [The Rustc Driver and Interface](./rustc-driver.md)
         - [Rustdoc](./rustdoc.md)
-        - [Interacting with the AST](./rustc-driver-interacting-with-the-ast.md)
+        - [Example: Type checking through `rustc_interface`](./rustc-driver-interacting-with-the-ast.md)
     - [Queries: demand-driven compilation](./query.md)
         - [The Query Evaluation Model in Detail](./queries/query-evaluation-model-in-detail.md)
         - [Incremental compilation](./queries/incremental-compilation.md)

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -1,0 +1,41 @@
+# Interacting with the AST
+
+`rustc_interface` allows you to interact with Rust code at various stages of compilation.
+
+## Getting the type of an expression
+
+To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`:
+
+```rust
+// In this example, config specifies the rust program:
+//   fn main() { let message = \"Hello, world!\"; println!(\"{}\", message); }
+// Our goal is to get the type of the string literal "Hello, world!".
+//
+// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-example.rs for a complete example of configuring rustc_interface
+rustc_interface::run_compiler(config, |compiler| {
+    compiler.enter(|queries| {
+        // Analyze the crate and inspect the types under the cursor.
+        queries.global_ctxt().unwrap().take().enter(|tcx| {
+            // Every compilation contains a single crate.
+            let krate = tcx.hir().krate();
+            // Iterate over the top-level items in the crate, looking for the main function.
+            for (_, item) in &krate.items {
+                // Use pattern-matching to find a specific node inside the main function.
+                if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
+                    let expr = &tcx.hir().body(body_id).value;
+                    if let rustc_hir::ExprKind::Block(block, _) = expr.kind {
+                        if let rustc_hir::StmtKind::Local(local) = block.stmts[0].kind {
+                            if let Some(expr) = local.init {
+                                let hir_id = expr.hir_id; // hir_id identifies the string "Hello, world!"
+                                let def_id = tcx.hir().local_def_id(item.hir_id); // def_id identifies the main function
+                                let ty = tcx.typeck_tables_of(def_id).node_type(hir_id);
+                                println!("{:?}: {:?}", expr, ty); // prints expr(HirId { owner: DefIndex(3), local_id: 4 }: "Hello, world!"): &'static str
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    });
+});
+```

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -1,4 +1,4 @@
-# Interacting with the AST
+# Example: Type checking through `rustc_interface`
 
 `rustc_interface` allows you to interact with Rust code at various stages of compilation.
 


### PR DESCRIPTION
I am learning rustc_interface, and I am trying to improve the docs as I go. I am eager for feedback if there's a better way to do what I am documenting here. My [first PR](https://github.com/rust-lang/rustc-dev-guide/pull/621) added a "Hello world" working example for rustc_interface.

This PR creates a new page, which will document how to do various common tasks with rustc_interface. It's less of a reference and more of a howto. The rustc_interface API surface is very large and so it's quite hard to get started---this page is designed to remedy that. 

This page will have multiple examples, but as a place to start, I am showing how to get the type of an expression. 

@mark-i-m FYI