### PR TITLE
"About This Guide" updates following Guide reorganization

### DIFF
--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -9,13 +9,13 @@ There are six parts to this guide:
 1. [Building, Debugging, and Contributing to `rustc`][p1]: Contains information that should be useful no matter how
    you are contributing, such as procedures for contribution, building the
    compiler, etc.
-2. [How `rustc` Works][p2]: Discusses the high-level
-   architecture of the compiler and stages of the compile process
+2. [High-Level Compiler Architecture][p2]: Discusses the high-level
+   architecture of the compiler and stages of the compile process.
 3. [Source Code Representation][p3]: Describes the process of taking raw source code from the user and
-   transforming it into various forms that the compiler can work with easily
+   transforming it into various forms that the compiler can work with easily.
 4. [Analysis][p4]: discusses the analyses that the compiler uses to check various
-   properties of the code and inform later stages of the compile process
-5. [From MIR to Binaries][p5]: How linked executable machine code is generated
+   properties of the code and inform later stages of the compile process (e.g., type checking).
+5. [From MIR to Binaries][p5]: How linked executable machine code is generated.
 6. [Appendices][app] at the end with useful reference information. There are a
    few of these with different information, inluding a glossary.
 

--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -6,16 +6,16 @@ development.
 
 There are six parts to this guide:
 
-1. [Contributing][p1]: Contains information that should be useful no matter how
+1. [Building, Debugging, and Contributing to `rustc`][p1]: Contains information that should be useful no matter how
    you are contributing, such as procedures for contribution, building the
    compiler, etc.
-2. [High-level Compiler Architecture][p2]: Discusses the high-level
-   architecture of the compiler, especially the query system.
-3. [The Compiler Frontend][p3]: Discusses the compiler frontend and internal
-   representations.
-4. [The Type System][p4]: Discusses the type system.
-5. [The Compiler Backend][p5]: Discusses the compiler backend, code generation,
-   linking, and debug info.
+2. [How `rustc` Works][p2]: Discusses the high-level
+   architecture of the compiler and stages of the compile process
+3. [Source Code Representation][p3]: Describes the process of taking raw source code from the user and
+   transforming it into various forms that the compiler can work with easily
+4. [Analysis][p4]: discusses the analyses that the compiler uses to check various
+   properties of the code and inform later stages of the compile process
+5. [From MIR to Binaries][p5]: How linked executable machine code is generated
 6. [Appendices][app] at the end with useful reference information. There are a
    few of these with different information, inluding a glossary.
 
@@ -26,7 +26,7 @@ There are six parts to this guide:
 [p5]: ./part-5-intro.md
 [app]: ./appendix/background.md
 
-The guide itself is of course open-source as well, and the sources can
+The Guide itself is of course open-source as well, and the sources can
 be found at the [GitHub repository]. If you find any mistakes in the
 guide, please file an issue about it, or even better, open a PR
 with a correction!
@@ -35,12 +35,12 @@ with a correction!
 
 You might also find the following sites useful:
 
-- [Rustc API docs] -- rustdoc documentation for the compiler
+- [rustc API docs] -- rustdoc documentation for the compiler
 - [Forge] -- contains documentation about rust infrastructure, team procedures, and more
 - [compiler-team] -- the home-base for the rust compiler team, with description
   of the team procedures, active working groups, and the team calendar.
 
 [GitHub repository]: https://github.com/rust-lang/rustc-dev-guide/
-[Rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/
+[rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/
 [Forge]: https://forge.rust-lang.org/
 [compiler-team]: https://github.com/rust-lang/compiler-team/

--- a/src/part-1-intro.md
+++ b/src/part-1-intro.md
@@ -1,4 +1,4 @@
-# Part 1: Building, debugging, and contributing to Rustc
+# Part 1: Building, Debugging, and Contributing to `rustc`
 
 This section of the rustc-dev-guide contains knowledge that should be useful to you
 regardless of what part of the compiler you are working on. This includes both

--- a/src/part-2-intro.md
+++ b/src/part-2-intro.md
@@ -1,4 +1,4 @@
-# Part 2: How rustc works
+# Part 2: How `rustc` Works
 
 The remaining parts of this guide discuss how the compiler works. They go
 through everything from high-level structure of the compiler to how each stage

--- a/src/part-2-intro.md
+++ b/src/part-2-intro.md
@@ -1,4 +1,4 @@
-# Part 2: How `rustc` Works
+# Part 2: High-Level Compiler Architecture
 
 The remaining parts of this guide discuss how the compiler works. They go
 through everything from high-level structure of the compiler to how each stage

--- a/src/part-5-intro.md
+++ b/src/part-5-intro.md
@@ -1,4 +1,4 @@
-# From MIR to binaries
+# From MIR to Binaries
 
 All of the preceding chapters of this guide have one thing in common: we never
 generated any executable machine code at all! With this chapter, all of that


### PR DESCRIPTION
This PR updates the About This Guide page with the new section titles/descriptions following the reorganization in #651.  