### PR TITLE
Reduce cache timeout to catch broken links faster.

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -16,5 +16,5 @@ level = 1
 [output.linkcheck]
 follow-web-links = true
 exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il" ]
-cache-timeout = 172800
+cache-timeout = 86400
 warning-policy = "error"


### PR DESCRIPTION
It would be nice to catch broken links a bit faster. The tradeoff is that we might end up with more spurious failures.

I propose that we shorten the cache timeout from 2 days to 1 day as an experiment.

Thoughts?