### PR TITLE
Fix example for winnowing

### DIFF
--- a/src/traits/resolution.md
+++ b/src/traits/resolution.md
@@ -191,12 +191,16 @@ trait Get {
     fn get(&self) -> Self;
 }
 
-impl<T:Copy> Get for T {
-    fn get(&self) -> T { *self }
+impl<T: Copy> Get for T {
+    fn get(&self) -> T {
+        *self
+    }
 }
 
-impl<T:Get> Get for Box<T> {
-    fn get(&self) -> Box<T> { Box::new(get_it(&**self)) }
+impl<T: Get> Get for Box<T> {
+    fn get(&self) -> Box<T> {
+        Box::new(<T>::get(self))
+    }
 }
 ```
 


### PR DESCRIPTION
This example mentioned a method `get_it` which does not exist afaict.

This is still not optimal IMO as we get the following error when using this
outside of std.
```
error[E0119]: conflicting implementations of trait `Get` for type `std::boxed::Box<_>`:
  --> src/lib.rs:11:1
   |
5  | impl<T: Copy> Get for T {
   | ----------------------- first implementation here
...
11 | impl<T: Get> Get for Box<T> {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `std::boxed::Box<_>`
   |
   = note: downstream crates may implement trait `std::marker::Copy` for type `std::boxed::Box<_>`
```