### PR TITLE
Example of getting diagnostics

### DIFF
--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -1,0 +1,89 @@
+#![feature(rustc_private)]
+
+// NOTE: For the example to compile, you will need to first run the following:
+//   rustup component add rustc-dev
+
+extern crate rustc;
+extern crate rustc_error_codes;
+extern crate rustc_errors;
+extern crate rustc_hash;
+extern crate rustc_hir;
+extern crate rustc_interface;
+extern crate rustc_session;
+extern crate rustc_span;
+
+use rustc_errors::registry;
+use rustc_session::config;
+use rustc_span::source_map;
+use std::io;
+use std::path;
+use std::process;
+use std::str;
+use std::sync;
+
+// Buffer diagnostics in a Vec<u8>.
+#[derive(Clone)]
+pub struct DiagnosticSink(sync::Arc<sync::Mutex<Vec<u8>>>);
+
+impl io::Write for DiagnosticSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+fn main() {
+    let out = process::Command::new("rustc")
+        .arg("--print=sysroot")
+        .current_dir(".")
+        .output()
+        .unwrap();
+    let sysroot = str::from_utf8(&out.stdout).unwrap().trim();
+    let buffer = sync::Arc::new(sync::Mutex::new(Vec::new()));
+    let config = rustc_interface::Config {
+        opts: config::Options {
+            maybe_sysroot: Some(path::PathBuf::from(sysroot)),
+            // Configure the compiler to emit diagnostics in compact JSON format.
+            error_format: config::ErrorOutputType::Json {
+                pretty: false,
+                json_rendered: rustc_errors::emitter::HumanReadableErrorType::Default(
+                    rustc_errors::emitter::ColorConfig::Never,
+                ),
+            },
+            ..config::Options::default()
+        },
+        // This program contains a type error.
+        input: config::Input::Str {
+            name: source_map::FileName::Custom("main.rs".to_string()),
+            input: "fn main() { let x: &str = 1; }".to_string(),
+        },
+        // Redirect the diagnostic output of the compiler to a buffer.
+        diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
+            buffer.clone(),
+        ))),
+        crate_cfg: rustc_hash::FxHashSet::default(),
+        input_path: None,
+        output_dir: None,
+        output_file: None,
+        file_loader: None,
+        stderr: None,
+        crate_name: None,
+        lint_caps: rustc_hash::FxHashMap::default(),
+        register_lints: None,
+        override_queries: None,
+        registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
+    };
+    rustc_interface::run_compiler(config, |compiler| {
+        compiler.enter(|queries| {
+            queries.global_ctxt().unwrap().take().enter(|tcx| {
+                // Run the analysis phase on the local crate to trigger the type error.
+                tcx.analysis(rustc_hir::def_id::LOCAL_CRATE);
+            });
+        });
+    });
+    // Read buffered diagnostics.
+    let diagnostics = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    println!("{}", diagnostics);
+}

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -1,0 +1,78 @@
+#![feature(rustc_private)]
+
+// NOTE: For the example to compile, you will need to first run the following:
+//   rustup component add rustc-dev
+
+extern crate rustc;
+extern crate rustc_error_codes;
+extern crate rustc_errors;
+extern crate rustc_hash;
+extern crate rustc_hir;
+extern crate rustc_interface;
+extern crate rustc_session;
+extern crate rustc_span;
+
+use rustc_errors::registry;
+use rustc_session::config;
+use rustc_span::source_map;
+use std::path;
+use std::process;
+use std::str;
+
+fn main() {
+    let out = process::Command::new("rustc")
+        .arg("--print=sysroot")
+        .current_dir(".")
+        .output()
+        .unwrap();
+    let sysroot = str::from_utf8(&out.stdout).unwrap().trim();
+    let config = rustc_interface::Config {
+        opts: config::Options {
+            maybe_sysroot: Some(path::PathBuf::from(sysroot)),
+            ..config::Options::default()
+        },
+        input: config::Input::Str {
+            name: source_map::FileName::Custom("main.rs".to_string()),
+            input: "fn main() { let message = \"Hello, world!\"; println!(\"{}\", message); }"
+                .to_string(),
+        },
+        diagnostic_output: rustc_session::DiagnosticOutput::Default,
+        crate_cfg: rustc_hash::FxHashSet::default(),
+        input_path: None,
+        output_dir: None,
+        output_file: None,
+        file_loader: None,
+        stderr: None,
+        crate_name: None,
+        lint_caps: rustc_hash::FxHashMap::default(),
+        register_lints: None,
+        override_queries: None,
+        registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
+    };
+    rustc_interface::run_compiler(config, |compiler| {
+        compiler.enter(|queries| {
+            // Analyze the crate and inspect the types under the cursor.
+            queries.global_ctxt().unwrap().take().enter(|tcx| {
+                // Every compilation contains a single crate.
+                let krate = tcx.hir().krate();
+                // Iterate over the top-level items in the crate, looking for the main function.
+                for (_, item) in &krate.items {
+                    // Use pattern-matching to find a specific node inside the main function.
+                    if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
+                        let expr = &tcx.hir().body(body_id).value;
+                        if let rustc_hir::ExprKind::Block(block, _) = expr.kind {
+                            if let rustc_hir::StmtKind::Local(local) = block.stmts[0].kind {
+                                if let Some(expr) = local.init {
+                                    let hir_id = expr.hir_id; // hir_id identifies the string "Hello, world!"
+                                    let def_id = tcx.hir().local_def_id(item.hir_id); // def_id identifies the main function
+                                    let ty = tcx.typeck_tables_of(def_id).node_type(hir_id);
+                                    println!("{:?}: {:?}", expr, ty); // prints expr(HirId { owner: DefIndex(3), local_id: 4 }: "Hello, world!"): &'static str
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        });
+    });
+}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -49,6 +49,7 @@
     - [The Rustc Driver and Interface](./rustc-driver.md)
         - [Rustdoc](./rustdoc.md)
         - [Ex: Type checking through `rustc_interface`](./rustc-driver-interacting-with-the-ast.md)
+        - [Ex: Getting diagnostics through `rustc_interface`](./rustc-driver-getting-diagnostics.md)
     - [Syntax and the AST](./syntax-intro.md)
         - [Lexing and Parsing](./the-parser.md)
         - [`#[test]` Implementation](./test-implementation.md)

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -4,100 +4,38 @@
 
 ## Getting diagnostics
 
-NOTE: For the example to compile, you will need to first run the following:
-
-    rustup component add rustc-dev
-
 To get diagnostics from the compiler, 
 configure `rustc_interface::Config` to output diagnostic to a buffer, 
 and run `TyCtxt.analysis`:
 
 ```rust
-#![feature(rustc_private)]
-
-extern crate rustc;
-extern crate rustc_error_codes;
-extern crate rustc_errors;
-extern crate rustc_hash;
-extern crate rustc_hir;
-extern crate rustc_interface;
-extern crate rustc_session;
-extern crate rustc_span;
-
-use rustc_errors::registry;
-use rustc_session::config;
-use rustc_span::source_map;
-use std::io;
-use std::path;
-use std::process;
-use std::str;
-use std::sync;
-
-// Buffer diagnostics in a Vec<u8>.
-#[derive(Clone)]
-pub struct DiagnosticSink(sync::Arc<sync::Mutex<Vec<u8>>>);
-
-impl io::Write for DiagnosticSink {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.lock().unwrap().flush()
-    }
-}
-
-fn main() {
-    let out = process::Command::new("rustc")
-        .arg("--print=sysroot")
-        .current_dir(".")
-        .output()
-        .unwrap();
-    let sysroot = str::from_utf8(&out.stdout).unwrap().trim();
-    let buffer = sync::Arc::new(sync::Mutex::new(Vec::new()));
-    let config = rustc_interface::Config {
-        opts: config::Options {
-            maybe_sysroot: Some(path::PathBuf::from(sysroot)),
-            // Configure the compiler to emit diagnostics in compact JSON format.
-            error_format: config::ErrorOutputType::Json {
-                pretty: false,
-                json_rendered: rustc_errors::emitter::HumanReadableErrorType::Default(
-                    rustc_errors::emitter::ColorConfig::Never,
-                ),
-            },
-            ..config::Options::default()
+// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs for complete program.
+let buffer = sync::Arc::new(sync::Mutex::new(Vec::new()));
+let config = rustc_interface::Config {
+    opts: config::Options {
+        // Configure the compiler to emit diagnostics in compact JSON format.
+        error_format: config::ErrorOutputType::Json {
+            pretty: false,
+            json_rendered: rustc_errors::emitter::HumanReadableErrorType::Default(
+                rustc_errors::emitter::ColorConfig::Never,
+            ),
         },
-        // This program contains a type error.
-        input: config::Input::Str {
-            name: source_map::FileName::Custom("main.rs".to_string()),
-            input: "fn main() { let x: &str = 1; }".to_string(),
-        },
-        // Redirect the diagnostic output of the compiler to a buffer.
-        diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
-            buffer.clone(),
-        ))),
-        crate_cfg: rustc_hash::FxHashSet::default(),
-        input_path: None,
-        output_dir: None,
-        output_file: None,
-        file_loader: None,
-        stderr: None,
-        crate_name: None,
-        lint_caps: rustc_hash::FxHashMap::default(),
-        register_lints: None,
-        override_queries: None,
-        registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
-    };
-    rustc_interface::run_compiler(config, |compiler| {
-        compiler.enter(|queries| {
-            queries.global_ctxt().unwrap().take().enter(|tcx| {
-                // Run the analysis phase on the local crate to trigger the type error.
-                tcx.analysis(rustc_hir::def_id::LOCAL_CRATE);
-            });
+        /* other config */
+    },
+    // Redirect the diagnostic output of the compiler to a buffer.
+    diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
+        buffer.clone(),
+    ))),
+    /* other config */
+};
+rustc_interface::run_compiler(config, |compiler| {
+    compiler.enter(|queries| {
+        queries.global_ctxt().unwrap().take().enter(|tcx| {
+            // Run the analysis phase on the local crate to trigger the type error.
+            tcx.analysis(rustc_hir::def_id::LOCAL_CRATE);
         });
     });
-    // Read and print buffered diagnostics.
-    let diagnostics = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
-    println!("{}", diagnostics);
-}
-
+});
+// Read buffered diagnostics.
+let diagnostics = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
 ```

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -1,0 +1,101 @@
+# Example: Getting diagnostic through `rustc_interface`
+
+`rustc_interface` allows you to intercept diagnostics that would otherwise be printed to stderr.
+
+## Getting diagnostics
+
+NOTE: For the example to compile, you will need to first run the following:
+
+    rustup component add rustc-dev
+
+To get diagnostics from the compiler, configure `rustc_interface::Config` to output diagnostic to a buffer, and run `TyCtxt.analysis`:
+
+```rust
+#![feature(rustc_private)]
+
+extern crate rustc;
+extern crate rustc_error_codes;
+extern crate rustc_errors;
+extern crate rustc_hash;
+extern crate rustc_hir;
+extern crate rustc_interface;
+extern crate rustc_session;
+extern crate rustc_span;
+
+use rustc_errors::registry;
+use rustc_session::config;
+use rustc_span::source_map;
+use std::io;
+use std::path;
+use std::process;
+use std::str;
+use std::sync;
+
+// Buffer diagnostics in a Vec<u8>.
+#[derive(Clone)]
+pub struct DiagnosticSink(sync::Arc<sync::Mutex<Vec<u8>>>);
+
+impl io::Write for DiagnosticSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.lock().unwrap().flush()
+    }
+}
+
+fn main() {
+    let out = process::Command::new("rustc")
+        .arg("--print=sysroot")
+        .current_dir(".")
+        .output()
+        .unwrap();
+    let sysroot = str::from_utf8(&out.stdout).unwrap().trim();
+    let buffer = sync::Arc::new(sync::Mutex::new(Vec::new()));
+    let config = rustc_interface::Config {
+        opts: config::Options {
+            maybe_sysroot: Some(path::PathBuf::from(sysroot)),
+            // Configure the compiler to emit diagnostics in compact JSON format.
+            error_format: config::ErrorOutputType::Json {
+                pretty: false,
+                json_rendered: rustc_errors::emitter::HumanReadableErrorType::Default(
+                    rustc_errors::emitter::ColorConfig::Never,
+                ),
+            },
+            ..config::Options::default()
+        },
+        // This program contains a type error.
+        input: config::Input::Str {
+            name: source_map::FileName::Custom("main.rs".to_string()),
+            input: "fn main() { let x: &str = 1; }".to_string(),
+        },
+        // Redirect the diagnostic output of the compiler to a buffer.
+        diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
+            buffer.clone(),
+        ))),
+        crate_cfg: rustc_hash::FxHashSet::default(),
+        input_path: None,
+        output_dir: None,
+        output_file: None,
+        file_loader: None,
+        stderr: None,
+        crate_name: None,
+        lint_caps: rustc_hash::FxHashMap::default(),
+        register_lints: None,
+        override_queries: None,
+        registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
+    };
+    rustc_interface::run_compiler(config, |compiler| {
+        compiler.enter(|queries| {
+            queries.global_ctxt().unwrap().take().enter(|tcx| {
+                // Run the analysis phase on the local crate to trigger the type error.
+                tcx.analysis(rustc_hir::def_id::LOCAL_CRATE);
+            });
+        });
+    });
+    // Read and print buffered diagnostics.
+    let diagnostics = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    println!("{}", diagnostics);
+}
+
+```

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -8,7 +8,9 @@ NOTE: For the example to compile, you will need to first run the following:
 
     rustup component add rustc-dev
 
-To get diagnostics from the compiler, configure `rustc_interface::Config` to output diagnostic to a buffer, and run `TyCtxt.analysis`:
+To get diagnostics from the compiler, 
+configure `rustc_interface::Config` to output diagnostic to a buffer, 
+and run `TyCtxt.analysis`:
 
 ```rust
 #![feature(rustc_private)]

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -4,18 +4,18 @@
 
 ## Getting the type of an expression
 
-NOTE: For the example to compile, you will need to first run the following:
-
-    rustup component add rustc-dev
-
 To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`:
 
 ```rust
-// In this example, config specifies the rust program:
-//   fn main() { let message = \"Hello, world!\"; println!(\"{}\", message); }
-// Our goal is to get the type of the string literal "Hello, world!".
-//
-// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-example.rs for a complete example of configuring rustc_interface
+// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs for complete program.
+let config = rustc_interface::Config {
+    input: config::Input::Str {
+        name: source_map::FileName::Custom("main.rs".to_string()),
+        input: "fn main() { let message = \"Hello, world!\"; println!(\"{}\", message); }"
+            .to_string(),
+    },
+    /* other config */
+};
 rustc_interface::run_compiler(config, |compiler| {
     compiler.enter(|queries| {
         // Analyze the crate and inspect the types under the cursor.


### PR DESCRIPTION
Follow-up of [forum chat](https://internals.rust-lang.org/t/using-the-rustc-interface-crate/11982/20), https://github.com/rust-lang/rust/issues/71770, and [zulip chat](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Is.20rustc_interface.20a.20rustc.20interface.3F)

Using `rustc_session::DiagnosticOutput::Raw` and parsing the resulting JSON seems to be the recommended way to get diagnostics from rustc, so this is a minimal example of how to do that.

The code example is long, but there are a bunch of top-level subtleties, and so I think it is necessary to give a complete working program. If we just give the central snippet, I think future readers will have difficulty figuring out the surrounding context they need to get the program to work.