### PR TITLE
Extern blocks are allowed for #[track_caller] now.

### DIFF
--- a/src/codegen/implicit-caller-location.md
+++ b/src/codegen/implicit-caller-location.md
@@ -160,7 +160,6 @@ The `#[track_caller]` attribute is checked alongside other codegen attributes to
 function:
 
 * has the `"Rust"` ABI (as opposed to e.g., `"C"`)
-* is not a foreign import (e.g., in an `extern {...}` block)
 * is not a closure
 * is not `#[naked]`
 


### PR DESCRIPTION
since https://github.com/rust-lang/rust/pull/70916