### PR TITLE
Add some guidelines on the CLI.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,7 +29,6 @@
     - [Emitting Errors and other Diagnostics](diagnostics.md)
         - [`LintStore`](./diagnostics/lintstore.md)
         - [Diagnostic Codes](./diagnostics/diagnostic-codes.md)
-    - [Command-line arguments](./cli.md)
     - [ICE-breaker teams](ice-breaker/about.md)
         - ["Cleanup Crew" ICE-breakers](ice-breaker/cleanup-crew.md)
         - [LLVM ICE-breakers](ice-breaker/llvm.md)
@@ -48,6 +47,7 @@
     - [Parallel Compilation](./parallel-rustc.md)
 
 - [Part 3: Source Code Representations](./part-3-intro.md)
+    - [Command-line arguments](./cli.md)
     - [The Rustc Driver and Interface](./rustc-driver.md)
         - [Rustdoc](./rustdoc.md)
         - [Ex: Type checking through `rustc_interface`](./rustc-driver-interacting-with-the-ast.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,6 +29,7 @@
     - [Emitting Errors and other Diagnostics](diagnostics.md)
         - [`LintStore`](./diagnostics/lintstore.md)
         - [Diagnostic Codes](./diagnostics/diagnostic-codes.md)
+    - [Command-line arguments](./cli.md)
     - [ICE-breaker teams](ice-breaker/about.md)
         - ["Cleanup Crew" ICE-breakers](ice-breaker/cleanup-crew.md)
         - [LLVM ICE-breakers](ice-breaker/llvm.md)

--- a/src/cli.md
+++ b/src/cli.md
@@ -1,0 +1,29 @@
+# Command-line Arguments
+
+Command-line flags are documented in the [rustc book][cli-docs]. All *stable*
+flags should be documented there. Unstable flags should be documented in the
+[unstable book].
+
+## Guidelines
+
+- Flags should be orthogonal to each other. For example, if we'd have a
+  json-emitting variant of multiple actions `foo` and `bar`, an additional
+  `--json` flag is better than adding `--foo-json` and `--bar-json`.
+- Avoid flags with the `no-` prefix. Instead, use the [`parse_bool`] function,
+  such as `-C embed-bitcode=no`.
+- Consider the behavior if the flag is passed multiple times. In some
+  situations, the values should be accumulated (in order!). In other
+  situations, subsequence flags should override previous flags (for example,
+  the lint-level flags). And some flags (like `-o`) should generate an error
+  if it is too ambiguous what multiple flags would mean.
+- Always give options a long descriptive name, if only for more understandable
+  compiler scripts.
+- The `--verbose` flag is for adding verbose information to `rustc` output
+  when not compiling a program. For example, using it with the `--version`
+  flag gives information about the hashes of the code.
+- Experimental flags and options must be guarded behind the `-Z
+  unstable-options` flag.
+
+[cli-docs]: https://doc.rust-lang.org/rustc/command-line-arguments.html
+[unstable book]: https://doc.rust-lang.org/nightly/unstable-book/
+[`parse_bool`]: https://github.com/rust-lang/rust/blob/e5335592e78354e33d798d20c04bcd677c1df62d/src/librustc_session/options.rs#L307-L313

--- a/src/cli.md
+++ b/src/cli.md
@@ -13,14 +13,14 @@ flags should be documented there. Unstable flags should be documented in the
   such as `-C embed-bitcode=no`.
 - Consider the behavior if the flag is passed multiple times. In some
   situations, the values should be accumulated (in order!). In other
-  situations, subsequence flags should override previous flags (for example,
+  situations, subsequent flags should override previous flags (for example,
   the lint-level flags). And some flags (like `-o`) should generate an error
   if it is too ambiguous what multiple flags would mean.
 - Always give options a long descriptive name, if only for more understandable
   compiler scripts.
 - The `--verbose` flag is for adding verbose information to `rustc` output
   when not compiling a program. For example, using it with the `--version`
-  flag gives information about the hashes of the code.
+  flag gives information about the hashes of the compiler code.
 - Experimental flags and options must be guarded behind the `-Z
   unstable-options` flag.
 


### PR DESCRIPTION
This provides some guidelines on CLI flags. I'm sure there is more to say here, but this is a start.  Sourced from [rustc-ux-guidelines](https://github.com/rust-lang/rust/blob/e5335592e78354e33d798d20c04bcd677c1df62d/src/doc/rustc-ux-guidelines.md), https://github.com/rust-lang/rust/pull/70729, and my own experience.
