### PR TITLE
Broken Link to the high-level overview

### DIFF
--- a/src/query.md
+++ b/src/query.md
@@ -10,7 +10,7 @@ the [def-id] of some item, will compute the type of that item and return
 it to you.
 
 [def-id]: appendix/glossary.md#def-id
-[hl]: high-level-overview.html
+[hl]: compiler-src.html
 
 Query execution is **memoized** – so the first time you invoke a
 query, it will go do the computation, but the next time, the result is


### PR DESCRIPTION
I'm about to release version `0.6.0` of `mdbook-linkcheck` and found this broken link while testing it on the rustc dev guide. 

Hopefully I'm correct in guessing `high-level-overview.md` was renamed to `overview.md`. If not, let me know and I'll update it accordingly.