### PR TITLE
Add documentation of UI test error annotation message substring support

### DIFF
--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -194,7 +194,10 @@ source.
 Error annotations specify the errors that the compiler is expected to
 emit. They are "attached" to the line in source where the error is
 located. Error annotations are considered during tidy lints of line
-length and should be formatted according to tidy requirements. 
+length and should be formatted according to tidy requirements. You may
+use an error message prefix sub-string if necessary to meet line length 
+requirements.  Make sure that the text is long enough for the error 
+message to be self-documenting.
 
 The error annotation definition and source line definition association
 is defined with the following set of idioms:

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -196,7 +196,7 @@ emit. They are "attached" to the line in source where the error is
 located. Error annotations are considered during tidy lints of line
 length and should be formatted according to tidy requirements. You may
 use an error message prefix sub-string if necessary to meet line length 
-requirements.  Make sure that the text is long enough for the error 
+requirements. Make sure that the text is long enough for the error 
 message to be self-documenting.
 
 The error annotation definition and source line definition association


### PR DESCRIPTION
This adds a [useful tip from @mark-i-m](https://rust-lang.zulipchat.com/#narrow/stream/196385-t-compiler.2Fwg-rustc-dev-guide/topic/https.3A.2F.2Fgithub.2Ecom.2Frust-lang.2Frustc-dev-guide.2Fpull.2F724) about UI test error annotation message substring support to address tidy line length requirements.

Associated #724