### PR TITLE
[WIP] Document remote testing

### DIFF
--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -134,6 +134,8 @@ Some examples of `X` in `ignore-X`:
   `musl`.
 * Pointer width: `32bit`, `64bit`.
 * Stage: `stage0`, `stage1`, `stage2`.
+* When cross compiling: `cross-compile`
+* When remote testing is used: `remote`
 
 ### Other Header Commands
 


### PR DESCRIPTION
Document how to run tests on remote machines (which may be emulated).

This provides accompanying documentation for https://github.com/rust-lang/rust/pull/72704/, and should remain WIP until that is merged. 

r? @ehuss 