### PR TITLE
Do a rebase before link checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 - cargo install mdbook --version 0.3.7
 - cargo install mdbook-linkcheck --version 0.5.0
 script:
+- git rebase master # this will exit with an error on conflict
 - mdbook build
 notifications:
   email:


### PR DESCRIPTION
The goal here is that people won't have to rebase over the latest master to get link fixes; instead, travis will automatically rebase on master before testing so that the latest fixes are automatically pulled in.

cc @rust-lang/wg-rustc-dev-guide This is unconventional to do in a CI tmk, so let me know if anyone sees problems here.

One disadvantage is that if there are conflicts, the build will fail, but I think that is acceptable.