### PR TITLE
Clean up the paragraph about aliases for pinging the notification groups

### DIFF
--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -62,6 +62,8 @@ group. For example:
 ```text
 @rustbot ping llvm
 @rustbot ping cleanup-crew
+@rustbot ping windows
+@rustbot ping arm
 ```
 
 To make some commands shorter and easier to remember, there are aliases,


### PR DESCRIPTION
As noted [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.22notificationn.20groups.22/near/200451186), the old version seemed nonsensical.