### PR TITLE
Only build master branch on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,8 @@ deploy:
   fqdn: rustc-dev-guide.rust-lang.org
   on:
     branch: master
+    
+# Only build master branch on push
+branches:
+  only:
+  - master


### PR DESCRIPTION
Ok, so I disabled Travis's "Build branch pushes" feature, which I think means that we shouldn't be double-building PRs any more. But we need this setting so that Travis will still build and push updates to `gh-pages`, IIUC.

source: https://docs.travis-ci.com/user/customizing-the-build/#building-specific-branches https://docs.travis-ci.com/user/web-ui/#build-pushed-branches