### PR TITLE
Add information about size for building the Rust Compiler

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -118,6 +118,9 @@ process described above, producing a usable compiler toolchain from the source
 code you have checked out. This takes a long time, so it is not usually what
 you want to actually run (more on this later).
 
+Note that building will require a relatively large amount of storage space.
+You may want to have upwards of 10 or 15 gigabytes available to build the compiler.
+
 There are many flags you can pass to the build command of `x.py` that can be
 beneficial to cutting down compile times or fitting other things you might
 need to change. They are:


### PR DESCRIPTION
The Rust codebase is large, not to mention the submodules. It would be helpful for some to have a warning or note about storage required before they spend possible hours to build, only to get a message in some form that they are running out/already out of storage. I did a stage1 build incrementally and it produced a build directory of about 14 gigabytes, which is where the estimated figure is obtained. If there's a way to make this statement better or more clear, I'm willing to help.