### PR TITLE
Revamp bootstrapping section

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -15,7 +15,7 @@ only way to build a modern version of rustc is a slightly less modern
 version.
 
 This is exactly how `x.py` works: it downloads the current `beta` release of
-rustc, then uses it to compile the nightly compiler. The beta release is
+rustc, then uses it to compile the new compiler. The beta release is
 called `stage0` and the newly built compiler is `stage1` (or `stage0
 artifacts`). To get the full benefits of the new compiler (e.g. optimizations
 and new features), the `stage1` compiler then compiles _itself_ again. This
@@ -62,7 +62,7 @@ components of bootstrap: the main one written in rust, and `bootstrap.py`.
 `stage0` compiler, which will then build the bootstrap binary written in
 Rust.
 
-Because there are two separate codebases being from from `x.py`, they need to
+Because there are two separate codebases behind `x.py`, they need to
 be kept in sync. In particular, both `bootstrap.py` and the bootstrap binary
 parse `config.toml` and read the same command line arguments. `bootstrap.py`
 keeps these in sync by setting various environment variables, and the

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -71,7 +71,8 @@ read by the other.
 
 ### Adding a setting to config.toml
 
-This section is a work in progress. In the meantime, you can see an example contribution [here][bootstrap-build].
+This section is a work in progress. In the meantime, you can see an example
+contribution [here][bootstrap-build].
 
 [bootstrap-build]: https://github.com/rust-lang/rust/pull/71994
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -309,25 +309,17 @@ but there are already some promising performance improvements.
 ### Bootstrapping
 
 `rustc` itself is written in Rust. So how do we compile the compiler? We use an
-older compiler to compile the newer compiler. This is called _bootstrapping_.
+older compiler to compile the newer compiler. This is called [_bootstrapping_].
 
-Bootstrapping has a lot of interesting implications. For example, it means that
-one of the major users of Rust is Rust, so we are constantly testing our own
-software ("eating our own dogfood"). Also, it means building the compiler can
-take a long time because one must first build the new compiler with an older
-compiler and then use that to build the new compiler with itself (sometimes you
-can get away without the full 2-stage build, but for release artifacts you need
-the 2-stage build).
+Bootstrapping has a lot of interesting implications. For example, it means
+that one of the major users of Rust is the Rust compiler, so we are
+constantly testing our own software ("eating our own dogfood").
 
-Bootstrapping also has implications for when features are usable in the
-compiler itself. The build system uses the current beta compiler to build the
-stage-1 bootstrapping compiler. This means that the compiler source code can't
-use some features until they reach beta (because otherwise the beta compiler
-doesn't support them). On the other hand, for [compiler intrinsics][intrinsics]
-and internal features, we may be able to use them immediately because the
-stage-1 bootstrapping compiler will support them.
+For more details on bootstrapping, see
+[the bootstrapping section of the guide][rustc-bootstrap].
 
-[intrinsics]: ./appendix/glossary.md#intrinsic
+[_bootstrapping_]: https://en.wikipedia.org/wiki/Bootstrapping_(compilers)
+[rustc-bootstrap]: building/bootstrapping.md
 
 # Unresolved Questions
 


### PR DESCRIPTION
- Move most of the overview to building/bootstrapping.md
- Add things besides stages to bootstrapping.md

I didn't touch most of the existing `bootstrapping.md` because to be honest it looked really dense and I didn't want to read it 😅 

Addresses https://github.com/rust-lang/rustc-dev-guide/issues/674

r? @Mark-Simulacrum 
cc @mark-i-m 