### PR TITLE
Rename resolvers following the latest rustc change

### DIFF
--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -154,7 +154,7 @@ whole crate, like we normally do).
 ### Other Data Structures
 
 Here are some other notable data structures involved in expansion and integration:
-- [`Resolver`] - a trait used to break crate dependencies. This allows the
+- [`ResolverExpand`] - a trait used to break crate dependencies. This allows the
   resolver services to be used in [`rustc_ast`], despite [`rustc_resolve`] and
   pretty much everything else depending on [`rustc_ast`].
 - [`ExtCtxt`]/[`ExpansionData`] - various intermediate data kept and used by expansion
@@ -168,7 +168,7 @@ Here are some other notable data structures involved in expansion and integratio
 
 [`rustc_ast`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/index.html
 [`rustc_resolve`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_resolve/index.html
-[`Resolver`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.Resolver.html
+[`ResolverExpand`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.ResolverExpand.html
 [`ExtCtxt`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/struct.ExtCtxt.html
 [`ExpansionData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/struct.ExpansionData.html
 [`Annotatable`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/enum.Annotatable.html

--- a/src/name-resolution.md
+++ b/src/name-resolution.md
@@ -43,7 +43,7 @@ namespaces and therefore can co-exist.
 The name resolution in Rust is a two-phase process. In the first phase, which runs
 during macro expansion, we build a tree of modules and resolve imports. Macro
 expansion and name resolution communicate with each other via the
-[`Resolver`] trait.
+[`ResolverAstLowering`] trait.
 
 The input to the second phase is the syntax tree, produced by parsing input
 files and expanding macros. This phase produces links from all the names in the
@@ -59,7 +59,7 @@ The name resolution lives in the `librustc_resolve` crate, with the meat in
 `lib.rs` and some helpers or symbol-type specific logic in the other modules.
 
 [`Resolver::resolve_crate`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_resolve/struct.Resolver.html#method.resolve_crate
-[`Resolver`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_lowering/trait.Resolver.html
+[`ResolverAstLowering`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_lowering/trait.ResolverAstLowering.html
 
 ## Namespaces
 


### PR DESCRIPTION
Follows https://github.com/rust-lang/rust/pull/73813.