### PR TITLE
Fix the names of table of contents and heading are different

### DIFF
--- a/src/appendix/background.md
+++ b/src/appendix/background.md
@@ -1,4 +1,4 @@
-# Appendix B: Background topics
+# Background topics
 
 This section covers a numbers of common compiler terms that arise in
 this guide. We try to give the general definition while providing some

--- a/src/appendix/code-index.md
+++ b/src/appendix/code-index.md
@@ -1,4 +1,4 @@
-# Appendix D: Code Index
+# Code Index
 
 rustc has a lot of important data structures. This is an attempt to give some
 guidance on where to learn more about some of the key data structures of the

--- a/src/appendix/glossary.md
+++ b/src/appendix/glossary.md
@@ -1,4 +1,4 @@
-# Appendix C: Glossary
+# Glossary
 
 Term                                     | Meaning
 -----------------------------------------|--------


### PR DESCRIPTION
Not to write the part of Appendix `A` in heading along with other appendix.

before
<img width="1440" alt="スクリーンショット 2020-07-02 23 33 21" src="https://user-images.githubusercontent.com/17407489/86371973-8afe0c00-bcbc-11ea-9d95-a8f813d9a86c.png">
Left side is Appendix A but heading is Appendix B.

after
<img width="1440" alt="スクリーンショット 2020-07-02 23 34 34" src="https://user-images.githubusercontent.com/17407489/86372044-a2d59000-bcbc-11ea-8a20-5052b47007e6.png">
Appendix part in heading is removed same as Appendix D, E or Z.