### PR TITLE
Fix the difference of title in appendix A

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -145,7 +145,7 @@
 
 ---
 
-[Appendix A: Background material](./appendix/background.md)
+[Appendix A: Background topics](./appendix/background.md)
 [Appendix B: Glossary](./appendix/glossary.md)
 [Appendix C: Code Index](./appendix/code-index.md)
 [Appendix D: Compiler Lecture Series](./appendix/compiler-lecture.md)


### PR DESCRIPTION
Left side is `Background material` but title is `Background topics`, so I fix it to `Background topics`. ( If `Background material` is preferrable, I fix it like that.)

<img width="1440" alt="スクリーンショット 2020-07-13 12 09 43" src="https://user-images.githubusercontent.com/17407489/87267135-cfca4400-c501-11ea-98ea-22db0485b24c.png">
