### PR TITLE
Fix distortions of "representation"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -59,7 +59,7 @@
 - [Parallel Compilation](./parallel-rustc.md)
 - [Rustdoc](./rustdoc-internals.md)
 
-# Source Code Representations
+# Source Code Representation
 
 - [Prologue](./part-3-intro.md)
 - [Command-line arguments](./cli.md)

--- a/src/backend/backend-agnostic.md
+++ b/src/backend/backend-agnostic.md
@@ -2,7 +2,7 @@
 
 In the future, it would be nice to allow other codegen backends (e.g.
 [Cranelift]). To this end, `librustc_codegen_ssa` provides an
-abstract interface for all backends to implenent.
+abstract interface for all backends to implement.
 
 [Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/master/cranelift
 
@@ -175,7 +175,7 @@ in the LLVM implementation of the trait).
 
 The traits offer an API which is very similar to the API of LLVM. This is not
 the best solution since LLVM has a very special way of doing things: when
-addding another backend, the traits definition might be changed in order to
+adding another backend, the traits definition might be changed in order to
 offer more flexibility.
 
 However, the current separation between backend-agnostic and LLVM-specific code

--- a/src/backend/debugging.md
+++ b/src/backend/debugging.md
@@ -117,7 +117,7 @@ tutorial above):
 - The `-Cno-prepopulate-passes` will avoid pre-populate the LLVM pass
   manager with a list of passes.  This will allow you to view the LLVM
   IR that rustc generates, not the LLVM IR after optimizations.
-- The `-Cpasses=val` option allows you to supply a (space seprated) list of extra LLVM passes to run
+- The `-Cpasses=val` option allows you to supply a space separated list of extra LLVM passes to run
 - The `-Csave-temps` option saves all temporary output files during compilation
 - The `-Zprint-llvm-passes` option will print out LLVM optimization passes being run
 - The `-Ztime-llvm-passes` option measures the time of each LLVM pass

--- a/src/backend/implicit-caller-location.md
+++ b/src/backend/implicit-caller-location.md
@@ -84,7 +84,7 @@ the approach: as we grow the stack down we pass an additional argument to calls 
 rather than walking up the stack when the intrinsic is called. That additional argument can be
 returned wherever the caller location is queried.
 
-The argument we append is of type `&'static core::panic::Location<'staic>`. A reference was chosen
+The argument we append is of type `&'static core::panic::Location<'static>`. A reference was chosen
 to avoid unnecessary copying because a pointer is a third the size of 
 `std::mem::size_of::<core::panic::Location>() == 24` at time of writing.
 

--- a/src/backend/lowering-mir.md
+++ b/src/backend/lowering-mir.md
@@ -38,7 +38,7 @@ LLVM's `mem2reg` for those variables. The analysis can be found in
 [`rustc_codegen_ssa::mir::analyze`][mirana].
 
 [mirana]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_ssa/mir/analyze/index.html
-  
+
 Usually a single MIR basic block will map to a LLVM basic block, with very few
 exceptions: intrinsic or function calls and less basic MIR statements like
 `assert` can result in multiple basic blocks. This is a perfect lede into the

--- a/src/part-3-intro.md
+++ b/src/part-3-intro.md
@@ -1,4 +1,4 @@
-# Part 3: Source Code Representations
+# Part 3: Source Code Representation
 
 This part describes the process of taking raw source code from the user and
 transforming it into various forms that the compiler can work with easily.


### PR DESCRIPTION
I think "Source Code Representation" is more natural than "Representations" here. Also fix some typos.