### PR TITLE
Exclude `rustaceans.org` from linkcheck

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,6 +15,6 @@ level = 0
 
 [output.linkcheck]
 follow-web-links = true
-exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il", "www\\.amazon\\.com" ]
+exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il", "www\\.amazon\\.com", "www\\.rustaceans\\.org" ]
 cache-timeout = 86400
 warning-policy = "error"


### PR DESCRIPTION
Now it causes timeout. And I think we don't have to check it since it won't be likely invalid or outdated. Let's take this opportunity to exclude it.