### PR TITLE
Clean-up minor issues

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -176,11 +176,11 @@ So to put it together.
 ```bash
 # This puts the output of all debug calls in `librustc_middle/traits` into
 # standard error, which might fill your console backscroll.
-$ RUSTC_LOG=rustc::traits rustc +local my-file.rs
+$ RUSTC_LOG=rustc_middle::traits rustc +local my-file.rs
 
 # This puts the output of all debug calls in `librustc_middle/traits` in
 # `traits-log`, so you can then see it with a text editor.
-$ RUSTC_LOG=rustc::traits rustc +local my-file.rs 2>traits-log
+$ RUSTC_LOG=rustc_middle::traits rustc +local my-file.rs 2>traits-log
 
 # Not recommended. This will show the output of all `debug!` calls
 # in the Rust compiler, and there are a *lot* of them, so it will be

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -453,7 +453,7 @@ If you're looking for somewhere to start, check out the [E-easy][eeasy] tag.
 ## Out-of-tree Contributions
 
 There are a number of other ways to contribute to Rust that don't deal with
-this repository.
+rust-lang/rust.
 
 Answer questions in the _Get Help!_ channels from the [Rust Discord
 server][rust-discord], on [users.rust-lang.org][users], or on

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -268,7 +268,7 @@ the code:
 *Note*: we don't use stable `rustfmt`; we use a pinned version with a special
 config, so this may result in different style from normal `rustfmt` if you have
 format-on-save turned on. It's a good habit to run `./x.py fmt` before every
-commit, as this reduces conflicts later. The pinned verson is built under
+commit, as this reduces conflicts later. The pinned version is built under
 `build/<target>/stage0/bin/rustfmt`, so if you want, you can use it for a
 single file or for format-on-save in your editor, which can be faster than `./x.py fmt`.
 
@@ -508,4 +508,4 @@ master.
 - [The t-compiler zulip][z]
 - [The compiler's documentation (rustdocs)](https://doc.rust-lang.org/nightly/nightly-rustc/)
 - [The Forge](https://forge.rust-lang.org/) has more documentation about various procedures.
-- `#contribute`, `#compiler`, and `#rustdoc` on [Discord](https://discord.gg/rust-lang).
+- `#contribute` and `#rustdoc` on [Discord](https://discord.gg/rust-lang).


### PR DESCRIPTION
- Fix a typo and wording
- Remove mention to `#t-compiler` on Discord
- Rename `rustc` to `rustc_middle`