### PR TITLE
[WIP] Fix and clean up the terminology for stages

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -204,11 +204,11 @@ The following tables indicate the outputs of various stage actions:
 `--stage=2` stops here.
 
 Note that the convention `x.py` uses is that:
-- A "stage N artifact" is an artifact that is _produced_ by the stage N compiler.
-- The "stage (N+1) compiler" is assembled from "stage N artifacts".
-- A `--stage N` flag means build _with_ stage N.
+- A "stage N artifact" is an artifact that is part of stage N.
+- The compiler in `build/$target/stage(N+1)` is assembled from "stage N artifacts".
+- A `--stage N` flag means build a stage N artifact.
 
-In short, _stage 0 uses the stage0 compiler to create stage0 artifacts which
+In short, _stage 0 uses the bootstrap compiler to create stage0 artifacts which
 will later be uplifted to stage1_.
 
 Every time any of the main artifacts (`std` and `rustc`) are compiled, two

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -57,13 +57,13 @@ When you use the bootstrap system, you'll call it through `x.py`.
 However, most of the code lives in `src/bootstrap`.
 `bootstrap` has a difficult problem: it is written in Rust, but yet it is run
 before the rust compiler is built! To work around this, there are two
-components of bootstrap: the main one written in rust, and `bootstrap.py`.
+components of bootstrap: the main one written in Rust, called `rustbuild`,
+and `bootstrap.py`.
 `bootstrap.py` is what gets run by x.py. It takes care of downloading the
-`stage0` compiler, which will then build the bootstrap binary written in
-Rust.
+bootstrap compiler, which will then compile `rustbuild`.
 
 Because there are two separate codebases behind `x.py`, they need to
-be kept in sync. In particular, both `bootstrap.py` and the bootstrap binary
+be kept in sync. In particular, both `bootstrap.py` and `rustbuild`
 parse `config.toml` and read the same command line arguments. `bootstrap.py`
 keeps these in sync by setting various environment variables, and the
 programs sometimes to have add arguments that are explicitly ignored, to be

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -109,38 +109,6 @@ to build it, such as `libstd` and other tooling, may use some unstable features
 internally, requiring a specific version which understands these unstable
 features.
 
-The result is that compiling `rustc` is done in stages:
-
-- **Stage 0:** the stage0 compiler is usually (you can configure `x.py` to use
-  something else) the current _beta_ `rustc` compiler and its associated dynamic
-  libraries (which `x.py` will download for you). This stage0 compiler is then
-  used only to compile `rustbuild`, `std`, and `rustc`. When compiling
-  `rustc`, this stage0 compiler uses the freshly compiled `std`.
-  There are two concepts at play here: a compiler (with its set of dependencies)
-  and its 'target' or 'object' libraries (`std` and `rustc`).
-  Both are staged, but in a staggered manner.
-- **Stage 1:** the code in your clone (for new version) is then
-  compiled with the stage0 compiler to produce the stage1 compiler.
-  However, it was built with an older compiler (stage0), so to
-  optimize the stage1 compiler we go to next the stage.
-  - In theory, the stage1 compiler is functionally identical to the
-    stage2 compiler, but in practice there are subtle differences. In
-    particular, the stage1 compiler itself was built by stage0 and
-    hence not by the source in your working directory: this means that
-    the symbol names used in the compiler source may not match the
-    symbol names that would have been made by the stage1 compiler. This is
-    important when using dynamic linking and the lack of ABI compatibility
-    between versions. This primarily manifests when tests try to link with any
-    of the `rustc_*` crates or use the (now deprecated) plugin infrastructure.
-    These tests are marked with `ignore-stage1`.
-- **Stage 2:** we rebuild our stage1 compiler with itself to produce
-  the stage2 compiler (i.e. it builds itself) to have all the _latest
-  optimizations_. (By default, we copy the stage1 libraries for use by
-  the stage2 compiler, since they ought to be identical.)
-- _(Optional)_ **Stage 3**: to sanity check our new compiler, we
-  can build the libraries with the stage2 compiler. The result ought
-  to be identical to before, unless something has broken.
-
 To read more about the bootstrap process, [read this chapter][bootstrap].
 
 [bootstrap]: ./bootstrapping.md


### PR DESCRIPTION
- Name `rustbuild` instead of saying 'the bootstrap binary'
- Use 'stage0 rustc' and 'stage0 compiler' to mean `stage0-rustc`
- Use 'bootstrap' to mean `build/$target/stage0` (i.e. the beta compiler)
- Mention that 'ignore-stage1' means 'ignore programs linked to stage1',
not built by it.

r? @eddyb 