### PR TITLE
Fix links for cranelift

### DIFF
--- a/src/backend/backend-agnostic.md
+++ b/src/backend/backend-agnostic.md
@@ -4,7 +4,7 @@ In the future, it would be nice to allow other codegen backends (e.g.
 [Cranelift]). To this end, `librustc_codegen_ssa` provides an
 abstract interface for all backends to implement.
 
-[Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/master/cranelift
+[Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/HEAD/cranelift
 
 > The following is a copy/paste of a README from the rust-lang/rust repo.
 > Please submit a PR if it needs updating.

--- a/src/backend/codegen.md
+++ b/src/backend/codegen.md
@@ -7,7 +7,7 @@ codegen itself. It's worth noting, though, that in the rust source code, many
 parts of the backend have `codegen` in their names (there are no hard
 boundaries).
 
-[Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/master/cranelift
+[Cranelift]: https://github.com/bytecodealliance/wasmtime/tree/HEAD/cranelift
 
 > NOTE: If you are looking for hints on how to debug code generation bugs,
 > please see [this section of the debugging chapter][debugging].


### PR DESCRIPTION
The wasmtime renamed their default branch to `main` thus its link returns 404 now.
This replaces `master` with `HEAD` which is an alias for the default branch on GitHub, not `main`, just in case.