### PR TITLE
Add RISC-V notification group instructions

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,10 +37,11 @@
 - [Stabilizing Features](./stabilization_guide.md)
 - [Coding conventions](./conventions.md)
 - [Notification groups](notification-groups/about.md)
-    - ["Cleanup Crew"](notification-groups/cleanup-crew.md)
-    - [LLVM](notification-groups/llvm.md)
-    - [Windows](notification-groups/windows.md)
     - [ARM](notification-groups/arm.md)
+    - [Cleanup Crew](notification-groups/cleanup-crew.md)
+    - [LLVM](notification-groups/llvm.md)
+    - [RISC-V](notification-groups/risc-v.md)
+    - [Windows](notification-groups/windows.md)
 - [Licenses](./licenses.md)
 
 # High-level Compiler Architecture

--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -48,10 +48,11 @@ cargo run add-person $your_user_name
 
 Example PRs:
 
+* [Example of adding yourself to the ARM group.](https://github.com/rust-lang/team/pull/358)
 * [Example of adding yourself to the Cleanup Crew.](https://github.com/rust-lang/team/pull/221)
 * [Example of adding yourself to the LLVM group.](https://github.com/rust-lang/team/pull/140)
+* [Example of adding yourself to the RISC-V group.](https://github.com/rust-lang/team/pull/394)
 * [Example of adding yourself to the Windows group.](https://github.com/rust-lang/team/pull/348)
-* [Example of adding yourself to the ARM group.](https://github.com/rust-lang/team/pull/358)
 
 ## Tagging an issue for a notification group
 

--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -16,6 +16,15 @@ search for existing issues that haven't been claimed yet.
 
 [claim the issue]: https://github.com/rust-lang/triagebot/wiki/Assignment
 
+## List of notification groups
+
+Here's the list of the notification groups:
+- [ARM](./arm.md)
+- [Cleanup Crew](./cleanup-crew.md)
+- [LLVM](./llvm.md)
+- [RISC-V](./risc-v.md)
+- [Windows](./windows.md)
+
 ## What issues are a good fit for notification groups?
 
 Notification groups tend to get pinged on **isolated** bugs,

--- a/src/notification-groups/arm.md
+++ b/src/notification-groups/arm.md
@@ -8,7 +8,7 @@ This list will be used to ask for help both in diagnosing and testing
 ARM-related issues as well as suggestions on how to resolve
 interesting questions regarding our ARM support.
 
-The group also has an associated Zulip stream (`#t-compiler/arm`)
+The group also has an associated Zulip stream ([`#t-compiler/arm`])
 where people can go to pose questions and discuss ARM-specific
 topics.
 
@@ -17,7 +17,6 @@ ARM group! To do so, you open a PR against the [rust-lang/team]
 repository. Just [follow this example][eg], but change the username to
 your own!
 
+[`#t-compiler/arm`]: https://rust-lang.zulipchat.com/#narrow/stream/242906-t-compiler.2Farm
 [rust-lang/team]: https://github.com/rust-lang/team
 [eg]: https://github.com/rust-lang/team/pull/358
-[#72569]: https://github.com/rust-lang/rust/pull/72569
-[#29520]: https://github.com/rust-lang/rust/pull/29520

--- a/src/notification-groups/arm.md
+++ b/src/notification-groups/arm.md
@@ -13,7 +13,7 @@ where people can go to pose questions and discuss ARM-specific
 topics.
 
 So, if you are interested in participating, please sign up for the
-ARM group! To do so, you open a PR against the [rust-lang/team]
+ARM group! To do so, open a PR against the [rust-lang/team]
 repository. Just [follow this example][eg], but change the username to
 your own!
 

--- a/src/notification-groups/risc-v.md
+++ b/src/notification-groups/risc-v.md
@@ -13,7 +13,7 @@ where people can go to pose questions and discuss RISC-V-specific
 topics.
 
 So, if you are interested in participating, please sign up for the
-RISC-V group! To do so, you open a PR against the [rust-lang/team]
+RISC-V group! To do so, open a PR against the [rust-lang/team]
 repository. Just [follow this example][eg], but change the username to
 your own!
 

--- a/src/notification-groups/risc-v.md
+++ b/src/notification-groups/risc-v.md
@@ -1,0 +1,22 @@
+# RISC-V notification group
+
+**Github Label:** [O-riscv]
+
+[O-riscv]: https://github.com/rust-lang/rust/labels/O-riscv
+
+This list will be used to ask for help both in diagnosing and testing
+RISC-V-related issues as well as suggestions on how to resolve
+interesting questions regarding our RISC-V support.
+
+The group also has an associated Zulip stream ([`#t-compiler/risc-v`])
+where people can go to pose questions and discuss RISC-V-specific
+topics.
+
+So, if you are interested in participating, please sign up for the
+RISC-V group! To do so, you open a PR against the [rust-lang/team]
+repository. Just [follow this example][eg], but change the username to
+your own!
+
+[`#t-compiler/risc-v`]: https://rust-lang.zulipchat.com/#narrow/stream/250483-t-compiler.2Frisc-v
+[rust-lang/team]: https://github.com/rust-lang/team
+[eg]: https://github.com/rust-lang/team/pull/394

--- a/src/notification-groups/windows.md
+++ b/src/notification-groups/windows.md
@@ -21,7 +21,7 @@ the group for advice in determining the best course of action:
 * What names should we use for static libraries on Windows? [#29520]
 
 So, if you are interested in participating, please sign up for the
-Windows group! To do so, you open a PR against the [rust-lang/team]
+Windows group! To do so, open a PR against the [rust-lang/team]
 repository. Just [follow this example][eg], but change the username to
 your own!
 

--- a/src/notification-groups/windows.md
+++ b/src/notification-groups/windows.md
@@ -8,7 +8,7 @@ This list will be used to ask for help both in diagnosing and testing
 Windows-related issues as well as suggestions on how to resolve
 interesting questions regarding our Windows support.
 
-The group also has an associated Zulip stream (`#t-compiler/windows`)
+The group also has an associated Zulip stream ([`#t-compiler/windows`])
 where people can go to pose questions and discuss Windows-specific
 topics.
 
@@ -18,13 +18,14 @@ the group for advice in determining the best course of action:
 
 * Which versions of MinGW should we support?
 * Should we remove the legacy InnoSetup GUI installer? [#72569]
-* What names should we use for static libraries on Windows? [#29520] 
+* What names should we use for static libraries on Windows? [#29520]
 
 So, if you are interested in participating, please sign up for the
 Windows group! To do so, you open a PR against the [rust-lang/team]
 repository. Just [follow this example][eg], but change the username to
 your own!
 
+[`#t-compiler/windows`]: https://rust-lang.zulipchat.com/#streams/242869/t-compiler.2Fwindows
 [rust-lang/team]: https://github.com/rust-lang/team
 [eg]: https://github.com/rust-lang/team/pull/348/
 [#72569]: https://github.com/rust-lang/rust/pull/72569


### PR DESCRIPTION
~~This is still WIP as we don't have the Zulip stream (`#t-compiler/risc-v`) yet.~~
Now it's ready to review!