### PR TITLE
Rename `HAIR` to `THIR`

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -80,7 +80,7 @@
     - [Lowering AST to HIR](./lowering.md)
     - [Debugging](./hir-debugging.md)
 - [The MIR (Mid-level IR)](./mir/index.md)
-    - [HAIR and MIR construction](./mir/construction.md)
+    - [THIR and MIR construction](./mir/construction.md)
     - [MIR visitor and traversal](./mir/visitor.md)
     - [MIR passes: getting the MIR for a function](./mir/passes.md)
 - [Closure expansion](./closure.md)

--- a/src/borrow_check/two_phase_borrows.md
+++ b/src/borrow_check/two_phase_borrows.md
@@ -74,7 +74,7 @@ The activation points are found using the [`GatherBorrows`] visitor. The
 borrow.
 
 [`AutoBorrow`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/adjustment/enum.AutoBorrow.html
-[converted]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/hair/cx/expr/trait.ToBorrowKind.html#method.to_borrow_kind
+[converted]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/cx/expr/trait.ToBorrowKind.html#method.to_borrow_kind
 [`BorrowKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.BorrowKind.html
 [`GatherBorrows`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/visit/trait.Visitor.html#method.visit_local
 [`BorrowData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/borrow_check/borrow_set/struct.BorrowData.html

--- a/src/mir/construction.md
+++ b/src/mir/construction.md
@@ -14,6 +14,7 @@ list of items:
 The lowering is triggered by calling the [`mir_built`] query.
 There is an intermediate representation
 between [HIR] and [MIR] called the [THIR] that is only used during the lowering.
+[THIR] means "Typed HIR" and used to be called "HAIR (High-level Abstract IR)".
 The [THIR]'s most important feature is that the various adjustments (which happen
 without explicit syntax) like coercions, autoderef, autoref and overloaded method
 calls have become explicit casts, deref operations, reference expressions or

--- a/src/mir/construction.md
+++ b/src/mir/construction.md
@@ -1,4 +1,4 @@
-# HAIR and MIR construction
+# THIR and MIR construction
 
 The lowering of [HIR] to [MIR] occurs for the following (probably incomplete)
 list of items:
@@ -13,19 +13,19 @@ list of items:
 
 The lowering is triggered by calling the [`mir_built`] query.
 There is an intermediate representation
-between [HIR] and [MIR] called the [HAIR] that is only used during the lowering.
-The [HAIR]'s most important feature is that the various adjustments (which happen
+between [HIR] and [MIR] called the [THIR] that is only used during the lowering.
+The [THIR]'s most important feature is that the various adjustments (which happen
 without explicit syntax) like coercions, autoderef, autoref and overloaded method
 calls have become explicit casts, deref operations, reference expressions or
 concrete function calls.
 
-The [HAIR] has datatypes that mirror the [HIR] datatypes, but instead of e.g. `-x`
-being a `hair::ExprKind::Neg(hair::Expr)` it is a `hair::ExprKind::Neg(hir::Expr)`.
-This shallowness enables the `HAIR` to represent all datatypes that [HIR] has, but
+The [THIR] has datatypes that mirror the [HIR] datatypes, but instead of e.g. `-x`
+being a `thir::ExprKind::Neg(thir::Expr)` it is a `thir::ExprKind::Neg(hir::Expr)`.
+This shallowness enables the `THIR` to represent all datatypes that [HIR] has, but
 without having to create an in-memory copy of the entire [HIR].
 [MIR] lowering will first convert the topmost expression from
-[HIR] to [HAIR] (in [`rustc_mir_build::hair::cx::expr`]) and then process
-the [HAIR] expressions recursively.
+[HIR] to [THIR] (in [`rustc_mir_build::thir::cx::expr`]) and then process
+the [THIR] expressions recursively.
 
 The lowering creates local variables for every argument as specified in the signature.
 Next it creates local variables for every binding specified (e.g. `(a, b): (i32, String)`)
@@ -152,7 +152,7 @@ case of `enum`s.
 
 [MIR]: ./index.html
 [HIR]: ../hir.html
-[HAIR]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/hair/index.html
+[THIR]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/index.html
 
-[`rustc_mir_build::hair::cx::expr`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/hair/cx/expr/index.html
+[`rustc_mir_build::thir::cx::expr`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/cx/expr/index.html
 [`mir_built`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/build/fn.mir_built.html

--- a/src/overview.md
+++ b/src/overview.md
@@ -187,10 +187,10 @@ for different purposes:
 - High-level IR (HIR): This is a sort of desugared AST. It's still close
   to what the user wrote syntactically, but it includes some implicit things
   such as some elided lifetimes, etc. This IR is amenable to type checking.
-- Typed HIR (THIR): This is an intermediate between HIR and MIR. It is like the HIR
-  but it is fully typed and a bit more desugared (e.g. method calls and implicit
-  dereferences are made fully explicit). Moreover, it is easier to lower to MIR
-  from THIR than from HIR.
+- Typed HIR (THIR): This is an intermediate between HIR and MIR, and used to be called
+  High-level Abstract IR (HAIR). It is like the HIR but it is fully typed and a bit
+  more desugared (e.g. method calls and implicit dereferences are made fully explicit).
+  Moreover, it is easier to lower to MIR from THIR than from HIR.
 - Middle-level IR (MIR): This IR is basically a Control-Flow Graph (CFG). A CFG
   is a type of diagram that shows the basic blocks of a program and how control
   flow can go between them. Likewise, MIR also has a bunch of basic blocks with

--- a/src/overview.md
+++ b/src/overview.md
@@ -55,7 +55,7 @@ we'll talk about that later.
     - `stmt.rs`
 - This naming scheme is used across many compiler stages. You will find
   either a file or directory with the same name across the parsing, lowering,
-  type checking, HAIR lowering, and MIR building sources.
+  type checking, THIR lowering, and MIR building sources.
 - Macro expansion, AST validation, name resolution, and early linting takes place
   during this stage of the compile process.
 - The parser uses the standard `DiagnosticBuilder` API for error handling, but we
@@ -69,8 +69,8 @@ we'll talk about that later.
 - **TODO: Maybe some other things are done here? I think initial type checking
   happens here? And trait solving?**
 - The HIR is then [lowered to Mid-Level Intermediate Representation (MIR)][mir].
-  - Along the way, we construct the HAIR, which is an even more desugared HIR.
-    HAIR is used for pattern and exhaustiveness checking. It is also more
+  - Along the way, we construct the THIR, which is an even more desugared HIR.
+    THIR is used for pattern and exhaustiveness checking. It is also more
     convenient to convert into MIR than HIR is.
 - The MIR is used for [borrow checking].
 - We (want to) do [many optimizations on the MIR][mir-opt] because it is still
@@ -187,10 +187,10 @@ for different purposes:
 - High-level IR (HIR): This is a sort of desugared AST. It's still close
   to what the user wrote syntactically, but it includes some implicit things
   such as some elided lifetimes, etc. This IR is amenable to type checking.
-- HAIR: This is an intermediate between HIR and MIR. It is like the HIR but it
-  is fully typed and a bit more desugared (e.g. method calls and implicit
+- Typed HIR (THIR): This is an intermediate between HIR and MIR. It is like the HIR
+  but it is fully typed and a bit more desugared (e.g. method calls and implicit
   dereferences are made fully explicit). Moreover, it is easier to lower to MIR
-  from HAIR than from HIR.
+  from THIR than from HIR.
 - Middle-level IR (MIR): This IR is basically a Control-Flow Graph (CFG). A CFG
   is a type of diagram that shows the basic blocks of a program and how control
   flow can go between them. Likewise, MIR also has a bunch of basic blocks with


### PR DESCRIPTION
rust-lang/rust#74582 is merged, let's cut our hair here as well :)
The nightly rustc doc isn't updated so the links are currently broken.
Closes #806