### PR TITLE
Fix misguided suggestions in config.toml

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -57,16 +57,8 @@ assertions = true
 #
 debug = true
 
-# Number of codegen units to use for each compiler invocation. A value of 0
-# means "the number of cores on this machine", and 1+ is passed through to the
-# compiler.
-codegen-units = 0
-
 # Whether to always use incremental compilation when building rustc
 incremental = true
-
-# Emits extra output from tests so test failures are debuggable just from logfiles.
-verbose-tests = true
 ```
 
 If you have already built `rustc`, then you may have to execute `rm -rf build` for subsequent


### PR DESCRIPTION
- `verbose-tests` is for debugging the test harness, not the tests
themselves. See also https://github.com/rust-lang/rust/pull/76141
- `codegen-units` defaults to `256` whenever `incremental = true`. So
there's no need to explicitly set it to `0` if we already recommend
incremental. See also https://github.com/rust-lang/rustc-dev-guide/pull/795#discussion_r479762977.

r? @eddyb 