### PR TITLE
Link to 'prerequisites' immediately

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -6,7 +6,7 @@ be hacking on `rustc`, you'll want to tweak the configuration of the compiler.
 The default configuration is oriented towards running the compiler as a user,
 not a developer.
 
-For instructions on how to install python and other prerequisites,
+For instructions on how to install Python and other prerequisites,
 see [the next page](./prerequisites.md).
 
 ## Get the source code

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -6,6 +6,9 @@ be hacking on `rustc`, you'll want to tweak the configuration of the compiler.
 The default configuration is oriented towards running the compiler as a user,
 not a developer.
 
+For instructions on how to install python and other prerequisites,
+see [the next page](./prerequisites.md).
+
 ## Get the source code
 
 The very first step to work on `rustc` is to clone the repository:


### PR DESCRIPTION
Several of the commands on 'how to build' use python.
But we haven't yet told the user how to install it!
Do that first before going into detail on how x.py works.