### PR TITLE
Fix incorrect docs about stages

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -178,7 +178,7 @@ build. The **full** `rustc` build (what you get if you say `./x.py build
 - Build only the core and `proc_macro` libraries
 
 ```bash
-./x.py build library/core library/proc_macro
+./x.py build --stage 0 library/core library/proc_macro
 ```
 
 Sometimes you might just want to test if the part you’re working on can

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -172,7 +172,7 @@ build. The **full** `rustc` build (what you get if you say `./x.py build
 - Build only the core library
 
 ```bash
-./x.py build library/core
+./x.py build --stage 0 library/core
 ```
 
 - Build only the core and `proc_macro` libraries


### PR DESCRIPTION
`build library/core` builds the compiler, not just the standard library.

cc @thomcc