### PR TITLE
add suggested workflow to setup nightly rustup for rust/

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -67,6 +67,22 @@ the problem. A nice side-effect of this style is that you are left
 with a fairly fine-grained set of commits at the end, all of which
 build and pass tests. This often helps reviewing.
 
+## Configuring `rustup` to use nightly
+
+Some parts of the bootstrap process uses pinned, nightly versions of tools like
+rustfmt. To make things like `cargo fmt` work correctly in your repo, run
+
+```console
+cd <path to rustc repo>
+rustup override set nightly
+```
+
+after [installing a nightly toolchain] with `rustup`. Don't forget to do this for all
+directories you have [setup a worktree for].
+
+[installing a nightly toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html?highlight=nightl#working-with-nightly-rust
+[setup a worktree for]: ./suggested.html#working-on-multiple-branches-at-the-same-time
+
 ## Incremental builds with `--keep-stage`.
 
 Sometimes just checking

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -80,8 +80,13 @@ rustup override set nightly
 after [installing a nightly toolchain] with `rustup`. Don't forget to do this for all
 directories you have [setup a worktree for].
 
+**note** see [the section on vscode] for how to configure it with this real rustfmt `x.py` uses, 
+and [the section on rustup] for how to setup `rustup` toolchain for your bootstrapped compiler
+
 [installing a nightly toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html?highlight=nightl#working-with-nightly-rust
 [setup a worktree for]: ./suggested.html#working-on-multiple-branches-at-the-same-time
+[the section on vscode]: suggested.html#configuring-rust-analyzer-for-rustc
+[the section on rustup]: how-to-build-and-run.html?highlight=rustup#creating-a-rustup-toolchain
 
 ## Incremental builds with `--keep-stage`.
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -90,9 +90,9 @@ still have to use `x.py` to work on the compiler or standard library, this just
 lets you use `cargo fmt`.
 
 [installing a nightly toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html?highlight=nightl#working-with-nightly-rust
-[setup a worktree for]: ./suggested.html#working-on-multiple-branches-at-the-same-time
-[the section on vscode]: suggested.html#configuring-rust-analyzer-for-rustc
-[the section on rustup]: how-to-build-and-run.html?highlight=rustup#creating-a-rustup-toolchain
+[setup a worktree for]: ./suggested.md#working-on-multiple-branches-at-the-same-time
+[the section on vscode]: suggested.md#configuring-rust-analyzer-for-rustc
+[the section on rustup]: how-to-build-and-run.md?highlight=rustup#creating-a-rustup-toolchain
 
 ## Incremental builds with `--keep-stage`.
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -1,6 +1,6 @@
 # Suggested Workflows
 
-The full bootstrapping process takes quite a while. Here are five suggestions
+The full bootstrapping process takes quite a while. Here are some suggestions
 to make your life easier.
 
 ## Configuring `rust-analyzer` for `rustc`
@@ -78,12 +78,16 @@ rustup override set nightly
 ```
 
 after [installing a nightly toolchain] with `rustup`. Don't forget to do this for all
-directories you have [setup a worktree for].
+directories you have [setup a worktree for]. You may need to use the pinned
+nightly version from `src/stage0.txt`, but often the normal `nightly` channel
+will work.
 
 **Note** see [the section on vscode] for how to configure it with this real rustfmt `x.py` uses, 
 and [the section on rustup] for how to setup `rustup` toolchain for your bootstrapped compiler
 
-**Note** This does _not_ allow you to build `rustc` with cargo directly. You still have to use `x.py` to work on the compiler or standard library, this just lets you use `cargo fmt`.
+**Note** This does _not_ allow you to build `rustc` with cargo directly. You
+still have to use `x.py` to work on the compiler or standard library, this just
+lets you use `cargo fmt`.
 
 [installing a nightly toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html?highlight=nightl#working-with-nightly-rust
 [setup a worktree for]: ./suggested.html#working-on-multiple-branches-at-the-same-time

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -80,8 +80,10 @@ rustup override set nightly
 after [installing a nightly toolchain] with `rustup`. Don't forget to do this for all
 directories you have [setup a worktree for].
 
-**note** see [the section on vscode] for how to configure it with this real rustfmt `x.py` uses, 
+**Note** see [the section on vscode] for how to configure it with this real rustfmt `x.py` uses, 
 and [the section on rustup] for how to setup `rustup` toolchain for your bootstrapped compiler
+
+**Note** This does _not_ allow you to build `rustc` with cargo directly. You still have to use `x.py` to work on the compiler or standard library, this just lets you use `cargo fmt`.
 
 [installing a nightly toolchain]: https://rust-lang.github.io/rustup/concepts/channels.html?highlight=nightl#working-with-nightly-rust
 [setup a worktree for]: ./suggested.html#working-on-multiple-branches-at-the-same-time


### PR DESCRIPTION
Talked about this in zulip, this makes it to cargo fmt and editor integrations kindof just work