### PR TITLE
Recommend setting up `check_line_lengths` as a pre-commit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ and execute the following command in the root of the repository:
 
 The build files are found in the `book` directory.
 
+### Pre-commit script
+
+We also test that line lengths are less than 100 columns. To test this locally,
+you can run `ci/check_line_lengths.sh`.
+
+You can also set this to run automatically with the following command:
+
+```bash
+ln -s ../../ci/check_line_lengths.sh .git/hooks/pre-commit
+```
+
 ### Link Validations
 
 We use `mdbook-linkcheck` to validate URLs included in our documentation. To perform link checks, uncomment the `[output.linkcheck]` field in the `book.toml` configuration file and install `mdbook-linkcheck` with:

--- a/README.md
+++ b/README.md
@@ -81,10 +81,18 @@ The build files are found in the `book` directory.
 We also test that line lengths are less than 100 columns. To test this locally,
 you can run `ci/check_line_lengths.sh`.
 
-You can also set this to run automatically with the following command:
+You can also set this to run automatically.
+
+On Linux:
 
 ```bash
 ln -s ../../ci/check_line_lengths.sh .git/hooks/pre-commit
+```
+
+On Windows:
+
+```powershell
+cd .git/hooks && New-Item -Path ../../.git_hooks/* -ItemType SymbolicLink -Value . && cd ../..
 ```
 
 ### Link Validations

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ln -s ../../ci/check_line_lengths.sh .git/hooks/pre-commit
 On Windows:
 
 ```powershell
-cd .git/hooks && New-Item -Path ../../.git_hooks/* -ItemType SymbolicLink -Value . && cd ../..
+New-Item -Path .git/hooks/pre-commit -ItemType HardLink -Value <absolute_path/to/check_line_lengths.sh>
 ```
 
 ### Link Validations

--- a/ci/check_line_lengths.sh
+++ b/ci/check_line_lengths.sh
@@ -1,19 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$1" == "--help" ]; then
-    echo 'Usage:'
-    echo '  MAX_LINE_LENGTH=100' "$0" 'src/**/*.md'
-    exit 1
+  echo 'Usage:' "[MAX_LINE_LENGTH=n] $0 [file ...]"
+  exit 1
 fi
 
 if [ "$MAX_LINE_LENGTH" == "" ]; then
-    echo '`MAX_LINE_LENGTH` environment variable not set. Try --help.'
-    exit 1
+    MAX_LINE_LENGTH=100
 fi
 
 if [ "$1" == "" ]; then
-    echo 'No files provided.'
-    exit 1
+  files=( src/**/*.md )
+else
+  files=( "$@" )
 fi
 
 echo "Checking line lengths in all source files <= $MAX_LINE_LENGTH chars..."
@@ -21,7 +20,7 @@ echo "Checking line lengths in all source files <= $MAX_LINE_LENGTH chars..."
 echo "Offending files and lines:"
 (( bad_lines = 0 ))
 (( inside_block = 0 ))
-for file in "$@" ; do
+for file in "${files[@]}"; do
   echo "$file"
   (( line_no = 0 ))
   while IFS="" read -r line || [[ -n "$line" ]] ; do


### PR DESCRIPTION
I've run into lots of annoying failures from this.

- Make it runnable without arguments
- Add it in the README

Open questions: How does this work on Windows (if at all)?