### PR TITLE
update 'ByRef' borrow types of closures + minor fixes

### DIFF
--- a/src/closure.md
+++ b/src/closure.md
@@ -5,7 +5,7 @@ effectively "desugared" into structs that contain the values they use (or
 references to the values they use) from their creator's stack frame. rustc has
 the job of figuring out which values a closure uses and how, so it can decide
 whether to capture a given variable by shared reference, mutable reference, or
-by move. rustc also has to figure out which the closure traits ([`Fn`][fn],
+by move. rustc also has to figure out which of the closure traits ([`Fn`][fn],
 [`FnMut`][fn_mut], or [`FnOnce`][fn_once]) a closure is capable of
 implementing.
 
@@ -120,7 +120,7 @@ for this purpose.
 
 [upvars]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/query/queries/struct.upvars_mentioned.html
 
-Other than lazy invocation, one other thing that the distinguishes a closure from a
+Other than lazy invocation, one other thing that distinguishes a closure from a
 normal function is that it can use the upvars. It borrows these upvars from its surrounding
 context; therefore the compiler has to determine the upvar's borrow type. The compiler starts with
 assigning an immutable borrow type and lowers the restriction (that is, changes it from
@@ -189,7 +189,7 @@ can be `ByValue` (moved) or `ByRef` (borrowed). For `ByRef` borrows, it can be
 [mir_mod]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/index.html
 
 `Delegate` defines a few different methods (the different callbacks):
-**consume**: for *move* of a variable, **borrow** for a *borrow* of some kind
+**consume** for *move* of a variable, **borrow** for a *borrow* of some kind
 (shared or mutable), and **mutate** when we see an *assignment* of something.
 
 All of these callbacks have a common argument *cmt* which stands for Category,

--- a/src/closure.md
+++ b/src/closure.md
@@ -183,10 +183,10 @@ The callbacks are defined by implementing the [`Delegate`] trait. The
 [`InferBorrowKind`][ibk] type implements `Delegate` and keeps a map that
 records for each upvar which mode of capture was required. The modes of capture
 can be `ByValue` (moved) or `ByRef` (borrowed). For `ByRef` borrows, the possible
-[`BorrowKind`][BorrowKind]s are `ImmBorrow`, `UniqueImmBorrow`, `MutBorrow` as defined in the
+[`BorrowKind`]s are `ImmBorrow`, `UniqueImmBorrow`, `MutBorrow` as defined in the
 [`compiler/rustc_middle/src/ty/mod.rs`][middle_ty].
 
-[BorrowKind]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.BorrowKind.html
+[`BorrowKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.BorrowKind.html
 [middle_ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/index.html
 
 `Delegate` defines a few different methods (the different callbacks):

--- a/src/closure.md
+++ b/src/closure.md
@@ -183,10 +183,10 @@ The callbacks are defined by implementing the [`Delegate`] trait. The
 [`InferBorrowKind`][ibk] type implements `Delegate` and keeps a map that
 records for each upvar which mode of borrow was required. The modes of borrow
 can be `ByValue` (moved) or `ByRef` (borrowed). For `ByRef` borrows, it can be
-`shared`, `shallow`, `unique` or `mut` as defined in the
-[`compiler/rustc_middle/src/mir/mod.rs`][mir_mod].
+`ImmBorrow`, `UniqueImmBorrow`, `MutBorrow` as defined in the
+[`compiler/rustc_middle/src/ty/mod.rs`][middle_ty].
 
-[mir_mod]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/index.html
+[middle_ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/index.html
 
 `Delegate` defines a few different methods (the different callbacks):
 **consume** for *move* of a variable, **borrow** for a *borrow* of some kind

--- a/src/closure.md
+++ b/src/closure.md
@@ -181,11 +181,12 @@ shared borrow and another one for a mutable borrow. It will also tell us what wa
 
 The callbacks are defined by implementing the [`Delegate`] trait. The
 [`InferBorrowKind`][ibk] type implements `Delegate` and keeps a map that
-records for each upvar which mode of borrow was required. The modes of borrow
-can be `ByValue` (moved) or `ByRef` (borrowed). For `ByRef` borrows, it can be
-`ImmBorrow`, `UniqueImmBorrow`, `MutBorrow` as defined in the
+records for each upvar which mode of capture was required. The modes of capture
+can be `ByValue` (moved) or `ByRef` (borrowed). For `ByRef` borrows, the possible
+[`BorrowKind`][BorrowKind]s are `ImmBorrow`, `UniqueImmBorrow`, `MutBorrow` as defined in the
 [`compiler/rustc_middle/src/ty/mod.rs`][middle_ty].
 
+[BorrowKind]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.BorrowKind.html
 [middle_ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/index.html
 
 `Delegate` defines a few different methods (the different callbacks):

--- a/src/compiler-src.md
+++ b/src/compiler-src.md
@@ -78,7 +78,7 @@ something like this:
 You can see the exact dependencies by reading the `Cargo.toml` for the various
 crates, just like a normal Rust crate.
 
-One final thing: [`src/llvm-project`] is a submodule for our fork of LLVM
+One final thing: [`src/llvm-project`] is a submodule for our fork of LLVM.
 During bootstrapping, LLVM is built and the [`src/librustc_llvm`] and
 [`src/rustllvm`] crates contain rust wrappers around LLVM (which is written in
 C++), so that the compiler can interface with it.


### PR DESCRIPTION
Hello! 🦀  This PR contains 2 commits.
1. update description of `ByRef` borrows of closures
The current version of `src/closure.md` explains that `ByRef` borrows can either be `shared`, `shallow`, `unique` or `mut` (enum variants of [`rustc_middle::mir::BorrowKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.BorrowKind.html)). 
However, the actual enum type used for representing borrows from closures seems to be a different type with the same name.  This PR updates the description for borrow types of closures. I found this out while tracking the type definitions.
([`InferBorrowKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_typeck/check/upvar/struct.InferBorrowKind.html) -> [`UpvarCaptureMap`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/type.UpvarCaptureMap.html) -> [`UpvarCapture`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.UpvarCapture.html) -> [`UpvarBorrow`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.UpvarBorrow.html) -> [`BorrowKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.BorrowKind.html))
```rust
// rustc_middle::ty::BorrowKind
pub enum BorrowKind {
    ImmBorrow,
    UniqueImmBorrow,
    MutBorrow,
}
```

2. minor punctual/grammar fixes

Thank you for reviewing this PR 😃 

**P.S.**
I'm really grateful to the authors who worked on the `closure.md` writeup! 😺 
It was very helpful for understanding how borrows from closures are resolved.