### PR TITLE
Add links to documentation sources.

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -373,9 +373,9 @@ the submodule to. Running `./x.py build` should work now.
 ## Writing Documentation
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`
-is located in  [`src/doc`][srcdoc] in the tree, and standard API documentation is generated
-from the source code itself (e.g. [`lib.rs`][librs]). Documentation pull requests function in the same way
-as other pull requests.
+is located in [`src/doc`][srcdoc] in the tree, and standard API documentation is generated
+from the source code itself (e.g. [`lib.rs`][librs]). Documentation pull requests function
+in the same way as other pull requests.
 
 [srcdoc]: https://github.com/rust-lang/rust/tree/master/src/doc
 [librs]: https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs#L1

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -373,12 +373,12 @@ the submodule to. Running `./x.py build` should work now.
 ## Writing Documentation
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`
-is located in [`src/doc`][srcdoc] in the tree, and standard API documentation is generated
-from the source code itself (e.g. [`lib.rs`][librs]). Documentation pull requests function
+is located in [`src/doc`] in the tree, and standard API documentation is generated
+from the source code itself (e.g. [`lib.rs`]). Documentation pull requests function
 in the same way as other pull requests.
 
-[srcdoc]: https://github.com/rust-lang/rust/tree/master/src/doc
-[librs]: https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs#L1
+[`src/doc`]: https://github.com/rust-lang/rust/tree/master/src/doc
+[`lib.rs`]: https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs#L1
 
 To find documentation-related issues, sort by the [T-doc label][tdoc].
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -373,9 +373,12 @@ the submodule to. Running `./x.py build` should work now.
 ## Writing Documentation
 
 Documentation improvements are very welcome. The source of `doc.rust-lang.org`
-is located in `src/doc` in the tree, and standard API documentation is generated
-from the source code itself. Documentation pull requests function in the same way
+is located in  [`src/doc`][srcdoc] in the tree, and standard API documentation is generated
+from the source code itself (e.g. [`lib.rs`][librs]). Documentation pull requests function in the same way
 as other pull requests.
+
+[srcdoc]: https://github.com/rust-lang/rust/tree/master/src/doc
+[librs]: https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs#L1
 
 To find documentation-related issues, sort by the [T-doc label][tdoc].
 


### PR DESCRIPTION
Linking directly to the relevant/example document source locations makes it easier for potential contributors to find the sources.

The choice of the `lib.rs` example is somewhat arbitrary based primarily on where I first encountered the question of where the docs were located:

 * https://github.com/rust-lang/rust/pull/77195#discussion_r495115432
 * https://github.com/rust-lang/rust/pull/77050