### PR TITLE
Allow anyone to change the status of a PR

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,8 @@
 [assign]
+
+[relabel]
+allow-unauthenticated = [
+    "waiting-on-review",
+    "waiting-on-author",
+    "blocked",
+]


### PR DESCRIPTION
Allows anyone to change the status of PRs by using the `@rustbot modify labels` command, so [this](https://github.com/rust-lang/rustc-dev-guide/pull/905#issuecomment-703255140) is allowed now.