### PR TITLE
Linkcheck only changed files (except for cron jobs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
 - source ~/.cargo/env || true
 - cargo install mdbook --version '^0.4.3'
-- cargo install mdbook-linkcheck --version '^0.7.0'
+- cargo install mdbook-linkcheck --git https://github.com/Michael-F-Bryan/mdbook-linkcheck
 script:
 - git checkout -b ci
 - git rebase origin/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 install:
 - source ~/.cargo/env || true
 - cargo install mdbook --version '^0.4.3'
-- cargo install mdbook-linkcheck --git https://github.com/Michael-F-Bryan/mdbook-linkcheck
+- cargo install mdbook-linkcheck --git https://github.com/Michael-F-Bryan/mdbook-linkcheck --rev 14441d77646d58cea8ffc32fde9ea33b2bedb1a2
 script:
 - git checkout -b ci
 - git rebase origin/master

--- a/book.toml
+++ b/book.toml
@@ -14,6 +14,7 @@ enable = true
 level = 0
 
 [output.linkcheck]
+command = "../../ci/linkcheck.sh"
 follow-web-links = true
 exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il", "www\\.amazon\\.com", "www\\.rustaceans\\.org" ]
 cache-timeout = 86400

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -10,7 +10,7 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
   echo "Doing full link check."
 elif [ "$CI" = "true" ] ; then # running in PR CI build
   if [ -z "$TRAVIS_COMMIT_RANGE" ]; then
-    echo "error: unexpected state: COMMIT_RANGE must be non-empty in CI"
+    echo "error: unexpected state: TRAVIS_COMMIT_RANGE must be non-empty in CI"
     exit 1
   fi
 

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -9,7 +9,7 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
 
   echo "Doing full link check."
 elif [ "$CI" = "true" ] ; then # running in PR CI build
-  if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
+  if [ -z "$TRAVIS_COMMIT_RANGE" ]; then
     echo "error: unexpected state: COMMIT_RANGE must be non-empty in CI"
     exit 1
   fi

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
+  FLAGS=""
+
+  echo "Doing full link check."
+elif [ "$CI" = "true" ] ; then # running in PR CI build
+  CHANGED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | tr '\n' ' ')
+  FLAGS="-f $CHANGED_FILES"
+
+  echo "Checking files changed in $TRAVIS_COMMIT_RANGE: $CHANGED_FILES"
+else # running locally
+  COMMIT_RANGE=master...
+  CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE | tr '\n' ' ')
+  FLAGS="-f $CHANGED_FILES"
+
+  echo "Checking files changed in $COMMIT_RANGE: $CHANGED_FILES"
+fi
+
+exec mdbook-linkcheck $FLAGS -- $TRAVIS_BUILD_DIR

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -9,6 +9,11 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
 
   echo "Doing full link check."
 elif [ "$CI" = "true" ] ; then # running in PR CI build
+  if [ -n "$TRAVIS_COMMIT_RANGE" ]; then
+    echo "error: unexpected state: COMMIT_RANGE must be non-empty in CI"
+    exit 1
+  fi
+
   CHANGED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE | tr '\n' ' ')
   FLAGS="-f $CHANGED_FILES"
 

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -ev
+set -o pipefail
+
 # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
   FLAGS=""

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ] ; then # running in cron job
   FLAGS=""
 


### PR DESCRIPTION
Closes #886

In this PR, we change the CI setup to only check files that have changed in the
most recent git commit. This means that changes in PRs are less likely to get
blocked on unrelated breakage (it's still possible if that breakage happens to
be in the same file).

On the other hand, we do want to periodically check all files. Currently, there
is a cron job that runs every day. We change the CI script to check if the
Travis run is a cron job and if so do a full link check. The hope is that by
having the cron job run often enough and preserving the linkcheck cache, we can
continue to find breakage relatively soon while avoiding the 429 Too Many
Requests issues we've been seeing.

This is currently blocked on a new mdbook-linkcheck release.
