### PR TITLE
Replace links to `buildbot2.r-l.o` with `bors.r-l.o`

### DIFF
--- a/src/compiler-team.md
+++ b/src/compiler-team.md
@@ -82,7 +82,7 @@ offer r+ privileges. This means that you have the right to instruct
 merge a PR
 ([here are some instructions for how to talk to bors][homu-guide]).
 
-[homu-guide]: https://buildbot2.rust-lang.org/homu/
+[homu-guide]: https://bors.rust-lang.org/
 
 The guidelines for reviewers are as follows:
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -128,7 +128,7 @@ with one another are marked as "always roll up".
 [rust-highfive]: https://github.com/rust-highfive
 [steveklabnik]: https://github.com/steveklabnik
 [@bors]: https://github.com/bors
-[merge-queue]: https://buildbot2.rust-lang.org/homu/queue/rust
+[merge-queue]: https://bors.rust-lang.org/queue/rust
 
 ### Opening a PR
 
@@ -540,4 +540,4 @@ are:
 [tlgba]: http://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: https://www.rustaceans.org/
 [rctd]: https://rustc-dev-guide.rust-lang.org/tests/intro.html
-[cheatsheet]: https://buildbot2.rust-lang.org/homu/
+[cheatsheet]: https://bors.rust-lang.org/

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -408,7 +408,7 @@ a PR (there are few other commands, but they are less relevant here). This puts
 the PR in [bors's queue][bors] to be tested and merged. Be patient; this can take a
 while and the queue can sometimes be long. PRs are never merged by hand.
 
-[bors]: https://buildbot2.rust-lang.org/homu/queue/rust
+[bors]: https://bors.rust-lang.org/queue/rust
 
 ### Bug Fixes or "Normal" code changes
 

--- a/src/tests/intro.md
+++ b/src/tests/intro.md
@@ -132,7 +132,7 @@ only a subset run the full suite of tests (see Rust's [platform tiers]).
 [GitHub Actions]: https://github.com/rust-lang/rust/actions
 [rust-lang-ci]: https://github.com/rust-lang-ci/rust/actions
 [bors]: https://github.com/servo/homu
-[queue]: https://buildbot2.rust-lang.org/homu/queue/rust
+[queue]: https://bors.rust-lang.org/queue/rust
 [platform tiers]: https://forge.rust-lang.org/release/platform-support.html#rust-platform-support
 
 ## Testing with Docker images


### PR DESCRIPTION
We've migrated to bors.rust-lang.org, thanks to Pietro :)