### PR TITLE
Add a `check-in.sh` script to automate writing markdown links for weekly check-in

### DIFF
--- a/ci/check-in.sh
+++ b/ci/check-in.sh
@@ -24,11 +24,16 @@ show_pulls() {
   jq -r '.[] | { title, number, html_url, user: .user.login } | "- " + .title + " [#" + (.number | tostring) + "](" + .html_url + ")"'
 }
 
-echo "Authors:"
-jq -r '{ login: .[].user.login } | "- **@" + .login + "**"' < pulls.json | sort -u
-echo "Changes:"
+echo "### Authors"
+jq -r '{ login: .[].user.login } | "- **@" + .login + "**"' < pulls.json \
+  | sort -u
+echo
+echo "### Changes"
+echo
 show_pulls < pulls.json
-echo "Changes in progress:"
+echo
+echo "### Changes in progress"
+echo
 # If there are more than 30 PRs open at a time, you'll need to set `per_page`.
 # For now this seems unlikely.
 curl "https://api.github.com/repos/rust-lang/rustc-dev-guide/pulls?state=open" | show_pulls

--- a/ci/check-in.sh
+++ b/ci/check-in.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -eu
+
+# This is not a very smart script
+if [ $# != 2 ]; then
+  echo "usage: $0 <since> <number-of-prs-merged>"
+  if [ $# = 1 ] ; then
+    echo "help: you can find the number of PRs merged at" \
+      "https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+is%3Aclosed+updated%3A%3E$1"
+  fi
+  exit 1
+fi
+
+curl() {
+  command curl -s "$@"
+}
+
+# Get recently updated PRs
+curl "https://api.github.com/repos/rust-lang/rustc-dev-guide/pulls?state=closed&per_page=$2" \
+  | jq '[.[] | select(.merged_at > "'"$1"'")]' > pulls.json
+
+show_pulls() {
+  jq -r '.[] | { title, number, html_url, user: .user.login } | "- " + .title + " [#" + (.number | tostring) + "](" + .html_url + ")"'
+}
+
+echo "Authors:"
+jq -r '{ login: .[].user.login } | "- **@" + .login + "**"' < pulls.json | sort -u
+echo "Changes:"
+show_pulls < pulls.json
+echo "Changes in progress:"
+# If there are more than 30 PRs open at a time, you'll need to set `per_page`.
+# For now this seems unlikely.
+curl "https://api.github.com/repos/rust-lang/rustc-dev-guide/pulls?state=open" | show_pulls

--- a/ci/check-in.sh
+++ b/ci/check-in.sh
@@ -7,7 +7,7 @@ if [ $# != 2 ]; then
   echo "usage: $0 <since> <number-of-prs-merged>"
   if [ $# = 1 ] ; then
     echo "help: you can find the number of PRs merged at" \
-      "https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+is%3Aclosed+updated%3A%3E$1"
+         "https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+is%3Amerged+updated%3A%3E$1"
   fi
   exit 1
 fi


### PR DESCRIPTION
Example usage:

```
$ ./check-in.sh
usage: ./check-in.sh <since> <number-of-prs-merged>
$ ./check-in.sh 2020-09-03
usage: ./check-in.sh <since> <number-of-prs-merged>
help: you can find the number of PRs merged at https://github.com/rust-lang/rustc-dev-guide/pulls?q=is%3Apr+is%3Aclosed+updated%3A%3E2020-09-03
$ ./check-in.sh 2020-09-03 72
Authors:
- **@1c3t3a**
- **@arora-aman**
... snip ...
Changes:
- Replace links to `buildbot2.r-l.o` with `bors.r-l.o` [#929](https://github.com/rust-lang/rustc-dev-guide/pull/929)
- Add reference PRs for `r?` and `r+` comments [#928](https://github.com/rust-lang/rustc-dev-guide/pull/928)
... snip ...
Changes in progress:
```

r? @spastorino 