### PR TITLE
Document `src/tools/x`, an `x.py` wrapper

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -76,7 +76,7 @@ There is a binary that wraps `x.py` called `x` in `src/tools/x`. All it does is
 run `x.py`, but it can be installed system-wide and run from any subdirectory
 of a checkout.
 
-You can install it with `cargo install --path/src/tools/x`.
+You can install it with `cargo install --path src/tools/x`.
 
 [bootstrap]: ./bootstrapping.md
 

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -70,6 +70,14 @@ if you want to learn more about `x.py`, read its README.md
 To read more about the bootstrap process and why `x.py` is necessary,
 [read this chapter][bootstrap].
 
+### Running `x.py` slightly more conveniently
+
+There is a binary that wraps `x.py` called `x` in `src/tools/x`. All it does is
+run `x.py`, but it can be installed system-wide and run from any subdirectory
+of a checkout.
+
+You can install it with `cargo install --path/src/tools/x`.
+
 [bootstrap]: ./bootstrapping.md
 
 ## Building the Compiler

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -74,7 +74,7 @@ To read more about the bootstrap process and why `x.py` is necessary,
 
 There is a binary that wraps `x.py` called `x` in `src/tools/x`. All it does is
 run `x.py`, but it can be installed system-wide and run from any subdirectory
-of a checkout.
+of a checkout. It also looks up the appropriate version of `python` to use.
 
 You can install it with `cargo install --path src/tools/x`.
 


### PR DESCRIPTION
Document the newly added `x` binary that wraps `x.py`, which can be installed system-wide, and can be run from any subdirectory of a rust repo checkout.

This landed recently in https://github.com/rust-lang/rust/pull/78658, and I was requested to document it here.