### PR TITLE
Turn off caching for normal CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 - git rebase origin/master
 - git log --oneline | head -n 10
 - mdbook build
+- { [ -e /tmp/cache.json ] && mv /tmp/cache.json book/linkcheck/cache.json; } || echo "No cache to restore."
 notifications:
   email: false
 env:

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -18,6 +18,9 @@ elif [ "$CI" = "true" ] ; then # running in PR CI build
   FLAGS="-f $CHANGED_FILES"
 
   echo "Checking files changed in $TRAVIS_COMMIT_RANGE: $CHANGED_FILES"
+
+  echo "Temporarily removing cache (see .travis.yml)"
+  mv $TRAVIS_BUILD_DIR/book/linkcheck/cache.json /tmp/cache.json
 else # running locally
   COMMIT_RANGE=master...
   CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE | tr '\n' ' ')


### PR DESCRIPTION
Currently, we use caching for all CI runs with a timeout of 1 day. However,
recently, we switched to testing only changed files for non-cron CI jobs.

This PR additionally nixes the cache for non-cron CI jobs, so that we fully
check all links in the relevant files.
