### PR TITLE
Update `param_env` link

### DIFF
--- a/src/param_env.md
+++ b/src/param_env.md
@@ -25,7 +25,7 @@ You can get the parameter environment for a `def_id` using the
 your use case. Using the `ParamEnv` from the surrounding context can allow you
 to evaluate more things. For example, suppose we had something the following:
 
-[query]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ty/ty/fn.param_env.html
+[query]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ty_utils/ty/fn.param_env.html
 
 ```rust
 trait Foo {


### PR DESCRIPTION
`rustc_ty` was recently [renamed] to `rustc_ty_utils`, so this link has
to be updated.

cc @LeSeulArtichaut

[renamed]: https://github.com/rust-lang/rust/commit/f59d03038c8601a66bd165a2f1980109665d077c
