### PR TITLE
Link to the Rustdoc book in the rustdoc chapter

### DIFF
--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -2,6 +2,8 @@
 
 Rustdoc actually uses the rustc internals directly. It lives in-tree with the
 compiler and standard library. This chapter is about how it works.
+For information about Rustdoc's features and how to use them, see
+the [Rustdoc book](https://doc.rust-lang.org/nightly/rustdoc/).
 
 Rustdoc is implemented entirely within the crate [`librustdoc`][rd]. It runs
 the compiler up to the point where we have an internal representation of a


### PR DESCRIPTION
This makes a) makes it easier to find info about rustdoc's features and
b) redirects people in the wrong place to where they should be looking.