### PR TITLE
Edit the Mir page to fix infelicities.

### DIFF
--- a/src/mir/index.md
+++ b/src/mir/index.md
@@ -216,31 +216,31 @@ The MIR data types are defined in the [`compiler/rustc_middle/src/mir/`][mir]
 module.  Each of the key concepts mentioned in the previous section
 maps in a fairly straightforward way to a Rust type.
 
-The main MIR data type is `Mir`. It contains the data for a single
+The main MIR data type is [`Body`]. It contains the data for a single
 function (along with sub-instances of Mir for "promoted constants",
 but [you can read about those below](#promoted)).
 
 - **Basic blocks**: The basic blocks are stored in the field
-  [`Body::basic_blocks`][basicblocks]; this is a vector 
+  [`Body::basic_blocks`][basicblocks]; this is a vector
   of [`BasicBlockData`] structures. Nobody ever references a
   basic block directly: instead, we pass around [`BasicBlock`]
   values, which are [newtype'd] indices into this vector.
 - **Statements** are represented by the type [`Statement`].
-- **Terminators** are represented by the `Terminator`.
+- **Terminators** are represented by the [`Terminator`].
 - **Locals** are represented by a [newtype'd] index type [`Local`].
-  The data for a local variable is found in the `Mir` (the `local_decls`
-  vector). There is also a special constant `RETURN_PLACE` identifying
-  the special "local" representing the return value.
-- **Places** are identified by the enum [`Place`]. There are a few 
+  The data for a local variable is found in the 
+  [`Body::local_decls`][localdecls] vector). There is also a special constant
+  [`RETURN_PLACE`] identifying the special "local" representing the return value.
+- **Places** are identified by the enum [`Place`]. There are a few
   variants:
   - Local variables like `_1`
   - Static variables `FOO`
   - **Projections**, which are fields or other things that "project
-    out" from a base place. These are represented by the type 
-    [`Projection`].  So e.g. the place `_1.f` is a projection,
+    out" from a base place. These are represented by the type
+    [`ProjectionElem`].  So e.g. the place `_1.f` is a projection,
     with `f` being the "projection element and `_1` being the base
     path. `*_1` is also a projection, with the `*` being represented
-    by the `ProjectionElem::Deref` element.
+    by the [`ProjectionElem::Deref`] element.
 - **Rvalues** are represented by the enum [`Rvalue`].
 - **Operands** are represented by the enum [`Operand`].
 
@@ -257,13 +257,18 @@ but [you can read about those below](#promoted)).
 
 [mir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/index.html
 [mirmanip]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/index.html
+[`Body`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html
 [newtype'd]: ../appendix/glossary.html#newtype
-[basicblocks](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.basic_blocks)
+[basicblocks]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.basic_blocks
 [`BasicBlock`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.BasicBlock.html
 [`BasicBlockData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.BasicBlockData.html
 [`Statement`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Statement.html
 [`Terminator`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/terminator/struct.Terminator.html
 [`Local`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Local.html
+[localdecls]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.local_decls
+[`RETURN_PLACE`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/constant.RETURN_PLACE.html
 [`Place`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Place.html
+[`ProjectionElem`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.ProjectionElem.html
+[`ProjectionElem::Deref`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.ProjectionElem.html#variant.Deref
 [`Rvalue`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.Rvalue.html
 [`Operand`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.Operand.html


### PR DESCRIPTION
- Remove dead reference to Mir. reflow sentence to talk about
  `Body::local_decls`
- Fix broken links to render properly.
- Add links for `Terminator`, `RETURN_PLACE`, `ProjectionElem`.