### PR TITLE
[Fixes #778] Added and reorganized lecture links

### DIFF
--- a/src/appendix/compiler-lecture.md
+++ b/src/appendix/compiler-lecture.md
@@ -2,12 +2,12 @@
 
 These are videos where various experts explain different parts of the compiler:
 
-## General:
+## General
 - [January 2019: Tom Tromey discusses debugging support in rustc](https://www.youtube.com/watch?v=elBxMRSNYr4)
 - [June 2019: Responsive compilers - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=N6b44kMS6OM)
 - [June 2019: Things I Learned (TIL) - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=LIYkT3p5gTs)
 
-## Rust Analyzer:
+## Rust Analyzer
 - [January 2019: How Salsa Works](https://www.youtube.com/watch?v=_muY4HjSqVw)
 - [January 2019: Salsa In More Depth](https://www.youtube.com/watch?v=i_IhACacPRY)
 - [January 2019: Rust analyzer guide](https://www.youtube.com/watch?v=ANKBNiSWyfc)
@@ -15,34 +15,34 @@ These are videos where various experts explain different parts of the compiler:
 - [March 2019: rust-analyzer type-checker overview by flodiebold](https://www.youtube.com/watch?v=Lmp3P9WNL8o)
 - [March 2019: RLS 2.0, Salsa, and Name Resolution](https://www.youtube.com/watch?v=Xr-rBqLr-G4)
 
-## Type System:
+## Type System
 - [July 2015: Felix Klock - Rust: A type system you didn't know you wanted - Curry On](https://www.youtube.com/watch?v=Q7lQCgnNWU0)
 - [November 2016: Felix Klock - Subtyping in Rust and Clarke's Third Law](https://www.youtube.com/watch?v=fI4RG_uq-WU)
 - [February 2019: Universes and Lifetimes](https://www.youtube.com/watch?v=iV1Z0xYXkck)
 - [April 2019: Representing types in rustc](https://www.youtube.com/watch?v=c01TsOsr3-c)
 - [March 2019: RFC #2229 Disjoint Field Capture plan](https://www.youtube.com/watch?v=UTXOptVMuIc)
 
-## Closures:
+## Closures
 - [October 2018: closures and upvar capture](https://www.youtube.com/watch?v=fMopdkn5-Xw)
 - [October 2018: blitzerr closure upvar tys](https://www.youtube.com/watch?v=pLmVhSB-z4s)
 - [January 2019: Convert Closure Upvar Representation to Tuples with blitzerr](https://www.youtube.com/watch?v=2QCuNtISoYc)
 
-## Chalk:
+## Chalk
 - [July 2018: Coherence in Chalk by Sunjay Varma - Bay Area Rust Meetup](https://www.youtube.com/watch?v=rZqS4bLPL24)
 - [March 2019: rustc-chalk integration overview](https://www.youtube.com/watch?v=MBWtbDifPeU)
 - [April 2019: How the chalk-engine crate works](https://www.youtube.com/watch?v=Ny2928cGDoM)
 - [May 2019: How the chalk-engine crate works 2](https://www.youtube.com/watch?v=hmV66tB79LM)
 
-## Polonius:
+## Polonius
 - [March 2019: Polonius-rustc walkthrough](https://www.youtube.com/watch?v=i5KdU0ieb_A)
 - [May 2019: Polonius WG: Initialization and move tracking](https://www.youtube.com/watch?v=ilv9V-328HI)
 
-## Miri:
+## Miri
 - [March 2019: oli-obk on miri and constant evaluation](https://www.youtube.com/watch?v=5Pm2C1YXrvM)
 
-## Async:
+## Async
 - [February 2019: async-await implementation plans](https://www.youtube.com/watch?v=xe2_whJWBC0)
 - [April 2019: async-await region inferencer](https://www.youtube.com/watch?v=hlOxfkUDLPQ)
 
-## Code Generation:
+## Code Generation
 - [January 2019: Cranelift](https://www.youtube.com/watch?v=9OIA7DTFQWU)

--- a/src/appendix/compiler-lecture.md
+++ b/src/appendix/compiler-lecture.md
@@ -2,12 +2,12 @@
 
 These are videos where various experts explain different parts of the compiler:
 
-General:
+## General:
 - [January 2019: Tom Tromey discusses debugging support in rustc](https://www.youtube.com/watch?v=elBxMRSNYr4)
 - [June 2019: Responsive compilers - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=N6b44kMS6OM)
 - [June 2019: Things I Learned (TIL) - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=LIYkT3p5gTs)
 
-Rust Analyzer:
+## Rust Analyzer:
 - [January 2019: How Salsa Works](https://www.youtube.com/watch?v=_muY4HjSqVw)
 - [January 2019: Salsa In More Depth](https://www.youtube.com/watch?v=i_IhACacPRY)
 - [January 2019: Rust analyzer guide](https://www.youtube.com/watch?v=ANKBNiSWyfc)
@@ -15,34 +15,34 @@ Rust Analyzer:
 - [March 2019: rust-analyzer type-checker overview by flodiebold](https://www.youtube.com/watch?v=Lmp3P9WNL8o)
 - [March 2019: RLS 2.0, Salsa, and Name Resolution](https://www.youtube.com/watch?v=Xr-rBqLr-G4)
 
-Type System:
+## Type System:
 - [July 2015: Felix Klock - Rust: A type system you didn't know you wanted - Curry On](https://www.youtube.com/watch?v=Q7lQCgnNWU0)
 - [November 2016: Felix Klock - Subtyping in Rust and Clarke's Third Law](https://www.youtube.com/watch?v=fI4RG_uq-WU)
 - [February 2019: Universes and Lifetimes](https://www.youtube.com/watch?v=iV1Z0xYXkck)
 - [April 2019: Representing types in rustc](https://www.youtube.com/watch?v=c01TsOsr3-c)
 - [March 2019: RFC #2229 Disjoint Field Capture plan](https://www.youtube.com/watch?v=UTXOptVMuIc)
 
-Closures:
+## Closures:
 - [October 2018: closures and upvar capture](https://www.youtube.com/watch?v=fMopdkn5-Xw)
 - [October 2018: blitzerr closure upvar tys](https://www.youtube.com/watch?v=pLmVhSB-z4s)
 - [January 2019: Convert Closure Upvar Representation to Tuples with blitzerr](https://www.youtube.com/watch?v=2QCuNtISoYc)
 
-Chalk:
+## Chalk:
 - [July 2018: Coherence in Chalk by Sunjay Varma - Bay Area Rust Meetup](https://www.youtube.com/watch?v=rZqS4bLPL24)
 - [March 2019: rustc-chalk integration overview](https://www.youtube.com/watch?v=MBWtbDifPeU)
 - [April 2019: How the chalk-engine crate works](https://www.youtube.com/watch?v=Ny2928cGDoM)
 - [May 2019: How the chalk-engine crate works 2](https://www.youtube.com/watch?v=hmV66tB79LM)
 
-Polonius:
+## Polonius:
 - [March 2019: Polonius-rustc walkthrough](https://www.youtube.com/watch?v=i5KdU0ieb_A)
 - [May 2019: Polonius WG: Initialization and move tracking](https://www.youtube.com/watch?v=ilv9V-328HI)
 
-Miri:
+## Miri:
 - [March 2019: oli-obk on miri and constant evaluation](https://www.youtube.com/watch?v=5Pm2C1YXrvM)
 
-Async:
+## Async:
 - [February 2019: async-await implementation plans](https://www.youtube.com/watch?v=xe2_whJWBC0)
 - [April 2019: async-await region inferencer](https://www.youtube.com/watch?v=hlOxfkUDLPQ)
 
-Code Generation:
+## Code Generation:
 - [January 2019: Cranelift](https://www.youtube.com/watch?v=9OIA7DTFQWU)

--- a/src/appendix/compiler-lecture.md
+++ b/src/appendix/compiler-lecture.md
@@ -2,26 +2,47 @@
 
 These are videos where various experts explain different parts of the compiler:
 
-- [Tom Tromey discusses debugging support in rustc](https://www.youtube.com/watch?v=elBxMRSNYr4)
-- [How Salsa Works (2019.01)](https://www.youtube.com/watch?v=_muY4HjSqVw)
-- [Salsa In More Depth (2019.01)](https://www.youtube.com/watch?v=i_IhACacPRY)
-- [RLS 2.0, Salsa, and Name Resolution](https://www.youtube.com/watch?v=Xr-rBqLr-G4)
-- [Cranelift](https://www.youtube.com/watch?v=9OIA7DTFQWU)
-- [Rust analyzer guide](https://www.youtube.com/watch?v=ANKBNiSWyfc)
-- [Rust analyzer syntax trees](https://www.youtube.com/watch?v=DGAuLWdCCAI)
-- [rust-analyzer type-checker overview by flodiebold](https://www.youtube.com/watch?v=Lmp3P9WNL8o)
-- [oli-obk on miri and constant evaluation](https://www.youtube.com/watch?v=5Pm2C1YXrvM)
-- [Polonius-rustc walkthrough](https://www.youtube.com/watch?v=i5KdU0ieb_A)
-- [rustc-chalk integration overview](https://www.youtube.com/watch?v=MBWtbDifPeU)
-- [Coherence in Chalk by Sunjay Varma - Bay Area Rust Meetup](https://www.youtube.com/watch?v=rZqS4bLPL24)
-- [How the chalk-engine crate works](https://www.youtube.com/watch?v=Ny2928cGDoM)
-- [How the chalk-engine crate works 2](https://www.youtube.com/watch?v=hmV66tB79LM)
-- [RFC #2229 Disjoint Field Capture plan](https://www.youtube.com/watch?v=UTXOptVMuIc)
-- [closures and upvar capture](https://www.youtube.com/watch?v=fMopdkn5-Xw)
-- [blitzerr closure upvar tys](https://www.youtube.com/watch?v=pLmVhSB-z4s)
-- [Convert Closure Upvar Representation to Tuples with blitzerr](https://www.youtube.com/watch?v=2QCuNtISoYc)
-- [async-await implementation plans](https://www.youtube.com/watch?v=xe2_whJWBC0)
-- [async-await region inferencer](https://www.youtube.com/watch?v=hlOxfkUDLPQ)
-- [Universes and Lifetimes](https://www.youtube.com/watch?v=iV1Z0xYXkck)
-- [Representing types in rustc](https://www.youtube.com/watch?v=c01TsOsr3-c)
-- [Polonius WG: Initialization and move tracking](https://www.youtube.com/watch?v=ilv9V-328HI)
+General:
+- [January 2019: Tom Tromey discusses debugging support in rustc](https://www.youtube.com/watch?v=elBxMRSNYr4)
+- [June 2019: Responsive compilers - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=N6b44kMS6OM)
+- [June 2019: Things I Learned (TIL) - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=LIYkT3p5gTs)
+
+Rust Analyzer:
+- [January 2019: How Salsa Works](https://www.youtube.com/watch?v=_muY4HjSqVw)
+- [January 2019: Salsa In More Depth](https://www.youtube.com/watch?v=i_IhACacPRY)
+- [January 2019: Rust analyzer guide](https://www.youtube.com/watch?v=ANKBNiSWyfc)
+- [February 2019: Rust analyzer syntax trees](https://www.youtube.com/watch?v=DGAuLWdCCAI)
+- [March 2019: rust-analyzer type-checker overview by flodiebold](https://www.youtube.com/watch?v=Lmp3P9WNL8o)
+- [March 2019: RLS 2.0, Salsa, and Name Resolution](https://www.youtube.com/watch?v=Xr-rBqLr-G4)
+
+Type System:
+- [July 2015: Felix Klock - Rust: A type system you didn't know you wanted - Curry On](https://www.youtube.com/watch?v=Q7lQCgnNWU0)
+- [November 2016: Felix Klock - Subtyping in Rust and Clarke's Third Law](https://www.youtube.com/watch?v=fI4RG_uq-WU)
+- [February 2019: Universes and Lifetimes](https://www.youtube.com/watch?v=iV1Z0xYXkck)
+- [April 2019: Representing types in rustc](https://www.youtube.com/watch?v=c01TsOsr3-c)
+- [March 2019: RFC #2229 Disjoint Field Capture plan](https://www.youtube.com/watch?v=UTXOptVMuIc)
+
+Closures:
+- [October 2018: closures and upvar capture](https://www.youtube.com/watch?v=fMopdkn5-Xw)
+- [October 2018: blitzerr closure upvar tys](https://www.youtube.com/watch?v=pLmVhSB-z4s)
+- [January 2019: Convert Closure Upvar Representation to Tuples with blitzerr](https://www.youtube.com/watch?v=2QCuNtISoYc)
+
+Chalk:
+- [July 2018: Coherence in Chalk by Sunjay Varma - Bay Area Rust Meetup](https://www.youtube.com/watch?v=rZqS4bLPL24)
+- [March 2019: rustc-chalk integration overview](https://www.youtube.com/watch?v=MBWtbDifPeU)
+- [April 2019: How the chalk-engine crate works](https://www.youtube.com/watch?v=Ny2928cGDoM)
+- [May 2019: How the chalk-engine crate works 2](https://www.youtube.com/watch?v=hmV66tB79LM)
+
+Polonius:
+- [March 2019: Polonius-rustc walkthrough](https://www.youtube.com/watch?v=i5KdU0ieb_A)
+- [May 2019: Polonius WG: Initialization and move tracking](https://www.youtube.com/watch?v=ilv9V-328HI)
+
+Miri:
+- [March 2019: oli-obk on miri and constant evaluation](https://www.youtube.com/watch?v=5Pm2C1YXrvM)
+
+Async:
+- [February 2019: async-await implementation plans](https://www.youtube.com/watch?v=xe2_whJWBC0)
+- [April 2019: async-await region inferencer](https://www.youtube.com/watch?v=hlOxfkUDLPQ)
+
+Code Generation:
+- [January 2019: Cranelift](https://www.youtube.com/watch?v=9OIA7DTFQWU)


### PR DESCRIPTION
Added the following links as per the discussion in #778:

- [Responsive compilers - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=N6b44kMS6OM)
- [Things I Learned (TIL) - Nicholas Matsakis - PLISS 2019](https://www.youtube.com/watch?v=LIYkT3p5gTs)
- [Felix Klock - Subtyping in Rust and Clarke's Third Law](https://www.youtube.com/watch?v=fI4RG_uq-WU)
- [Felix Klock - Rust: A type system you didn't know you wanted - Curry On](https://www.youtube.com/watch?v=Q7lQCgnNWU0)

Only these links were added, none were removed, but they were reorganized to be closer grouped by topic and date.
The approximated date was also prefixed to the link text to give some sense of how old the information therein is.
