### PR TITLE
Corrected MIR file path and fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for the docs you're looking for instead of reading them top to bottom.
 
 ### Contributing to the guide
 
-The guide is useful today, but it has a lot of work still go.
+The guide is useful today, but it has a lot of work still to go.
 
 If you'd like to help improve the guide, we'd love to have you! You can find
 plenty of issues on the [issue

--- a/src/part-5-intro.md
+++ b/src/part-5-intro.md
@@ -9,7 +9,7 @@ and transform it into [MIR]. We have also shown how the compiler does various
 analyses on the code to detect things like type or lifetime errors. Now, we
 will finally take the MIR and produce some executable machine code.
 
-[MIR]: ./mir/index.html
+[MIR]: ./mir/index.md
 
 > NOTE: This part of a compiler is often called the _backend_ the term is a bit
 > overloaded because in the compiler source, it usually refers to the "codegen


### PR DESCRIPTION
In this PR I have corrected the hyperlink for MIR in the page https://github.com/rust-lang/rustc-dev-guide/blob/master/src/part-5-intro.md


> So far, we've shown how the compiler can take raw source code in text format and transform it into ```MIR```. We have also shown how the compiler does various analyses on the code to detect things like type or lifetime errors. Now, we will finally take the MIR and produce some executable machine code.

The link that originally pointed to the highlighted ```MIR``` was incorrectly set to https://github.com/rust-lang/rustc-dev-guide/blob/master/src/mir/index.html. I have set it to https://github.com/rust-lang/rustc-dev-guide/blob/master/src/mir/index.md.

Plus, I have corrected a typo in the readme.md.