### PR TITLE
Fixed a grammatical error in hardware requirements section

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/rustc-dev-guide.iml" filepath="$PROJECT_DIR$/.idea/rustc-dev-guide.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/rustc-dev-guide.iml
+++ b/.idea/rustc-dev-guide.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -70,7 +70,7 @@ recommend trying to build on a Raspberry Pi :P
   clearing incremental caches. More space is better, the compiler is a bit of a
   hog; it's a problem we are aware of.
 - Recommended >=8GB RAM.
-- Recommended >=2 cores; more cores really helps.
+- Recommended >=2 cores; having more cores really helps.
 - You will need an internet connection to build; the bootstrapping process
   involves updating git submodules and downloading a beta compiler. It doesn't
   need to be super fast, but that can help.


### PR DESCRIPTION
The hardware requirements section at https://rustc-dev-guide.rust-lang.org/getting-started.html#system-requirements has the line 

> Recommended >=2 cores; more cores really helps.

This should be either 
> Recommended >=2 cores; having more cores really helps.

where the verb help is being used in a singular form

or

> Recommended >=2 cores; more cores really help.

where the verb help is being used for the plural _cores_

The PR fixes this little error which makes the text better readable and technically better.