### PR TITLE
Fixed a grammatical error in hardware requirements section

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -70,7 +70,7 @@ recommend trying to build on a Raspberry Pi :P
   clearing incremental caches. More space is better, the compiler is a bit of a
   hog; it's a problem we are aware of.
 - Recommended >=8GB RAM.
-- Recommended >=2 cores; more cores really helps.
+- Recommended >=2 cores; having more cores really helps.
 - You will need an internet connection to build; the bootstrapping process
   involves updating git submodules and downloading a beta compiler. It doesn't
   need to be super fast, but that can help.


### PR DESCRIPTION
The hardware requirements section at https://rustc-dev-guide.rust-lang.org/getting-started.html#system-requirements has the line

>Recommended >=2 cores; more cores really helps.

This should be either

>Recommended >=2 cores; having more cores really helps.

where the verb help is being used in a singular form

or

>Recommended >=2 cores; more cores really help.

where the verb help is being used for the plural _cores_

The PR fixes this little error which makes the text better readable and technically better.