### PR TITLE
Note that `x.py check` now allows using any stage

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -70,12 +70,9 @@ These defaults are as follows:
 - `install`: `--stage 2`
 - `bench`: `--stage 2`
 
-You can always override the stage by passing `--stage N` explicitly, except for `check`,
-which is [hard-coded to stage 0][stage1-check].
+You can always override the stage by passing `--stage N` explicitly.
 
 For more information about stages, [see below](#understanding-stages-of-bootstrap).
-
-[stage1-check]: https://github.com/rust-lang/rust/issues/46955
 
 ## Complications of bootstrapping
 


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/81064 (and shouldn't be merged until after that PR is merged).