### PR TITLE
improved the readablity of a line

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -50,7 +50,7 @@ and a bunch of tools (e.g. `rustdoc`, the bootstrapping infrastructure, etc).
 
 There are also a bunch of submodules for things like LLVM, `clippy`, `miri`,
 etc. You don't need to clone these immediately, but the build tool will
-automatically clone and sync them (more later).
+automatically clone and sync them (more on this later).
 
 [**Take a look at the "Suggested Workflows" chapter for some helpful
 advice.**][suggested]


### PR DESCRIPTION
On the _Cloning and Building_ section on the page https://rustc-dev-guide.rust-lang.org/getting-started.html#cloning-and-building, the following line can be made better readable : 

> clone these immediately, but the build tool will automatically clone and sync them (more later).` 

In this PR, I have added the following : 

> clone these immediately, but the build tool will automatically clone and sync them (more on this later).` 

I believe this makes the text better readable and more precise technically.