### PR TITLE
put `x.py` in ticks

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -107,7 +107,7 @@ However, most of the code lives in `src/bootstrap`.
 `bootstrap` has a difficult problem: it is written in Rust, but yet it is run
 before the rust compiler is built! To work around this, there are two
 components of bootstrap: the main one written in rust, and `bootstrap.py`.
-`bootstrap.py` is what gets run by x.py. It takes care of downloading the
+`bootstrap.py` is what gets run by `x.py`. It takes care of downloading the
 `stage0` compiler, which will then build the bootstrap binary written in
 Rust.
 


### PR DESCRIPTION
I was reading the book and I found a little bug. This fix turns x.py -> `x.py`