### PR TITLE
Make check-in.sh output in way that suggest to add only the most relevant info

### DIFF
--- a/ci/check-in.sh
+++ b/ci/check-in.sh
@@ -24,15 +24,11 @@ show_pulls() {
   jq -r '.[] | { title, number, html_url, user: .user.login } | "- " + .title + " [#" + (.number | tostring) + "](" + .html_url + ")"'
 }
 
-echo "### Authors"
-jq -r '{ login: .[].user.login } | "- **@" + .login + "**"' < pulls.json \
-  | sort -u
-echo
-echo "### Changes"
+echo "### Most notable changes"
 echo
 show_pulls < pulls.json
 echo
-echo "### Changes in progress"
+echo "### Most notable WIPs"
 echo
 # If there are more than 30 PRs open at a time, you'll need to set `per_page`.
 # For now this seems unlikely.


### PR DESCRIPTION
I think our checkins should look more like https://hackmd.io/Umz8k0PwRb-YVUUEK8i0aQ#2021-02-04, without authors and more condensed.

r? @jyn514 