### PR TITLE
Update docs from date triage for 2021-02

### DIFF
--- a/src/compiler-src.md
+++ b/src/compiler-src.md
@@ -21,10 +21,6 @@ containing the compiler, the standard libraries (`core`, `alloc`, `std`,
 `proc_macro`, etc), and `rustdoc`, along with the build system and a bunch of
 tools and submodules for building a full Rust distribution.
 
-As of August 2020 <!-- date: 2020-08 -->, this structure is gradually undergoing
-some transformation to make it a bit less monolithic and more approachable,
-especially to newcomers.
-
 The repository consists of three main directories:
 
 - `compiler/` contains the source code for `rustc`. It consists of many crates

--- a/src/overview.md
+++ b/src/overview.md
@@ -250,7 +250,7 @@ Moreover, the compiler wasn't originally built to use a query system; the query
 system has been retrofitted into the compiler, so parts of it are not query-fied
 yet. Also, LLVM isn't our code, so that isn't querified either. The plan is to
 eventually query-fy all of the steps listed in the previous section, but as of
-April 2020 <!-- date: 2020-04 -->, only the steps between HIR and LLVM-IR are
+February 2021 <!-- date: 2021-02 -->, only the steps between HIR and LLVM IR are
 query-fied. That is, lexing and parsing are done all at once for the whole
 program.
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -251,8 +251,8 @@ system has been retrofitted into the compiler, so parts of it are not query-fied
 yet. Also, LLVM isn't our code, so that isn't querified either. The plan is to
 eventually query-fy all of the steps listed in the previous section, but as of
 February 2021 <!-- date: 2021-02 -->, only the steps between HIR and LLVM IR are
-query-fied. That is, lexing and parsing are done all at once for the whole
-program.
+query-fied. That is, lexing, parsing, name resolution, and macro expansion are
+done all at once for the whole program.
 
 One other thing to mention here is the all-important "typing context",
 [`TyCtxt`], which is a giant struct that is at the center of all things.

--- a/src/parallel-rustc.md
+++ b/src/parallel-rustc.md
@@ -22,9 +22,9 @@ There are a few basic ideas in this effort:
 
 [`rayon`]: https://crates.io/crates/rayon
 
-As of May 2020 <!-- date: 2020-05 -->, much of this effort is on hold due to
-lack of manpower. We have a working prototype with promising performance gains
-in many cases. However, there are two blockers:
+As of February 2021 <!-- date: 2021-02 -->, much of this effort is on hold due
+to lack of manpower. We have a working prototype with promising performance
+gains in many cases. However, there are two blockers:
 
 - It's not clear what invariants need to be upheld that might not hold in the
   face of concurrency. An auditing effort was underway, but seems to have

--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -86,7 +86,7 @@ Here is the list of passes as of February 2021 <!-- date: 2021-02 -->:
   separate doc attribute, and this will combine them into a single string with
   line breaks between each attribute.
 
-- `collect-intra-doc-links` resolves intra-doc links.
+- `collect-intra-doc-links` resolves [intra-doc links](https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html).
 
 - `collect-trait-impls` collects trait impls for each item in the crate. For
   example, if we define a struct that implements a trait, this pass will note
@@ -261,4 +261,3 @@ on the internet. For example, the url for `std` will be `/std/".
 
 [`rustdoc` api docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc/
 [The rustdoc user guide]: https://doc.rust-lang.org/nightly/rustdoc/
-

--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -74,7 +74,7 @@ Here is the list of passes as of February 2021 <!-- date: 2021-02 -->:
 - `check-code-block-syntax` validates syntax inside Rust code blocks
   (`` ```rust ``)
 
-- `check-invalid-html-tags` detects invalid HTML (like an unclosed `\<span\>`)
+- `check-invalid-html-tags` detects invalid HTML (like an unclosed `<span>`)
   in doc comments.
 
 - `check-non-autolinks` detects links that could or should be written using
@@ -106,15 +106,25 @@ Here is the list of passes as of February 2021 <!-- date: 2021-02 -->:
   from the output. `strip-private` implies `strip-priv-imports`. Basically, the
   goal is to remove items that are not relevant for public documentation.
 
-- `stripper` provides utilities for the `strip-*` passes.
+- `unindent-comments` removes excess indentation on comments in order for the
+  Markdown to be parsed correctly. This is necessary because the convention for
+  writing documentation is to provide a space between the `///` or `//!` marker
+  and the doc text, but Markdown is whitespace-sensitive. For example, a block
+  of text with four-space indentation is parsed as a code block, so if we didn't
+  unindent comments, these list items
 
-- `unindent-comments` removes excess indentation on comments in order for
-  markdown to like it. This is necessary because the convention for writing
-  documentation is to provide a space between the `///` or `//!` marker and the
-  text, and stripping that leading space will make the text easier to parse by
-  the Markdown parser. (In the past, the Markdown parser used was not
-  CommonMark-compliant, which caused annoyances with extra whitespace but this
-  seems to be less of an issue today.)
+  ```rust,ignore
+  /// A list:
+  ///
+  ///    - Foo
+  ///    - Bar
+  ```
+
+  would be parsed as if they were in a code block, which is likely not what the
+  user intended.
+
+There is also a `stripper` module in `passes/`, but it is a collection of
+utility functions for the `strip-*` passes and is not a pass itself.
 
 ## From clean to crate
 

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -339,8 +339,8 @@ The error levels that you can have are:
 
 ## Revisions
 
-Certain classes of tests support "revisions" (as of February 2018 <!-- date:
-2018-02 -->, this includes compile-fail, run-fail, and incremental, though
+Certain classes of tests support "revisions" (as of February 2021 <!-- date:
+2021-02 -->, this includes compile-fail, run-fail, and incremental, though
 incremental tests are somewhat different). Revisions allow a single test file to
 be used for multiple tests. This is done by adding a special header at the top
 of the file:

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -72,7 +72,7 @@ inference works, or perhaps this blog post on
 [Unification in the Chalk project]: http://smallcultfollowing.com/babysteps/blog/2017/03/25/unification-in-chalk-part-1/
 
 All told, the inference context stores four kinds of inference variables (as of
-January 2018 <!-- date: 2018-01 -->):
+February 2021 <!-- date: 2021-02 -->):
 
 - Type variables, which come in three varieties:
   - General type variables (the most common). These can be unified with any

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -72,7 +72,7 @@ inference works, or perhaps this blog post on
 [Unification in the Chalk project]: http://smallcultfollowing.com/babysteps/blog/2017/03/25/unification-in-chalk-part-1/
 
 All told, the inference context stores four kinds of inference variables (as of
-February 2021 <!-- date: 2021-02 -->):
+January 2018 <!-- date: 2018-01 -->):
 
 - Type variables, which come in three varieties:
   - General type variables (the most common). These can be unified with any


### PR DESCRIPTION
Closes #1046.

The biggest change was updating the list of rustdoc passes. Several new
ones have been added since that documentation was written, so I added
those, and I also sorted the list so it is roughly alphabetical (except
for the part for the `strip-*` passes, which I left in the same order
since one of the list items has two passes so there's no "correct"
order).
