### PR TITLE
Bump mdBook: 0.4.5 -> 0.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - MAX_LINE_LENGTH=100 bash ci/check_line_lengths.sh src/**/*.md
 install:
 - source ~/.cargo/env || true
-- cargo install mdbook --version '^0.4.5'
+- cargo install mdbook --version '^0.4.6'
 - cargo install mdbook-linkcheck --version '^0.7.2'
 - cargo install mdbook-toc --version '^0.6.1'
 script:


### PR DESCRIPTION
Patch version, so there shouldn't be any breaking changes: [changelog]

Two helpful changes and fixes that caught my eye:

- Pressing Escape will remove the `?highlight` argument from the URL.
  - This should make it much easier to copy-and-paste nice search URLs,
    so it's a pretty great quality of life improvement.
- Properly handle `<` and `>` characters in the table of contents.
  - Just a good bug to fix :)

[changelog]: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-046
