### PR TITLE
Point to main branch on llvm-project's links

### DIFF
--- a/src/llvm-coverage-instrumentation.md
+++ b/src/llvm-coverage-instrumentation.md
@@ -65,7 +65,7 @@ When compiling with `-Z instrument-coverage`,
 [`CrateLoader::postprocess()`][crate-loader-postprocess] dynamically loads the
 `profiler_builtins` library by calling `inject_profiler_runtime()`.
 
-[compiler-rt-profile]: https://github.com/llvm/llvm-project/tree/master/compiler-rt/lib/profile
+[compiler-rt-profile]: https://github.com/llvm/llvm-project/tree/main/compiler-rt/lib/profile
 [crate-loader-postprocess]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/creader/struct.CrateLoader.html#method.postprocess
 
 ### MIR Pass: `InstrumentCoverage`

--- a/src/profile-guided-optimization.md
+++ b/src/profile-guided-optimization.md
@@ -122,7 +122,7 @@ basically packs the C code from `compiler-rt` into a Rust crate.
 In order for `profiler_builtins` to be built, `profiler = true` must be set
 in `rustc`'s `config.toml`.
 
-[compiler-rt-profile]: https://github.com/llvm/llvm-project/tree/master/compiler-rt/lib/profile
+[compiler-rt-profile]: https://github.com/llvm/llvm-project/tree/main/compiler-rt/lib/profile
 
 ## Testing PGO
 

--- a/src/sanitizers.md
+++ b/src/sanitizers.md
@@ -51,7 +51,7 @@ libraries. Highlight of the most important aspects of the implementation:
    relative to default system root, so that this process is not affected
    by sysroot overrides used for example by cargo `-Z build-std` functionality.
 
-[compiler-rt]: https://github.com/llvm/llvm-project/tree/master/compiler-rt
+[compiler-rt]: https://github.com/llvm/llvm-project/tree/main/compiler-rt
 [sanitizer-build]: https://github.com/rust-lang/rust/blob/a29424a2265411dda7d7446516ac5fd7499e2b55/src/bootstrap/native.rs#L566-L624
 [sanitizer-copy]: https://github.com/rust-lang/rust/blob/a29424a2265411dda7d7446516ac5fd7499e2b55/src/bootstrap/compile.rs#L270-L304
 [sanitizer-attribute]: https://github.com/rust-lang/rust/blob/a29424a2265411dda7d7446516ac5fd7499e2b55/src/librustc_codegen_llvm/attributes.rs#L49-L72


### PR DESCRIPTION
Their default branch is now main. Other failures should be addressed by #1043.