### PR TITLE
Update cmake version in prerequisites.md

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -14,7 +14,7 @@ If building LLVM from source (the default), you'll need additional tools:
 
 * `g++` 5.1 or later, `clang++` 3.5 or later, or MSVC 2017 or later.
 * `ninja`, or GNU `make` 3.81 or later (ninja is recommended, especially on Windows)
-* `cmake` 3.4.3 or later
+* `cmake` 3.13.4 or later
 
 Otherwise, you'll need LLVM installed and `llvm-config` in your path.
 See [this section for more info][sysllvm].


### PR DESCRIPTION
LLVM requires at least cmake 3.13.4.

https://www.llvm.org/docs/CMake.html

Corresponding PR in https://github.com/rust-lang/rust/pull/82937