### PR TITLE
Add notes about nightly rustc version for the rustc-driver examples

### DIFF
--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -4,12 +4,15 @@
 
 ## Getting diagnostics
 
-To get diagnostics from the compiler, 
-configure `rustc_interface::Config` to output diagnostic to a buffer, 
-and run `TyCtxt.analysis`:
+To get diagnostics from the compiler,
+configure `rustc_interface::Config` to output diagnostic to a buffer,
+and run `TyCtxt.analysis`. The following should be compiled
+with <!-- date: 2021-03 --> `nightly-2021-03-28` (See [here][example]
+for the complete example):
+
+[example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs
 
 ```rust
-// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs for complete program.
 let buffer = sync::Arc::new(sync::Mutex::new(Vec::new()));
 let config = rustc_interface::Config {
     opts: config::Options {

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -4,10 +4,13 @@
 
 ## Getting the type of an expression
 
-To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`:
+To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`.
+The following should be compiled with <!-- date: 2021-03 --> `nightly-2021-03-28`
+(see [here][example] for the complete example):
+
+[example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs
 
 ```rust
-// See https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs for complete program.
 let config = rustc_interface::Config {
     input: config::Input::Str {
         name: source_map::FileName::Custom("main.rs".to_string()),
@@ -21,9 +24,9 @@ rustc_interface::run_compiler(config, |compiler| {
         // Analyze the crate and inspect the types under the cursor.
         queries.global_ctxt().unwrap().take().enter(|tcx| {
             // Every compilation contains a single crate.
-            let krate = tcx.hir().krate();
+            let hir_krate = tcx.hir().krate();
             // Iterate over the top-level items in the crate, looking for the main function.
-            for (_, item) in &krate.items {
+            for (_, item) in &hir_krate.items {
                 // Use pattern-matching to find a specific node inside the main function.
                 if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
                     let expr = &tcx.hir().body(body_id).value;
@@ -31,7 +34,7 @@ rustc_interface::run_compiler(config, |compiler| {
                         if let rustc_hir::StmtKind::Local(local) = block.stmts[0].kind {
                             if let Some(expr) = local.init {
                                 let hir_id = expr.hir_id; // hir_id identifies the string "Hello, world!"
-                                let def_id = tcx.hir().local_def_id(item.hir_id); // def_id identifies the main function
+                                let def_id = tcx.hir().local_def_id(item.hir_id()); // def_id identifies the main function
                                 let ty = tcx.typeck(def_id).node_type(hir_id);
                                 println!("{:?}: {:?}", expr, ty); // prints expr(HirId { owner: DefIndex(3), local_id: 4 }: "Hello, world!"): &'static str
                             }


### PR DESCRIPTION
Follow-up of #1095, now the docs mention the specific nightly version for the readers not to encounter a breaking change.
Also, extracted the example links from the snippets so that we can click them easily. 