### PR TITLE
Add sample nix shell

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -20,16 +20,10 @@ cd rust
 
 ## Create a `config.toml`
 
-To start, copy [`config.toml.example`] to `config.toml`:
+To start, run `x.py setup`. This will create a `config.toml` with reasonable defaults.
 
-[`config.toml.example`]: https://github.com/rust-lang/rust/blob/master/config.toml.example
-
-```bash
-cp config.toml.example config.toml
-```
-
-Then you will want to open up the file and change the following
-settings (and possibly others, such as `llvm.ccache`):
+You may also want to change some of the following settings (and possibly others, such as
+`llvm.ccache`):
 
 ```toml
 [llvm]
@@ -54,10 +48,9 @@ debug-logging = true
 incremental = true
 ```
 
-If you have already built `rustc`, then you may have to execute `rm -rf build` for subsequent
-configuration changes to take effect. Note that `./x.py clean` will not cause a
-rebuild of LLVM, so if your configuration change affects LLVM, you will need to
-manually `rm -rf build/` before rebuilding.
+If you have already built `rustc` and you change settings related to LLVM, then you may have to
+execute `rm -rf build` for subsequent configuration changes to take effect. Note that `./x.py
+clean` will not cause a rebuild of LLVM.
 
 ## What is `x.py`?
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -201,3 +201,74 @@ git worktree add -b my-feature ../rust2 master
 
 You can then use that rust2 folder as a separate workspace for modifying
 and building `rustc`!
+
+## Using nix-shell
+
+If you're using nix, you can use the following nix-shell to work on Rust:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+
+# This file contains a development shell for working on rustc.
+let
+  # Build configuration for rust-lang/rust. Based on `config.toml.example` from
+  # `1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5`.
+  config = pkgs.writeText "rustc-config" ''
+    profile = "compiler" # you may want to choose a different profile, like `library` or `tools`
+    changelog-seen = 2
+
+    [build]
+    # The path to (or name of) the GDB executable to use. This is only used for
+    # executing the debuginfo test suite.
+    gdb = "${pkgs.gdb}/bin/gdb"
+    python = "${pkgs.python3Full}/bin/python"
+
+    [rust]
+    debug = true
+    incremental = true
+    deny-warnings = false
+
+    # Indicates whether some LLVM tools, like llvm-objdump, will be made available in the
+    # sysroot.
+    llvm-tools = true
+
+    # Print backtrace on internal compiler errors during bootstrap
+    backtrace-on-ice = true
+  '';
+
+  ripgrepConfig =
+    let
+      # Files that are ignored by ripgrep when searching.
+      ignoreFile = pkgs.writeText "rustc-rgignore" ''
+        configure
+        config.toml.example
+        x.py
+        LICENSE-MIT
+        LICENSE-APACHE
+        COPYRIGHT
+        **/*.txt
+        **/*.toml
+        **/*.yml
+        **/*.nix
+        *.md
+        src/ci
+        src/etc/
+        src/llvm-emscripten/
+        src/llvm-project/
+        src/rtstartup/
+        src/rustllvm/
+        src/stdsimd/
+        src/tools/rls/rls-analysis/test_data/
+      '';
+    in
+    pkgs.writeText "rustc-ripgreprc" "--ignore-file=${ignoreFile}";
+in
+pkgs.mkShell {
+  name = "rustc";
+  nativeBuildInputs = with pkgs; [
+    gcc9 binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
+  ];
+  RIPGREP_CONFIG_PATH = ripgrepConfig;
+  RUST_BOOTSTRAP_CONFIG = config;
+}
+```


### PR DESCRIPTION
This also suggests using `x.py setup` instead of copying config.toml.

Setting `profile = "tools"` is bad because not everyone wants that, but I don't know another good way to give a sample config.toml :/