### PR TITLE
Add gccMultiStdenv to suggested nix shell

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -268,7 +268,7 @@ in
 pkgs.mkShell {
   name = "rustc";
   nativeBuildInputs = with pkgs; [
-    gcc9 binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
+    gcc9 gccMultiStdenv binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
   ];
   RIPGREP_CONFIG_PATH = ripgrepConfig;
   RUST_BOOTSTRAP_CONFIG = config;


### PR DESCRIPTION
This allows running `x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu`, which is one of the tests run in PRs.