### PR TITLE
Remove `--stage 1` argument from cheat sheet

### DIFF
--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -245,7 +245,7 @@ server. To test these features locally, you can run a local HTTP server, like
 this:
 
 ```bash
-$ ./x.py doc library/std --stage 1
+$ ./x.py doc library/std
 # The documentation has been generated into `build/[YOUR ARCH]/doc`.
 $ python3 -m http.server -d build/[YOUR ARCH]/doc
 ```

--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -42,7 +42,7 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
   * If you've used `rustup toolchain link local /path/to/build/$TARGET/stage1`
     previously, then after the previous build command, `cargo +local doc` will
     Just Work.
-* Use `./x.py doc --stage 1 library/std` to use this rustdoc to generate the
+* Use `./x.py doc library/std` to use this rustdoc to generate the
   standard library docs.
   * The completed docs will be available in `build/$TARGET/doc/std`, though the
     bundle is meant to be used as though you would copy out the `doc` folder to


### PR DESCRIPTION
Requested by @jyn514 on [zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/compiling.20rustdoc.20lib.2Fstd/near/238041043)