### PR TITLE
not all tools require waiting for a nightly release before they can be fixed

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -272,12 +272,16 @@ tests.
 That would mean that, in the default state, you couldn't update the compiler without first
 fixing miri, rls and the other tools that the compiler builds.
 
-Luckily, a feature was [added to Rust's build](https://github.com/rust-lang/rust/issues/45861)
-to make all of this easy to handle. The idea is that we allow these tools to be "broken",
-so that the rust-lang/rust build passes without trying to build them, then land the change
-in the compiler, wait for a nightly, and go update the tools that you broke. Once you're done
-and the tools are working again, you go back in the compiler and update the tools
-so they can be distributed again.
+Luckily, a feature was
+[added to Rust's build](https://github.com/rust-lang/rust/issues/45861) to make
+all of this easy to handle. The idea is that we allow these tools to be
+"broken", so that the rust-lang/rust build passes without trying to build them,
+then land the change in the compiler, and go update the tools that you
+broke. Some tools will require waiting for a nightly release before this can
+happen, while others use the builds uploaded after each bors merge and thus can
+be updated immediately (check the tool's documentation for details). Once you're
+done and the tools are working again, you go back in the compiler and update the
+tools so they can be distributed again.
 
 This should avoid a bunch of synchronization dances and is also much easier on contributors as
 there's no need to block on rls/miri/other tools changes going upstream.

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -258,19 +258,16 @@ before the PR is merged.
 
 #### Breaking Tools Built With The Compiler
 
-Rust's build system builds a number of tools that make use of the
-internals of the compiler. This includes
-[RLS](https://github.com/rust-lang/rls) and
-[miri](https://github.com/rust-lang/miri). If these tools
-break because of your changes, you may run into a sort of "chicken and egg"
-problem. These tools rely on the latest compiler to be built so you can't update
-them to reflect your changes to the compiler until those changes are merged into
-the compiler. At the same time, you can't get your changes merged into the compiler
-because the rust-lang/rust build won't pass until those tools build and pass their
-tests.
-
-That would mean that, in the default state, you couldn't update the compiler without first
-fixing miri, rls and the other tools that the compiler builds.
+Rust's build system builds a number of tools that make use of the internals of
+the compiler and that are hosted in a separate repository, and included in Rust
+via git submodules. This includes [RLS](https://github.com/rust-lang/rls) and
+[Miri](https://github.com/rust-lang/Miri). If these tools break because of your
+changes, you may run into a sort of "chicken and egg" problem. These tools rely
+on the latest compiler to be built so you can't update them (in their own
+repositories) to reflect your changes to the compiler until those changes are
+merged into the compiler. At the same time, you can't get your changes merged
+into the compiler because the rust-lang/rust build won't pass until those tools
+build and pass their tests.
 
 Luckily, a feature was
 [added to Rust's build](https://github.com/rust-lang/rust/issues/45861) to make


### PR DESCRIPTION
For example, Miri installs a recent toolchain directly from the master branch using `rustup-toolchain-install-master`.

This fixes the docs so they are no longer incorrect for Miri. I do not know what other tools do.