### PR TITLE
Fix some links

### DIFF
--- a/src/appendix/bibliography.md
+++ b/src/appendix/bibliography.md
@@ -11,7 +11,7 @@ Rust, as well as publications about Rust.
 * [Making ad-hoc polymorphism less ad hoc](https://dl.acm.org/doi/10.1145/75277.75283)
 * [Macros that work together](https://www.cs.utah.edu/plt/publications/jfp12-draft-fcdf.pdf)
 * [Traits: composable units of behavior](http://scg.unibe.ch/archive/papers/Scha03aTraits.pdf)
-* [Alias burying](http://www.cs.uwm.edu/faculty/boyland/papers/unique-preprint.ps) - We tried something similar and abandoned it.
+* [Alias burying](https://dl.acm.org/doi/10.1002/spe.370) - We tried something similar and abandoned it.
 * [External uniqueness is unique enough](http://www.cs.uu.nl/research/techreps/UU-CS-2002-048.html)
 * [Uniqueness and Reference Immutability for Safe Parallelism](https://research.microsoft.com/pubs/170528/msr-tr-2012-79.pdf)
 * [Region Based Memory Management](https://www.cs.ucla.edu/~palsberg/tba/papers/tofte-talpin-iandc97.pdf)

--- a/src/compiler-team.md
+++ b/src/compiler-team.md
@@ -11,7 +11,7 @@ contributions to rustc and its design.
 
 Currently the compiler team chats in Zulip:
 
-- Team chat occurs in the `t-compiler` stream on [the Zulip instance][zulip]
+- Team chat occurs in the [`t-compiler`][zulip-t-compiler] stream on the Zulip instance
 - There are also a number of other associated Zulip streams,
   such as [`t-compiler/help`][zulip-help], where people can ask for help
   with rustc development, or [`t-compiler/meetings`][zulip-meetings],
@@ -60,8 +60,8 @@ The meeting currently takes place on Thursdays at 10am Boston time
 (UTC-4 typically, but daylight savings time sometimes makes things
 complicated).
 
-
 [procedure]: ./bug-fix-procedure.md
+[zulip-t-compiler]: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 [zulip-help]: https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp
 [zulip-meetings]: https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings
 

--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -53,7 +53,7 @@ See the [HIR chapter][hir-map] for more detailed information.
 [`LocalDefId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.LocalDefId.html
 [`HirId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir_id/struct.HirId.html
 [`BodyId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/struct.BodyId.html
-[`CrateNum`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/enum.CrateNum.html
+[`CrateNum`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.CrateNum.html
 [`DefIndex`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.DefIndex.html
 [`Body`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/struct.Body.html
 [Node]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/enum.Node.html

--- a/src/query.md
+++ b/src/query.md
@@ -155,10 +155,10 @@ providers**. Almost all **extern providers** wind up going through the
 from the crate metadata. But in some cases there are crates that
 provide queries for *both* local and external crates, in which case
 they define both a `provide` and a `provide_extern` function, through
-[`provide_both`][ext_provide_both], that `rustc_driver` can invoke.
+[`wasm_import_module_map`][wasm_import_module_map], that `rustc_driver` can invoke.
 
 [rustc_metadata]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/index.html
-[ext_provide_both]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_llvm/attributes/fn.provide_both.html
+[wasm_import_module_map]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_ssa/back/symbol_export/fn.wasm_import_module_map.html
 
 ### Adding a new kind of query
 

--- a/src/thir.md
+++ b/src/thir.md
@@ -43,5 +43,5 @@ You can get a debug representation of the THIR by passing the `-Zunpretty=thir-t
 to `rustc`.
 
 [thir-docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/index.html
-[`thir::Expr`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/struct.Expr.html
-[`build_thir`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/fn.build_thir.html
+[`thir::Expr`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/thir/struct.Expr.html
+[`build_thir`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/build/scope/struct.DropTree.html#method.build_mir

--- a/src/thir.md
+++ b/src/thir.md
@@ -34,7 +34,7 @@ But it has some other interesting features that distinguish it from the HIR:
 [HIR]: ./hir.md
 
 The THIR lives in [`rustc_mir_build::thir`][thir-docs]. To construct a [`thir::Expr`],
-you can use the [`build_thir`] function, passing in the memory arena where the THIR
+you can use the [`thir_body`] function, passing in the memory arena where the THIR
 will be allocated. Dropping this arena will result in the THIR being destroyed,
 which is useful to keep peak memory in check. Having a THIR representation of
 all bodies of a crate in memory at the same time would be very heavy.
@@ -44,4 +44,4 @@ to `rustc`.
 
 [thir-docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/index.html
 [`thir::Expr`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/thir/struct.Expr.html
-[`build_thir`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/build/scope/struct.DropTree.html#method.build_mir
+[`thir_body`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/context/struct.TyCtxt.html#method.thir_body


### PR DESCRIPTION
Reference PRs/commits:
- https://github.com/rust-lang/rust/pull/85273
- https://github.com/rust-lang/rust/pull/85829/commits/1ef98856c741ceeeec8509c0d22698a531649f3f
- https://github.com/rust-lang/rust/commit/c47eeac61290cd3ef7994e0d68e754eb36d15001

And <http://www.cs.uwm.edu/faculty/boyland/papers/unique-preprint.ps> returns 403 now, therefore replace it with acm's one.