### PR TITLE
Change the feature used as an example of stabilizing lib features

### DIFF
--- a/src/stability.md
+++ b/src/stability.md
@@ -85,7 +85,10 @@ To stabilize a feature, follow these steps:
    - Add the appropriate labels: `@rustbot modify labels: +T-libs`.
    - Link to the tracking issue and say "Closes #XXXXX".
 
-You can see an example of stabilizing a feature at [#81656](https://github.com/rust-lang/rust/issues/81656).
+You can see an example of stabilizing a feature with
+[tracking issue #81656 with FCP](https://github.com/rust-lang/rust/issues/81656)
+and the associated
+[implementation PR #84642](https://github.com/rust-lang/rust/pull/84642).
 
 ## allow_internal_unstable
 

--- a/src/stability.md
+++ b/src/stability.md
@@ -85,7 +85,7 @@ To stabilize a feature, follow these steps:
    - Add the appropriate labels: `@rustbot modify labels: +T-libs`.
    - Link to the tracking issue and say "Closes #XXXXX".
 
-You can see an example of stabilizing a feature at [#75132](https://github.com/rust-lang/rust/pull/75132).
+You can see an example of stabilizing a feature at [#81656](https://github.com/rust-lang/rust/issues/81656).
 
 ## allow_internal_unstable
 


### PR DESCRIPTION
The previous one was not following the process we're documenting: it was a PR, which an FCP was started on after the fact. This doesn't match what the stated process is: we should instead link to an issue where t-libs started an fcp, then a pr was written later.