### PR TITLE
Add rustc-source to suggested rust-analyzer config

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -36,6 +36,7 @@ you can write:
     ],
     "editor.formatOnSave": true,
     "rust-analyzer.cargo.runBuildScripts": false,
+    "rust-analyzer.rustcSource": "./Cargo.toml",
     "rust-analyzer.procMacro.enable": false
 }
 ```


### PR DESCRIPTION
This allows loading the sources for crates loaded from the sysroot. See https://github.com/rust-analyzer/rust-analyzer/issues/6842.