### PR TITLE
Fix warning "Renderer command uses a path relative to the renderer output directory ..."

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -19,7 +19,7 @@ enable = true
 level = 0
 
 [output.linkcheck]
-command = "../../ci/linkcheck.sh"
+command = "ci/linkcheck.sh"
 follow-web-links = true
 exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il", "www\\.amazon\\.com", "www\\.rustaceans\\.org", "play\\.rust-lang\\.org" ]
 cache-timeout = 86400


### PR DESCRIPTION
Output of `mdbook build` currently includes
```
2021-08-27 22:01:01 [WARN] (mdbook::renderer): Renderer command `../../ci/linkcheck.sh` uses
a path relative to the renderer output directory `/PATH_TO/rustc-dev-guide/book/linkcheck`.
This was previously accepted, but has been deprecated. Relative executable paths should be
relative to the book root.
```

This PR aims to fix that.