### PR TITLE
Fix a code block containing ```rust

### DIFF
--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -72,7 +72,7 @@ Here is the list of passes as of <!-- date: 2021-02 --> February 2021:
   flag.
 
 - `check-code-block-syntax` validates syntax inside Rust code blocks
-  (`` ```rust ``)
+  (<code>```rust</code>)
 
 - `check-invalid-html-tags` detects invalid HTML (like an unclosed `<span>`)
   in doc comments.


### PR DESCRIPTION
This wasn't displayed correctly.
Changing ````` `` ```rust `` ````` to ````` `` ```rust`` ````` or ````` ```` ```rust```` ````` made it a code block again, but the leading space was then rendered as-well.
(This may be an issue in `mdbook`, but I'm not sure.)

This commit changes it to use HTML-syntax in order to get the desired result.