### PR TITLE
Fix trailing date comments in a line inside of a paragraph

### DIFF
--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -78,8 +78,8 @@ Here is the list of passes as of <!-- date: 2021-02 --> February 2021:
   in doc comments.
 
 - `check-non-autolinks` detects links that could or should be written using
-  angle brackets (the code behind the nightly-only <!-- date: 2021-02 -->
-  `non_autolinks` lint).
+  angle brackets (the code behind the nightly-only <!-- date: 2021-02 --> `non_autolinks`
+  lint).
 
 - `collapse-docs` concatenates all document attributes into one document
   attribute. This is necessary because each line of a doc comment is given as a

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -339,8 +339,8 @@ The error levels that you can have are:
 
 ## Revisions
 
-Certain classes of tests support "revisions" (as of <!-- date: 2021-02 -->
-February 2021, this includes compile-fail, run-fail, and incremental, though
+Certain classes of tests support "revisions" (as of <!-- date: 2021-02 --> February 2021,
+this includes compile-fail, run-fail, and incremental, though
 incremental tests are somewhat different). Revisions allow a single test file to
 be used for multiple tests. This is done by adding a special header at the top
 of the file:


### PR DESCRIPTION
Trailing date comments in a line inside of paragraph caused beginning of a new paragraph.

This PR fixes the 2 occurrences of that.
(I'm not sure if there's an underlying issue with mdbook or if this is working as intended.)