### PR TITLE
Fix a typo

### DIFF
--- a/src/overview.md
+++ b/src/overview.md
@@ -44,7 +44,7 @@ we'll talk about that later.
 - The parser [translates the token stream from the lexer into an Abstract Syntax
   Tree (AST)][parser]. It uses a recursive descent (top-down) approach to syntax
   analysis. The crate entry points for the parser are the `Parser::parse_crate_mod()` and
-  `Parser::parse_mod()` methods found in `rustc_parse::parser::item`. The external
+  `Parser::parse_mod()` methods found in `rustc_parse::parser::Parser`. The external
   module parsing entry point is `rustc_expand::module::parse_external_mod`. And
   the macro parser entry point is [`Parser::parse_nonterminal()`][parse_nonterminal].
 - Parsing is performed with a set of `Parser` utility methods including `fn bump`,


### PR DESCRIPTION
`parse_crate_mod` and `parse_mod` methods is in the `rustc_parse::parser::Parser`.