### PR TITLE
Suggests `--edition=2018` argument when using stage0/bin/rustfmt directly

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -22,7 +22,7 @@ You can also install the hook as a step of running `x.py setup`!
 a file. By default, `rust-analyzer` runs the `cargo check` and `rustfmt`
 commands, but you can override these commands to use more adapted versions
 of these tools when hacking on `rustc`. For example, for Visual Studio Code,
-you can write:
+you can write: <!-- date: 2021-09 --><!-- the date comment is for the edition below -->
 
 ```JSON
 {
@@ -32,7 +32,8 @@ you can write:
         "--json-output"
     ],
     "rust-analyzer.rustfmt.overrideCommand": [
-      "./build/TARGET_TRIPLE/stage0/bin/rustfmt"
+      "./build/TARGET_TRIPLE/stage0/bin/rustfmt",
+      "--edition=2018"
     ],
     "editor.formatOnSave": true,
     "rust-analyzer.cargo.runBuildScripts": false,

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -293,6 +293,8 @@ format-on-save turned on. It's a good habit to run `./x.py fmt` before every
 commit, as this reduces conflicts later. The pinned version is built under
 `build/<target>/stage0/bin/rustfmt`, so if you want, you can use it for a
 single file or for format-on-save in your editor, which can be faster than `./x.py fmt`.
+You'll have to pass the <!-- date: 2021-09 --> `--edition=2018` argument
+yourself when calling `rustfmt` directly.
 
 One last thing: you can use `RUSTC_LOG=XXX` to get debug logging. [Read more
 here][logging]. Notice the `C` in `RUSTC_LOG`. Other than that, it uses normal


### PR DESCRIPTION
Compare [this discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Which.20rustfmt.20does.20x.2Epy.20fmt.20use.3F/near/253672905) ([archive](https://zulip-archive.rust-lang.org/stream/122651-general/topic/Which.20rustfmt.20does.20x.2Epy.20fmt.20use.3F.html#253672905)).