### PR TITLE
Update links to `rustc_mir` in Two Phase Borrows

### DIFF
--- a/src/borrow_check/two_phase_borrows.md
+++ b/src/borrow_check/two_phase_borrows.md
@@ -77,7 +77,7 @@ borrow.
 [converted]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/thir/cx/expr/trait.ToBorrowKind.html#method.to_borrow_kind
 [`BorrowKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/enum.BorrowKind.html
 [`GatherBorrows`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/visit/trait.Visitor.html#method.visit_local
-[`BorrowData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/borrow_check/borrow_set/struct.BorrowData.html
+[`BorrowData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/borrow_set/struct.BorrowData.html
 
 ## Checking two-phase borrows
 
@@ -95,6 +95,6 @@ following exceptions:
    by using the [`Dominators`] for the MIR graph.
 4. After the activation point, the two-phase borrow acts as a mutable borrow.
 
-[check]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/borrow_check/struct.MirBorrowckCtxt.html#method.check_activations
+[check]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/struct.MirBorrowckCtxt.html#method.check_activations
 [`Dominators`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_data_structures/graph/dominators/struct.Dominators.html
-[`is_active`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/borrow_check/path_utils/fn.is_active.html
+[`is_active`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/path_utils/fn.is_active.html


### PR DESCRIPTION
 https://github.com/rust-lang/rust/pull/80522 split the `rustc_mir` crates into 5 crates, effectively invalidating all the direct links to `rustc_mir` in the docs.

I found this while looking at the Two Phase Borrows doc, which is why I am giving out this PR to fix this.