### PR TITLE
Remove docs on Assemble step

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -149,20 +149,6 @@ Build artifacts include, but are not limited to:
 
 [rlib]: ../serialization.md
 
-#### Assembling the compiler
-
-There is a separate step between building the compiler and making it possible
-to run. This step is called _assembling_ or _uplifting_ the compiler. It copies
-all the necessary build artifacts from `build/stageN-sysroot` to
-`build/stage(N+1)`, which allows you to use `build/stage(N+1)` as a [toolchain]
-with `rustup toolchain link`.
-
-There is [no way to trigger this step on its own][#73519], but `x.py` will
-perform it automatically any time you build with stage N+1.
-
-[toolchain]: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html#creating-a-rustup-toolchain
-[#73519]: https://github.com/rust-lang/rust/issues/73519
-
 #### Examples
 
 - `x.py build --stage 0` means to build with the beta `rustc`.
@@ -183,11 +169,10 @@ perform it automatically any time you build with stage N+1.
 - `x.py test --stage 0 compiler/rustc` builds the compiler but runs no tests:
   it's running `cargo test -p rustc`, but cargo doesn't understand Rust's
   tests. You shouldn't need to use this, use `test` instead (without arguments).
-- `x.py build --stage 0 compiler/rustc` builds the compiler, but does
-  not [assemble] it. Use `x.py build library/std` instead, which puts the
-  compiler in `stage1/rustc`.
-
-[assemble]: #assembling-the-compiler
+- `x.py build --stage 0 compiler/rustc` builds the compiler, but does not build
+  libstd or even libcore. Most of the time, you'll want `x.py build
+  library/std` instead, which allows compiling programs without needing to define
+  lang items.
 
 ### Building vs. Running
 


### PR DESCRIPTION
This is done automatically now, it shouldn't be necessary to know about
unless you're modifying bootstrap itself.

This shouldn't be merged until https://github.com/rust-lang/rust/pull/89759 is (which is hopefully quite soon).