### PR TITLE
Switch date-check to Rust 2021

### DIFF
--- a/ci/date-check/Cargo.toml
+++ b/ci/date-check/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "date-check"
 version = "0.1.0"
-authors = ["Camelid <camelidcamel@gmail.com>"]
+authors = ["Noah Lev <camelidcamel@gmail.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Closes #1212.
