### PR TITLE
Add note to emphasize replacing TARGET_TRIPLE

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -45,6 +45,12 @@ you can write: <!-- date: 2021-09 --><!-- the date comment is for the edition be
 in your `.vscode/settings.json` file. This will ask `rust-analyzer` to use
 `x.py check` to check the sources, and the stage 0 rustfmt to format them.
 
+> NOTE: Make sure to replace `TARGET_TRIPLE` in the `rust-analyzer.rustfmt.overrideCommand`
+> setting with the appropriate target triple for your machine. An example of such
+> a triple is `x86_64-unknown-linux-gnu`. An easy way to check the target triple
+> is looking in the `build` folder in the root of your rust clone after building the
+> compiler at least once. It will have a folder with the same name as your target triple.
+
 If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
 `.vim/coc-settings.json` and enter the same settings as above, but replacing
 `editor.formatOnSave: true,` with

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -32,7 +32,7 @@ you can write: <!-- date: 2021-09 --><!-- the date comment is for the edition be
         "--json-output"
     ],
     "rust-analyzer.rustfmt.overrideCommand": [
-        "./build/TARGET_TRIPLE/stage0/bin/rustfmt",
+        "./build/$TARGET_TRIPLE/stage0/bin/rustfmt",
         "--edition=2021"
     ],
     "editor.formatOnSave": true,

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -47,9 +47,8 @@ in your `.vscode/settings.json` file. This will ask `rust-analyzer` to use
 
 > NOTE: Make sure to replace `TARGET_TRIPLE` in the `rust-analyzer.rustfmt.overrideCommand`
 > setting with the appropriate target triple for your machine. An example of such
-> a triple is `x86_64-unknown-linux-gnu`. An easy way to check the target triple
-> is looking in the `build` folder in the root of your rust clone after building the
-> compiler at least once. It will have a folder with the same name as your target triple.
+> a triple is `x86_64-unknown-linux-gnu`. An easy way to check your target triple
+> is to run `rustc -vV` and checking the `host` value of its output.
 
 If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
 `.vim/coc-settings.json` and enter the same settings as above, but replacing


### PR DESCRIPTION
In the suggested workflows page there is an example settings.json file that many people use.  It uses a placeholder `TARGET_TRIPLE` in the file name, but many people, myself included on one occasion, forget to replace it or don't notice that it needs replacing.  This adds an emphasized note that should help remind people that replacing the triple is necessary.

Closes #1219