### PR TITLE
Fix compare-mode documentation

### DIFF
--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -186,8 +186,17 @@ To run the UI test suite in NLL mode, one would use the following:
 ./x.py test src/test/ui --compare-mode=nll
 ```
 
-Other examples of compare-modes are "noopt", "migrate", and
-[revisions](./adding.html#revisions).
+The possible compare modes are:
+
+* nll - currently nll is implemented in migrate mode, this option runs with true nll.
+* polonius
+* chalk
+* split-dwarf
+* split-dwarf-single
+
+Note that compare modes are seperate to [revisions](./adding.html#revisions).
+All revisions are tested when running `./x.py test src/test/ui`,
+however compare-modes must be manually run individually via the `--compare-mode` flag.
 
 ## Running tests manually
 


### PR DESCRIPTION
I got the list of possible compare-modes from here: https://github.com/rust-lang/rust/blob/65b3c853178b04c5cbe41f26e6a1b1b90d7b8cc6/src/tools/compiletest/src/common.rs#L120
And I determined that compare-modes are separate to revisions from observing the behavior of tests like: https://github.com/rust-lang/rust/blob/56ebd57960efd1d96c142b456add67b5257c21fb/src/test/ui/regions/regions-outlives-projection-container-wc.rs