### PR TITLE
Fix an invalid link on Diagnostic Items

### DIFF
--- a/src/diagnostics/diagnostic-items.md
+++ b/src/diagnostics/diagnostic-items.md
@@ -23,7 +23,7 @@ struct Penguin;
 
 Diagnostic items are usually only added to traits, types and standalone functions. If the goal
 is to check for an associated type or method, please use the diagnostic item of the item and
-reference [*Using Diagnostic Items*](#using-diagnostic-items).
+reference [*How To Use Diagnostic Items*](#how-to-use-diagnostic-items).
 
 ## How To Add Diagnostic Items
 


### PR DESCRIPTION
I found the previous link name has already changed, so I made it up-to-date.