### PR TITLE
Update examples for latest compiler version

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -73,7 +73,7 @@ fn main() {
             println!("{:#?}", parse);
             // Analyze the program and inspect the types of definitions.
             queries.global_ctxt().unwrap().take().enter(|tcx| {
-                for (_, item) in &tcx.hir().krate().items {
+                for item in tcx.hir().items() {
                     match item.kind {
                         rustc_hir::ItemKind::Static(_, _, _) | rustc_hir::ItemKind::Fn(_, _, _) => {
                             let name = item.ident;

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -81,7 +81,7 @@ fn main() {
         compiler.enter(|queries| {
             queries.global_ctxt().unwrap().take().enter(|tcx| {
                 // Run the analysis phase on the local crate to trigger the type error.
-                tcx.analysis(rustc_hir::def_id::LOCAL_CRATE);
+                let _ = tcx.analysis(());
             });
         });
     });

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -64,9 +64,9 @@ fn main() {
             // Analyze the crate and inspect the types under the cursor.
             queries.global_ctxt().unwrap().take().enter(|tcx| {
                 // Every compilation contains a single crate.
-                let hir_krate = tcx.hir().krate();
+                let hir_krate = tcx.hir();
                 // Iterate over the top-level items in the crate, looking for the main function.
-                for (_, item) in &hir_krate.items {
+                for item in hir_krate.items() {
                     // Use pattern-matching to find a specific node inside the main function.
                     if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
                         let expr = &tcx.hir().body(body_id).value;


### PR DESCRIPTION
I used 1.58.0 nigthly to compile but compilation should be supported since 1.56.0 nightly