### PR TITLE
Improve 'Running tests manually' section

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -212,6 +212,11 @@ host: x86_64-unknown-linux-gnu
 release: 1.48.0-dev
 LLVM version: 11.0
 ```
+
+The rustup toolchain points to the specified toolchain compiled in your `build` directory,
+so the rustup toolchain will be updated whenever `x.py build` or `x.py test` are run for
+that toolchain/stage.
+
 ## Other `x.py` commands
 
 Here are a few other useful `x.py` commands. We'll cover some of them in detail

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -200,8 +200,10 @@ however compare-modes must be manually run individually via the `--compare-mode`
 
 ## Running tests manually
 
-Sometimes it's easier and faster to just run the test by hand. Most tests are
-just `rs` files, so you can do something like
+Sometimes it's easier and faster to just run the test by hand.
+Most tests are just `rs` files, so after
+[creating a rustup toolchain](/building/how-to-build-and-run.html#creating-a-rustup-toolchain),
+you can do something like:
 
 ```bash
 rustc +stage1 src/test/ui/issue-1234.rs


### PR DESCRIPTION
I started rustc development by running tests without ever directly invoking the compiler.
Because of this the `Running tests manually` section didnt work for me and it wasnt clear what I had to do to fix it.
I added a link to the prereq section to avoid similar occurrences in the future.

I also added a note explaining how rebuilding rust will affect the toolchain added to rustup.