### PR TITLE
Update LLVM coverage mapping format version supported by rustc

### DIFF
--- a/src/llvm-coverage-instrumentation.md
+++ b/src/llvm-coverage-instrumentation.md
@@ -221,17 +221,15 @@ substitution combinations), `mapgen`'s `finalize()` method queries the
 and `CodeRegion`s; and calls LLVM codegen APIs to generate
 properly-configured variables in LLVM IR, according to very specific
 details of the [_LLVM Coverage Mapping Format_][coverage-mapping-format]
-(Version 4).[^llvm-and-covmap-versions]
+(Version 6).[^llvm-and-covmap-versions]
 
-[^llvm-and-covmap-versions]: The Rust compiler (as of
-January 2021) supports _LLVM Coverage Mapping Format_ Version 4 (the most
-up-to-date version of the format, at the time of this writing) for improved
-compatibility with other LLVM-based compilers (like _Clang_), and to take
-advantage of some format optimizations. Version 4 was introduced in _LLVM 11_,
-which is currently the default LLVM version for Rust. Note that the Rust
-compiler optionally supports some earlier LLVM versions, prior to _LLVM 11_. If
-`rustc` is configured to use an incompatible version of LLVM, compiling with `-Z
-instrument-coverage` will generate an error message.
+[^llvm-and-covmap-versions]: The Rust compiler (as of <!-- date: 2021-12 -->
+December 2021) supports _LLVM Coverage Mapping Format_ Version 5 or 6. Version 5
+was introduced in _LLVM 12_, which is (as of this writing) the minimum LLVM
+version supported by the current version of Rust. Version 6 was introduced in
+_LLVM 13_, which is currently the default LLVM version for Rust. The Rust
+compiler will automatically use the most up-to-date coverage mapping format
+version that is compatible with the compiler's built-in version of LLVM.
 
 ```rust
 pub fn finalize<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {


### PR DESCRIPTION
rust-lang/rust#91207 updates the coverage mapping format to Version 5 or
6, depending on the built-in version of LLVM (12 or 13, respectively).

This change updates the dev guide to match the recent changes.

(Note, this PR replaces #1235 with slightly more up-to-date description of the new behavior.)

r? @tmandry 