### PR TITLE
Fix some broken links

### DIFF
--- a/src/hir.md
+++ b/src/hir.md
@@ -96,21 +96,16 @@ with a HIR node.
 [HIR map]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/hir/map/struct.Map.html
 [number of methods]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/hir/map/struct.Map.html#methods
 
-For example, if you have a [`DefId`], and you would like to convert it
-to a [`NodeId`], you can use
-[`tcx.hir().as_local_node_id(def_id)`][as_local_node_id]. This returns
-an `Option<NodeId>` – this will be `None` if the def-id refers to
-something outside of the current crate (since then it has no HIR
-node), but otherwise returns `Some(n)` where `n` is the node-id of the
-definition.
+For example, if you have a [`LocalDefId`], and you would like to convert it
+to a [`HirId`], you can use [`tcx.hir().local_def_id_to_hir_id(def_id)`][local_def_id_to_hir_id].
+You need a `LocalDefId`, rather than a `DefId`, since only local items have HIR nodes.
 
-[`NodeId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/node_id/struct.NodeId.html
-[as_local_node_id]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/hir/map/struct.Map.html#method.as_local_node_id
+[local_def_id_to_hir_id]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/hir/map/struct.Map.html#method.local_def_id_to_hir_id
 
 Similarly, you can use [`tcx.hir().find(n)`][find] to lookup the node for a
-[`NodeId`]. This returns a `Option<Node<'tcx>>`, where [`Node`] is an enum
-defined in the map; by matching on this you can find out what sort of
-node the node-id referred to and also get a pointer to the data
+[`HirId`]. This returns a `Option<Node<'hir>>`, where [`Node`] is an enum
+defined in the map. By matching on this, you can find out what sort of
+node the `HirId` referred to and also get a pointer to the data
 itself. Often, you know what sort of node `n` is – e.g. if you know
 that `n` must be some HIR expression, you can do
 [`tcx.hir().expect_expr(n)`][expect_expr], which will extract and return the

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -85,7 +85,7 @@ The array is an array of `&dyn MirPass` trait objects. Typically, a pass is
 implemented in its own module of the [`rustc_mir_transform`][trans] crate.
 
 [rop]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/fn.run_optimization_passes.html
-[`MirPass`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/trait.MirPass.html
+[`MirPass`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/trait.MirPass.html
 [trans]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/index.html
 
 Some examples of passes are:
@@ -95,7 +95,7 @@ Some examples of passes are:
 
 You can see the ["Implementors" section of the `MirPass` rustdocs][impl] for more examples.
 
-[impl]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/trait.MirPass.html#implementors
+[impl]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/trait.MirPass.html#implementors
 [constprop]: https://en.wikipedia.org/wiki/Constant_folding#Constant_propagation
 
 ## MIR optimization levels

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -12,7 +12,7 @@ Depending on what you're trying to measure, there are several different approach
 
 - If you want a medium-to-high level overview of where `rustc` is spending its time:
   - The `-Z self-profile` flag and [measureme](https://github.com/rust-lang/measureme) tools offer a query-based approach to profiling.
-    See [their docs](https://github.com/rust-lang/measureme/blob/master/summarize/Readme.md) for more information.
+    See [their docs](https://github.com/rust-lang/measureme/blob/master/summarize/README.md) for more information.
 
 - If you want function level performance data or even just more details than the above approaches:
   - Consider using a native code profiler such as [perf](profiling/with_perf.html)


### PR DESCRIPTION
Fixes #1269.

- Fix some broken links
- Update HIR chapter to use `HirId` instead of `NodeId`
