### PR TITLE
Clarify cargo fallback behavior for rustup link

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -217,6 +217,11 @@ The rustup toolchain points to the specified toolchain compiled in your `build` 
 so the rustup toolchain will be updated whenever `x.py build` or `x.py test` are run for
 that toolchain/stage.
 
+**Note:** the toolchain we've built does not include `cargo`.  In this case, `rustup` will
+fall back to using `cargo` from the installed `nightly`, `beta`, or `stable` toolchain
+(in that order).  If you need to use unstable `cargo` flags, be sure to run
+`rustup install nightly` if you haven't already.
+
 ## Other `x.py` commands
 
 Here are a few other useful `x.py` commands. We'll cover some of them in detail

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -220,7 +220,8 @@ that toolchain/stage.
 **Note:** the toolchain we've built does not include `cargo`.  In this case, `rustup` will
 fall back to using `cargo` from the installed `nightly`, `beta`, or `stable` toolchain
 (in that order).  If you need to use unstable `cargo` flags, be sure to run
-`rustup install nightly` if you haven't already.
+`rustup install nightly` if you haven't already.  See the
+[rustup documentation on custom toolchains](https://rust-lang.github.io/rustup/concepts/toolchains.html#custom-toolchains).
 
 ## Other `x.py` commands
 


### PR DESCRIPTION
When building and testing on a new system (without an installed `nightly` toolchain), the default behavior of `rustup link` can seem a bit surprising, namely that it uses **stable** `cargo`. This change adds a note to the section on `rustup link` to help clarify what's happening and how to fix it.

I think it would also make sense to include a note about how to get `rustup link` to use a cargo compiled with `./x.py build cargo`, but I haven't yet figured out how to do that.