### PR TITLE
Streamline "Getting Started" some more.

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -125,8 +125,8 @@ Options:
     -h, --help          print this help message
 ```
 
-For hacking, often building the stage 1 compiler is enough, but for
-final testing and release, the stage 2 compiler is used.
+For hacking, often building the stage 1 compiler is enough, which saves a lot
+of time. But for final testing and release, the stage 2 compiler is used.
 
 `./x.py check` is really fast to build the rust compiler.
 It is, in particular, very useful when you're doing some kind of
@@ -168,7 +168,7 @@ there is a (hacky) workaround.  See [the section on "recommended
 workflows"](./suggested.md) below.
 
 Note that this whole command just gives you a subset of the full `rustc`
-build. The **full** `rustc` build (what you get if you say `./x.py build
+build. The **full** `rustc` build (what you get with `./x.py build
 --stage 2 compiler/rustc`) has quite a few more steps:
 
 - Build `rustc` with the stage1 compiler.
@@ -176,20 +176,16 @@ build. The **full** `rustc` build (what you get if you say `./x.py build
 - Build `std` with stage2 compiler.
 - Build `librustdoc` and a bunch of other things with the stage2 compiler.
 
-<a name=toolchain></a>
+You almost never need to do this.
 
 ## Build specific components
 
-- Build only the core library
+If you are working on the standard library, you probably don't need to build
+the compiler unless you are planning to use a recently added nightly feature.
+Instead, you can just build stage 0, which uses the current beta compiler.
 
 ```bash
-./x.py build --stage 0 library/core
-```
-
-- Build only the core and `proc_macro` libraries
-
-```bash
-./x.py build --stage 0 library/core library/proc_macro
+./x.py build --stage 0 library/std
 ```
 
 Sometimes you might just want to test if the part you’re working on can
@@ -245,7 +241,8 @@ in other sections:
 - Building things:
   - `./x.py build` – builds everything using the stage 1 compiler,
     not just up to `std`
-  - `./x.py build --stage 2` – builds the stage2 compiler
+  - `./x.py build --stage 2` – builds the stage2 compiler, along with `std` and
+    `rustdoc` (which doesn't take too long)
 - Running tests (see the [section on running tests](../tests/running.html) for
   more details):
   - `./x.py test library/std` – runs the `#[test]` tests from `std`

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -182,7 +182,7 @@ You almost never need to do this.
 
 If you are working on the standard library, you probably don't need to build
 the compiler unless you are planning to use a recently added nightly feature.
-Instead, you can just build stage 0, which uses the current beta compiler.
+Instead, you can just build using the bootstrap compiler.
 
 ```bash
 ./x.py build --stage 0 library/std

--- a/src/conventions.md
+++ b/src/conventions.md
@@ -16,9 +16,8 @@ Therefore, formatting this repository using `cargo fmt` is not recommended.
 Instead, formatting should be done using `./x.py fmt`. It's a good habit to run
 `./x.py fmt` before every commit, as this reduces conflicts later. 
 
-Formatting is checked by the "tidy" script. It runs automatically when you do
-`./x.py test` and can be run in isolation with `./x.py test tidy`. `./x.py fmt
---check` also works.
+Formatting is checked by the `tidy` script. It runs automatically when you do
+`./x.py test` and can be run in isolation with `./x.py fmt --check`.
 
 If you want to use format-on-save in your editor, the pinned version of
 `rustfmt` is built under `build/<target>/stage0/bin/rustfmt`. You'll have to

--- a/src/conventions.md
+++ b/src/conventions.md
@@ -8,17 +8,25 @@ chapter covers [formatting](#formatting), [coding for correctness](#cc),
 # Formatting and the tidy script
 
 rustc is moving towards the [Rust standard coding style][fmt].
-This is enforced by the "tidy" script and can be mostly
-automated using `./x.py fmt`.
 
-As the output of [rustfmt] is not completely stable,
-formatting this repository using `cargo fmt` is not recommended.
+However, for now we don't use stable `rustfmt`; we use a pinned version with a
+special config, so this may result in different style from normal [`rustfmt`].
+Therefore, formatting this repository using `cargo fmt` is not recommended.
 
-The tidy script runs automatically when you do `./x.py test` and can be run
-in isolation with `./x.py test tidy`.
+Instead, formatting should be done using `./x.py fmt`. It's a good habit to run
+`./x.py fmt` before every commit, as this reduces conflicts later. 
+
+Formatting is checked by the "tidy" script. It runs automatically when you do
+`./x.py test` and can be run in isolation with `./x.py test tidy`. `./x.py fmt
+--check` also works.
+
+If you want to use format-on-save in your editor, the pinned version of
+`rustfmt` is built under `build/<target>/stage0/bin/rustfmt`. You'll have to
+pass the <!-- date: 2021-09 --> `--edition=2021` argument yourself when calling
+`rustfmt` directly.
 
 [fmt]: https://github.com/rust-dev-tools/fmt-rfcs
-[rustfmt]:https://github.com/rust-lang/rustfmt
+[`rustfmt`]:https://github.com/rust-lang/rustfmt
 
 <a name="copyright"></a>
 

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -116,8 +116,8 @@ of time.
 
 [rust-analyzer]: ./building/suggested.html#configuring-rust-analyzer-for-rustc
 
-See the chapters on [building](./building/how-to-build-and-run.md) and
-[testing](./tests/intro.md) for more details.
+See the chapters on [building](./building/how-to-build-and-run.md),
+[testing](./tests/intro.md), and [rustdoc](./rustdoc.md) for more details.
 
 ### Contributing code to other Rust projects
 

--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -46,7 +46,6 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
 * Use `./x.py build` to make a usable
   rustdoc you can run on other projects.
   * Add `library/test` to be able to use `rustdoc --test`.
-  * Add `--keep-stage 1` on subsequent runs to avoid rebuilding some things.
   * Run `rustup toolchain link stage2 build/$TARGET/stage2` to add a
     custom toolchain called `stage2` to your rustup environment. After
     running that, `cargo +stage2 doc` in any directory will build with

--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -1,6 +1,9 @@
 # Rustdoc overview
 
-Rustdoc actually uses the rustc internals directly. It lives in-tree with the
+`rustdoc` uses `rustc` internals (and, of course, the standard library), so you
+will have to build the compiler and `std` once before you can build `rustdoc`.
+
+`rustdoc` lives in-tree with the
 compiler and standard library. This chapter is about how it works.
 For information about Rustdoc's features and how to use them, see
 the [Rustdoc book](https://doc.rust-lang.org/nightly/rustdoc/).
@@ -39,9 +42,11 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
 * Run `./x.py setup tools` before getting started. This will configure `x.py`
   with nice settings for developing rustdoc and other tools, including
   downloading a copy of rustc rather than building it.
+* Use `./x.py check` to quickly check for compile errors.
 * Use `./x.py build` to make a usable
   rustdoc you can run on other projects.
   * Add `library/test` to be able to use `rustdoc --test`.
+  * Add `--keep-stage 1` on subsequent runs to avoid rebuilding some things.
   * Run `rustup toolchain link stage2 build/$TARGET/stage2` to add a
     custom toolchain called `stage2` to your rustup environment. After
     running that, `cargo +stage2 doc` in any directory will build with
@@ -52,7 +57,8 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
   * If you want to copy those docs to a webserver, copy all of
     `build/$TARGET/doc`, since that's where the CSS, JS, fonts, and landing
     page are.
-* Use `./x.py test src/test/rustdoc*` to run the tests using a stage1 rustdoc.
+* Use `./x.py test src/test/rustdoc*` to run the tests using a stage1
+  rustdoc.
   * See [Rustdoc internals] for more information about tests.
 
 ## Code structure

--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -42,7 +42,7 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
 * Run `./x.py setup tools` before getting started. This will configure `x.py`
   with nice settings for developing rustdoc and other tools, including
   downloading a copy of rustc rather than building it.
-* Use `./x.py check` to quickly check for compile errors.
+* Use `./x.py check src/tools/rustdoc` to quickly check for compile errors.
 * Use `./x.py build` to make a usable
   rustdoc you can run on other projects.
   * Add `library/test` to be able to use `rustdoc --test`.

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -36,11 +36,7 @@ modifying rustc to see if things are generally working correctly would be the
 following:
 
 ```bash
-# First build
 ./x.py test src/test/ui
-
-# Subsequent builds (optional, but can save time)
-./x.py test src/test/ui --keep-stage 1
 ```
 
 This will run the `ui` test suite. Of course, the choice

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -36,7 +36,11 @@ modifying rustc to see if things are generally working correctly would be the
 following:
 
 ```bash
+# First build
 ./x.py test src/test/ui
+
+# Subsequent builds (optional, but can save time)
+./x.py test src/test/ui --keep-stage 1
 ```
 
 This will run the `ui` test suite. Of course, the choice
@@ -91,6 +95,13 @@ tests for components you did not change at all.
 **Warning:** Note that bors only runs the tests with the full stage 2
 build; therefore, while the tests **usually** work fine with stage 1,
 there are some limitations.
+
+### Run all tests using a stage 2 compiler
+
+```bash
+./x.py test --stage 2
+```
+You almost never need to do this.
 
 ## Run unit tests on the compiler/library
 


### PR DESCRIPTION
This is a follow-up to #1279.

The "Getting Started" chapter is, TBH, pretty bad when it comes to the
stuff about building and testing. It has far too much detail and lots of
repetition, which would be overwhelming to a newcomer.

This commit removes most of it, leaving behind just quick mentions of
the most common `x.py` commands: `check`, `build`, `test`, `fmt`, with
links to the appropriate chapters for details. There were a few
interesting details that weren't covered elsewhere, so I moved those
into other chapters.