### PR TITLE
Clarify that r? works in comments.

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -77,7 +77,7 @@ All pull requests are reviewed by another person. We have a bot,
 to review your request based on which files you changed.
 
 If you want to request that a specific person reviews your pull request, you
-can add an `r?` to the pull request description. For example,
+can add an `r?` to the pull request description or in a comment. For example,
 [Steve][steveklabnik] usually reviews documentation changes. So if you were to
 make a documentation change, add
 


### PR DESCRIPTION
Reading the docs [here](https://rustc-dev-guide.rust-lang.org/contributing.html#r) I thought `r?` only applied to the original PR description. @nagisa  [pointed out](https://github.com/rust-lang/rust/pull/92835#issuecomment-1018006922) out that it should work in comments, so adding that information to the guide seems relevant as it currently only talks about the initial description.