### PR TITLE
Correction, building stage3 compiler

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -241,7 +241,7 @@ in other sections:
 - Building things:
   - `./x.py build` – builds everything using the stage 1 compiler,
     not just up to `std`
-  - `./x.py build --stage 2` – builds the stage2 compiler, along with `std` and
+  - `./x.py build --stage 2` – builds everything with the stage 2 compiler including
     `rustdoc` (which doesn't take too long)
 - Running tests (see the [section on running tests](../tests/running.html) for
   more details):


### PR DESCRIPTION
The [bootstrapping chapter](https://github.com/rust-lang/rustc-dev-guide/blame/master/src/building/bootstrapping.md#L185) states:

> `build --stage N compiler/rustc` **does not** build the stage N compiler:
> instead it builds the stage N+1 compiler _using_ the stage N compiler.

That is in conflict with the "How to build and run" chapter that states:

> `./x.py build --stage 2` – builds the stage2 compiler

I believe the former is correct.