### PR TITLE
Link to The Rust Performance Book

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -299,7 +299,11 @@ benchmarks on a compiler with your changes. The numbers are reported
 [here][perf], and you can see a comparison of your changes against the latest
 master.
 
+For an introduction to the performance of Rust code in general
+which would also be useful in rustc development, see [The Rust Performance Book].
+
 [perf]: https://perf.rust-lang.org
+[The Rust Performance Book]: https://nnethercote.github.io/perf-book/
 
 ## Other Resources
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustc-dev-guide/issues/1254.