### PR TITLE
Replace "Shell" highlighting with "Bash" highlighting

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -99,7 +99,7 @@ build and pass tests. This often helps reviewing.
 Some parts of the bootstrap process uses pinned, nightly versions of tools like
 rustfmt. To make things like `cargo fmt` work correctly in your repo, run
 
-```console
+```sh
 cd <path to rustc repo>
 rustup override set nightly
 ```

--- a/src/closure.md
+++ b/src/closure.md
@@ -34,7 +34,7 @@ fn main() {
 Let's say the above is the content of a file called `immut.rs`. If we compile
 `immut.rs` using the following command. The [`-Z dump-mir=all`][dump-mir] flag will cause
 `rustc` to generate and dump the [MIR][mir] to a directory called `mir_dump`.
-```console
+```sh
 > rustc +stage1 immut.rs -Z dump-mir=all
 ```
 
@@ -145,7 +145,7 @@ Before we go any further, let's discuss how we can examine the flow of control t
 codebase. For closures specifically, set the `RUST_LOG` env variable as below and collect the
 output in a file:
 
-```console
+```sh
 > RUST_LOG=rustc_typeck::check::upvar rustc +stage1 -Z dump-mir=all \
     <.rs file to compile> 2> <file where the output will be dumped>
 ```

--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -423,7 +423,7 @@ err.emit();
 
 This might emit an error like
 
-```console
+```sh
 $ rustc mycode.rs
 error[E0999]: oh no! this is an error!
  --> mycode.rs:3:5
@@ -439,7 +439,7 @@ For more information about this error, try `rustc --explain E0999`.
 In some cases, like when the suggestion spans multiple lines or when there are
 multiple suggestions, the suggestions are displayed on their own:
 
-```console
+```sh
 error[E0999]: oh no! this is an error!
  --> mycode.rs:3:5
   |
@@ -724,7 +724,7 @@ The compiler accepts an `--error-format json` flag to output
 diagnostics as JSON objects (for the benefit of tools such as `cargo
 fix` or the RLS). It looks like this:
 
-```console
+```sh
 $ rustc json_error_demo.rs --error-format json
 {"message":"cannot add `&str` to `{integer}`","code":{"code":"E0277","explanation":"\nYou tried to use a type which doesn't implement some trait in a place which\nexpected that trait. Erroneous code example:\n\n```compile_fail,E0277\n// here we declare the Foo trait with a bar method\ntrait Foo {\n    fn bar(&self);\n}\n\n// we now declare a function which takes an object implementing the Foo trait\nfn some_func<T: Foo>(foo: T) {\n    foo.bar();\n}\n\nfn main() {\n    // we now call the method with the i32 type, which doesn't implement\n    // the Foo trait\n    some_func(5i32); // error: the trait bound `i32 : Foo` is not satisfied\n}\n```\n\nIn order to fix this error, verify that the type you're using does implement\nthe trait. Example:\n\n```\ntrait Foo {\n    fn bar(&self);\n}\n\nfn some_func<T: Foo>(foo: T) {\n    foo.bar(); // we can now use this method since i32 implements the\n               // Foo trait\n}\n\n// we implement the trait on the i32 type\nimpl Foo for i32 {\n    fn bar(&self) {}\n}\n\nfn main() {\n    some_func(5i32); // ok!\n}\n```\n\nOr in a generic context, an erroneous code example would look like:\n\n```compile_fail,E0277\nfn some_func<T>(foo: T) {\n    println!(\"{:?}\", foo); // error: the trait `core::fmt::Debug` is not\n                           //        implemented for the type `T`\n}\n\nfn main() {\n    // We now call the method with the i32 type,\n    // which *does* implement the Debug trait.\n    some_func(5i32);\n}\n```\n\nNote that the error here is in the definition of the generic function: Although\nwe only call it with a parameter that does implement `Debug`, the compiler\nstill rejects the function: It must work with all possible input types. In\norder to make this example compile, we need to restrict the generic type we're\naccepting:\n\n```\nuse std::fmt;\n\n// Restrict the input type to types that implement Debug.\nfn some_func<T: fmt::Debug>(foo: T) {\n    println!(\"{:?}\", foo);\n}\n\nfn main() {\n    // Calling the method is still fine, as i32 implements Debug.\n    some_func(5i32);\n\n    // This would fail to compile now:\n    // struct WithoutDebug;\n    // some_func(WithoutDebug);\n}\n```\n\nRust only looks at the signature of the called function, as such it must\nalready specify all requirements that will be used for every type parameter.\n"},"level":"error","spans":[{"file_name":"json_error_demo.rs","byte_start":50,"byte_end":51,"line_start":4,"line_end":4,"column_start":7,"column_end":8,"is_primary":true,"text":[{"text":"    a + b","highlight_start":7,"highlight_end":8}],"label":"no implementation for `{integer} + &str`","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"the trait `std::ops::Add<&str>` is not implemented for `{integer}`","code":null,"level":"help","spans":[],"children":[],"rendered":null}],"rendered":"error[E0277]: cannot add `&str` to `{integer}`\n --> json_error_demo.rs:4:7\n  |\n4 |     a + b\n  |       ^ no implementation for `{integer} + &str`\n  |\n  = help: the trait `std::ops::Add<&str>` is not implemented for `{integer}`\n\n"}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error\n\n"}

--- a/src/git.md
+++ b/src/git.md
@@ -108,7 +108,7 @@ personal	https://github.com/jyn514/rust (push)
 
 If you renamed your fork, you can change the URL like this:
 
-```console
+```sh
 git remote set-url personal <URL>
 ```
 
@@ -120,7 +120,7 @@ This is left over from the move to the `library/` directory.
 Unfortunately, `git rebase` does not follow renames for submodules, so you
 have to delete the directory yourself:
 
-```console
+```sh
 rm -r src/stdarch
 ```
 
@@ -130,7 +130,7 @@ You were probably in the middle of a rebase or merge conflict. See
 [Conflicts](#conflicts) for how to fix the conflict. If you don't care about the changes
 and just want to get a clean copy of the repository back, you can use `git reset`:
 
-```console
+```sh
 # WARNING: this throws out any local changes you've made! Consider resolving the conflicts instead.
 git reset --hard master
 ```

--- a/src/llvm-coverage-instrumentation.md
+++ b/src/llvm-coverage-instrumentation.md
@@ -295,7 +295,7 @@ intrinsic calls to increment the runtime counters.
 Expected results for both the `mir-opt` tests and the `coverage*` tests under
 `run-make-fulldeps` can be refreshed by running:
 
-```shell
+```sh
 $ ./x.py test mir-opt --bless
 $ ./x.py test src/test/run-make-fulldeps/coverage --bless
 ```
@@ -423,7 +423,7 @@ produce a Graphviz document with "dark mode" styling. If you use a dark mode or
 theme in your development environment, you will probably want to use this
 option so you can review the graphviz output without straining your vision.
 
-```shell
+```sh
 $ rustc -Z instrument-coverage -Z dump-mir=InstrumentCoverage \
     -Z dump-mir-graphviz some_rust_source.rs
 ```
@@ -496,7 +496,7 @@ that can be used to assign coverage `Counter`s or `Expression`s, one-for-one.
 An visual, interactive representation of the final `CoverageSpan`s can be
 generated with the following `rustc` flags:
 
-```shell
+```sh
 $ rustc -Z instrument-coverage -Z dump-mir=InstrumentCoverage \
     -Z dump-mir-spanview some_rust_source.rs
 ```


### PR DESCRIPTION
(compare https://highlightjs.readthedocs.io/en/latest/supported-languages.html for a list of languages and their identifiers/aliases)

Motivation: This code block was mishighlighted: https://rustc-dev-guide.rust-lang.org/git.html#i-see--head