### PR TITLE
Consolidate crates.io convention section

### DIFF
--- a/src/conventions.md
+++ b/src/conventions.md
@@ -101,10 +101,7 @@ if foo {
 
 # Using crates from crates.io
 
-It is allowed to use crates from crates.io, though external
-dependencies should not be added gratuitously. All such crates must
-have a suitably permissive license. There is an automatic check which
-inspects the Cargo metadata to ensure this.
+See the [crates.io dependencies][crates] section.
 
 <a name="er"></a>
 
@@ -152,3 +149,4 @@ to the compiler.
   crate-related, often the spelling is changed to `krate`.
 
 [tcx]: ./ty.md
+[crates]: ./crates-io.md

--- a/src/crates-io.md
+++ b/src/crates-io.md
@@ -21,4 +21,4 @@ to the compiler unless there is a good reason to do so.
 The `tidy` tool has [a list of crates that are allowed]. To add a
 dependency that is not already in the compiler, you will need to add it to the list.
 
-[a list of crates that are allowed]: https://github.com/rust-lang/rust/blob/19ecce332e56941ea0dd2a805270faa102acdb14/src/tools/tidy/src/deps.rs#L59
+[a list of crates that are allowed]: https://github.com/rust-lang/rust/blob/9d1b2106e23b1abd32fce1f17267604a5102f57a/src/tools/tidy/src/deps.rs#L73


### PR DESCRIPTION
Today I was deciding between tinyvec and smallvec for a hobby project, I remembered seeing one of them in the compiler's allowed crate list a while back. This list is a very useful resource (even outside of rustc) as it indicates a certain level of quality and maintenance.

I couldn't really find the link to the list easily this time, because I found the [paragraph in the coding conventions page](https://rustc-dev-guide.rust-lang.org/conventions.html#using-crates-from-cratesio) instead of the [page on crates.io dependencies](https://rustc-dev-guide.rust-lang.org/crates-io.html) with the actual link.

This PR replaces the paragraph in the conventions with a link to the page detailing the dependencies. The second commit changes the commit hash to the link from a commit on [2 August 2020](https://github.com/rust-lang/rust/commit/19ecce332e56941ea0dd2a805270faa102acdb14) to the [list at the commit](https://github.com/rust-lang/rust/blob/9d1b2106e23b1abd32fce1f17267604a5102f57a/src/tools/tidy/src/deps.rs#L73) of the `1.59.0` tag. The difference between both lists is 9 removals and 44 additions, in case anyone is curious  :)

- [Rendered conventions.md](https://github.com/rust-lang/rustc-dev-guide/blob/8856ea7b1d44cdafd7e9cadc0977f6fc7a3d5977/src/conventions.md#using-crates-from-cratesio)
- [Rendered crates-io.md](https://github.com/rust-lang/rustc-dev-guide/blob/8856ea7b1d44cdafd7e9cadc0977f6fc7a3d5977/src/crates-io.md)