### PR TITLE
fix winget install instructions installing wrong packages

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -31,8 +31,8 @@ on Windows.
 Run the following in a terminal:
 
 ```powershell
-winget install python
-winget install cmake
+winget install -e Python.Python.3
+winget install -e Kitware.CMake
 ```
 
 If any of those is installed already, winget will detect it.


### PR DESCRIPTION
update winget install instructions to ensure proper packages are installed (-e for --exact, and full package names to ensure arbitrary packages from the msstore source aren't installed)

fixes #1324