### PR TITLE
r-a: Use `python3 x.py` instead of `./x.py`

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -22,12 +22,13 @@ You can also install the hook as a step of running `./x.py setup`!
 a file. By default, `rust-analyzer` runs the `cargo check` and `rustfmt`
 commands, but you can override these commands to use more adapted versions
 of these tools when hacking on `rustc`. For example, for Visual Studio Code,
-you can write: <!-- date: 2021-09 --><!-- the date comment is for the edition below -->
+you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition below -->
 
 ```JSON
 {
     "rust-analyzer.checkOnSave.overrideCommand": [
-        "./x.py",
+        "python3",
+        "x.py",
         "check",
         "--json-output"
     ],


### PR DESCRIPTION
This circumvents an issue on newer OSes (including now macOS Monterery):
rust-lang/rust#71818

Thanks to jyn514 for suggesting this fix.