### PR TITLE
Fix configuration names for vscode/r-a

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -37,8 +37,8 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "--edition=2021"
     ],
     "editor.formatOnSave": true,
-    "rust-analyzer.cargo.runBuildScripts": false,
-    "rust-analyzer.rustcSource": "./Cargo.toml",
+    "rust-analyzer.cargo.buildScripts.enable": false,
+    "rust-analyzer.rustc.source": "./Cargo.toml",
     "rust-analyzer.procMacro.enable": false
 }
 ```


### PR DESCRIPTION
See https://github.com/rust-lang/rust-analyzer/pull/12010 and https://github.com/rust-lang/rust-analyzer/pull/12213

r-a should automatically patch the old configuration, but we might just as well suggest the new one :)