### PR TITLE
Exclude `tomlee.co` from link-checking

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -21,7 +21,18 @@ level = 0
 [output.linkcheck]
 command = "ci/linkcheck.sh"
 follow-web-links = true
-exclude = [ "crates\\.io", "gcc\\.godbolt\\.org", "youtube\\.com", "youtu\\.be", "dl\\.acm\\.org", "cs\\.bgu\\.ac\\.il", "www\\.amazon\\.com", "www\\.rustaceans\\.org", "play\\.rust-lang\\.org" ]
+exclude = [
+    "crates\\.io",
+    "gcc\\.godbolt\\.org",
+    "youtube\\.com",
+    "youtu\\.be",
+    "dl\\.acm\\.org",
+    "cs\\.bgu\\.ac\\.il",
+    "www\\.amazon\\.com",
+    "www\\.rustaceans\\.org",
+    "play\\.rust-lang\\.org",
+    "tomlee\\.co"
+]
 cache-timeout = 86400
 warning-policy = "error"
 


### PR DESCRIPTION
https://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/ returns 404 on CI even though it's not actually 404.
So, that doesn't return any useful result, let's ignore it.
Also, formatted the exclude list for readability.