### PR TITLE
Triage some date references related to traits

### DIFF
--- a/src/traits/chalk.md
+++ b/src/traits/chalk.md
@@ -1,13 +1,14 @@
 # Chalk-based trait solving
 
 [Chalk][chalk] is an experimental trait solver for Rust that is (as of <!--
-date: 2021-01 --> January 2021) under development by the [Traits Working
-Group][wg]. Its goal is to enable a lot of trait system features and bug fixes
+date: 2022-05 --> May 2022) under development by the [Types team].
+Its goal is to enable a lot of trait system features and bug fixes
 that are hard to implement (e.g. GATs or specialization). If you would like to
-help in hacking on the new solver, you will find instructions for getting
-involved in the [Traits Working Group tracking issue][wg].
+help in hacking on the new solver, drop by on the rust-lang Zulip in the [`#t-types`]
+stream and say hello!
 
-[wg]: https://github.com/rust-lang/rust/issues/48416
+[Types team]: https://github.com/rust-lang/types-team
+[`#t-types`]: https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types
 
 The new-style trait solver is based on the work done in [chalk][chalk]. Chalk
 recasts Rust's trait system explicitly in terms of logic programming. It does

--- a/src/traits/resolution.md
+++ b/src/traits/resolution.md
@@ -120,7 +120,7 @@ the obligation contains unbound inference variables.
 
 The subroutines that decide whether a particular impl/where-clause/etc applies
 to a particular obligation are collectively referred to as the process of
-_matching_. As of <!-- date: 2021-01 --> January 2021, this amounts to unifying
+_matching_. As of <!-- date: 2022-05 --> May 2022, this amounts to unifying
 the `Self` types, but in the future we may also recursively consider some of the
 nested obligations, in the case of an impl.
 


### PR DESCRIPTION
Address renaming of the types team, previously wg-traits.
r? @rust-lang/types 

cc #1344