### PR TITLE
Make build scripts and proc macros work with the suggested rust-analyzer config

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -37,9 +37,16 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "--edition=2021"
     ],
     "editor.formatOnSave": true,
-    "rust-analyzer.cargo.buildScripts.enable": false,
+    "rust-analyzer.cargo.buildScripts.enable": true,
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "cargo",
+        "check",
+        "-p",
+        "rustc_driver",
+        "--message-format=json"
+    ],
     "rust-analyzer.rustc.source": "./Cargo.toml",
-    "rust-analyzer.procMacro.enable": false
+    "rust-analyzer.procMacro.enable": true,
 }
 ```
 


### PR DESCRIPTION
For some reason, using `procMacro.ignored` does not seem to work (many functions were missing from analysis because `#[tracing::instrument]` apparently expanded to nothing), so this config makes them work properly instead.