### PR TITLE
Remove nll compare mode.

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -501,23 +501,22 @@ To run the tests in a different mode, you need to pass the `--compare-mode`
 CLI flag:
 
 ```bash
-./x.py test src/test/ui --compare-mode=nll
+./x.py test src/test/ui --compare-mode=chalk
 ```
 
 The possible compare modes are:
 
-* `nll` — Runs in the "true" NLL mode with `-Zborrowck=mir`.
-  See [UI compare modes](ui.md#compare-modes) for more.
-* `polonius` — Runs with Polonius with `-Zpolonius -Zborrowck=mir`, and reuses
-  the `nll` stderr files.
+* `polonius` — Runs with Polonius with `-Zpolonius -Zborrowck=mir`.
 * `chalk` — Runs with Chalk with `-Zchalk`.
 * `split-dwarf` — Runs with unpacked split-DWARF with `-Csplit-debuginfo=unpacked`.
 * `split-dwarf-single` — Runs with packed split-DWARF with `-Csplit-debuginfo=packed`.
 
+See [UI compare modes](ui.md#compare-modes) for more information about how UI
+tests support different output for different modes.
+
 In CI, compare modes are only used in one Linux builder, and only with the
 following settings:
 
-* `src/test/ui`: Uses `nll` mode.
 * `src/test/debuginfo`: Uses `split-dwarf` mode.
   This helps ensure that none of the debuginfo tests are affected when
   enabling split-DWARF.

--- a/src/tests/headers.md
+++ b/src/tests/headers.md
@@ -125,7 +125,7 @@ Some examples of `X` in `ignore-X` or `only-X`:
 * When [remote testing] is used: `remote`
 * When debug-assertions are enabled: `debug`
 * When particular debuggers are being tested: `cdb`, `gdb`, `lldb`
-* Specific [compare modes]: `compare-mode-nll`, `compare-mode-polonius`,
+* Specific [compare modes]: `compare-mode-polonius`,
   `compare-mode-chalk`, `compare-mode-split-dwarf`,
   `compare-mode-split-dwarf-single`
 

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -196,13 +196,13 @@ of the `build` directory from time to time.
 ## Running tests with different "compare modes"
 
 UI tests may have different output depending on certain "modes" that
-the compiler is in. For example, when in "non-lexical lifetimes" (NLL)
-mode a test `foo.rs` will first look for expected output in
-`foo.nll.stderr`, falling back to the usual `foo.stderr` if not found.
-To run the UI test suite in NLL mode, one would use the following:
+the compiler is in. For example, when using the Polonius
+mode, a test `foo.rs` will first look for expected output in
+`foo.polonius.stderr`, falling back to the usual `foo.stderr` if not found.
+The following will run the UI test suite in Polonius mode:
 
 ```bash
-./x.py test src/test/ui --compare-mode=nll
+./x.py test src/test/ui --compare-mode=polonius
 ```
 
 See [Compare modes](compiletest.md#compare-modes) for more details.

--- a/src/tests/ui.md
+++ b/src/tests/ui.md
@@ -74,7 +74,7 @@ The general form is:
   * `32bit.stderr` — compiler stderr with `stderr-per-bitwidth` header on a 32-bit target
 
 A simple example would be `foo.stderr` next to a `foo.rs` test.
-A more complex example would be `foo.my-revision.nll.stderr`.
+A more complex example would be `foo.my-revision.polonius.stderr`.
 
 There are several [headers](headers.md) which will change how compiletest will
 check for output files:
@@ -496,12 +496,11 @@ In some cases, this might result in different output from the compiler.
 To support this, different output files can be saved which contain the
 output based on the compare mode.
 
-For example, when in "non-lexical lifetimes" (NLL) mode a test `foo.rs` will
-first look for expected output in `foo.nll.stderr`, falling back to the usual
+For example, when using the Polonius mode, a test `foo.rs` will
+first look for expected output in `foo.polonius.stderr`, falling back to the usual
 `foo.stderr` if not found.
-This is useful as "true" NLL mode can sometimes result in different
-diagnostics and behavior compared to the "migrate mode" NLL (which is the
-current default).
+This is useful as different modes can sometimes result in different
+diagnostics and behavior.
 This can help track which tests have differences between the modes, and to
 visually inspect those diagnostic differences.
 
@@ -509,7 +508,7 @@ If in the rare case you encounter a test that has different behavior, you can
 run something like the following to generate the alternate stderr file:
 
 ```sh
-./x.py test src/test/ui --compare-mode=nll --bless
+./x.py test src/test/ui --compare-mode=polonius --bless
 ```
 
-Currently, only `nll` mode is checked in CI for UI tests.
+Currently none of the compare modes are checked in CI for UI tests.


### PR DESCRIPTION
NLL compare mode was removed in https://github.com/rust-lang/rust/pull/95565.