### PR TITLE
Remove mention of -Zborrowck=mir with Polonius.

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -506,7 +506,7 @@ CLI flag:
 
 The possible compare modes are:
 
-* `polonius` — Runs with Polonius with `-Zpolonius -Zborrowck=mir`.
+* `polonius` — Runs with Polonius with `-Zpolonius`.
 * `chalk` — Runs with Chalk with `-Zchalk`.
 * `split-dwarf` — Runs with unpacked split-DWARF with `-Csplit-debuginfo=unpacked`.
 * `split-dwarf-single` — Runs with packed split-DWARF with `-Csplit-debuginfo=packed`.


### PR DESCRIPTION
This option was also removed, see https://github.com/rust-lang/rustc-dev-guide/pull/1366#discussion_r892701796.