### PR TITLE
humorust: Forbid pineapple on pizza

### DIFF
--- a/src/appendix/humorust.md
+++ b/src/appendix/humorust.md
@@ -12,3 +12,4 @@ enlightening?
 - [The Nomicon Intro](https://doc.rust-lang.org/stable/nomicon/)
 - [`rustc-ty` renaming punfest](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/rustc-ty.20naming.20bikeshed.20.2F.20punfest.20%28was.3A.20design.20meeting.202.2E.2E.2E/near/189906455)
 - [try using their name "ferris" instead](https://github.com/rust-lang/rust/pull/91476)
+- [Forbid pineapple on pizza](https://github.com/rust-lang/rust/pull/70645)


### PR DESCRIPTION
The PR wasn't merged, but neither was the rustc-ty punfest, so I think it belongs here.