### PR TITLE
Suggest a separate build directory for rust-analyzer

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -58,6 +58,10 @@ in your `.vscode/settings.json` file. This will ask `rust-analyzer` to use
 > a triple is `x86_64-unknown-linux-gnu`. An easy way to check your target triple
 > is to run `rustc -vV` and checking the `host` value of its output.
 
+If you have enough free disk space and you would like to be able to run `x.py` commands while
+rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
+`overrideCommand` to avoid x.py locking.
+
 If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
 `.vim/coc-settings.json` and enter the same settings as above, but replacing
 `editor.formatOnSave: true,` with


### PR DESCRIPTION
This shouldn't be merged until after https://github.com/rust-lang/rust/pull/98745.

I kind of want to add --build-dir to the suggested command directly, since I doubt people are reading the rest of the docs, but I worry that will cause unnecessary slowness for people with few cores ... not sure the right approach.

cc @thomcc