### PR TITLE
leave formatOnSave to the user

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -36,7 +36,7 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "./build/$TARGET_TRIPLE/stage0/bin/rustfmt",
         "--edition=2021"
     ],
-    "editor.formatOnSave": true,
+    "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "cargo",
@@ -46,7 +46,6 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "--message-format=json"
     ],
     "rust-analyzer.rustc.source": "./Cargo.toml",
-    "rust-analyzer.procMacro.enable": true,
 }
 ```
 


### PR DESCRIPTION
`editor.formatOnSave` is not rust-lang/rust specific, so I think we should leave that decision to the user. Also many test files in the rustc repo are not formatted so this will make diffs unnecessarily big.

I also grouped the enabling of proc macros and build scripts together since it kind of feels like a related thing. ;)