### PR TITLE
Add the config needed to get rust-analyzer working on src/bootstrap

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -46,6 +46,10 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "--message-format=json"
     ],
     "rust-analyzer.rustc.source": "./Cargo.toml",
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "src/bootstrap/Cargo.toml"
+    ]
 }
 ```
 


### PR DESCRIPTION
Bootstrap is no longer in the workspace since #97513.
See https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/.E2.9C.94.20ra.20stopped.20working.20in.20rust-lang.2Frust.3F.