### PR TITLE
Use `x.py check` instead of `cargo check` for build scripts

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -39,11 +39,10 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "cargo",
+        "python3",
+        "x.py",
         "check",
-        "-p",
-        "rustc_driver",
-        "--message-format=json"
+        "--json-output"
     ],
     "rust-analyzer.rustc.source": "./Cargo.toml",
 }


### PR DESCRIPTION
Cargo check isn't supported and gives an error that CFG_CHANNEL is missing.
It also generates a new target dir and recompiles dependencies.
Use x.py instead, which avoids both issues.

cc @jonas-schievink