### PR TITLE
Revert "Add the config needed to get rust-analyzer working on src/bootstrap (#1381)"

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -45,10 +45,6 @@ you can write: <!-- date: 2022-04 --><!-- the date comment is for the edition be
         "--json-output"
     ],
     "rust-analyzer.rustc.source": "./Cargo.toml",
-    "rust-analyzer.linkedProjects": [
-        "Cargo.toml",
-        "src/bootstrap/Cargo.toml"
-    ]
 }
 ```
 


### PR DESCRIPTION
This reverts commit d955bab63c229c3160e3023f44496ad93a81f3ab.

cc @jyn514 @RalfJung 

As @RalfJung [noted here](https://github.com/rust-lang/rustc-dev-guide/pull/1381#issuecomment-1174007794=) this doesn't work.