### PR TITLE
use relative links

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -66,7 +66,7 @@ If you set `download-ci-llvm = true`, in some circumstances, such as when
 updating the version of LLVM used by `rustc`, you may want to temporarily
 disable this feature. See the ["Updating LLVM" section] for more.
 
-["Updating LLVM" section]: https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html?highlight=download-ci-llvm#feature-updates
+["Updating LLVM" section]: /backend/updating-llvm.md#feature-updates
 
 If you have already built `rustc` and you change settings related to LLVM, then you may have to
 execute `rm -rf build` for subsequent configuration changes to take effect. Note that `./x.py

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -583,7 +583,7 @@ are:
   page!
 * Don't be afraid to ask! The Rust community is friendly and helpful.
 
-[rustc dev guide]: https://rustc-dev-guide.rust-lang.org/about-this-guide.html
+[rustc dev guide]: about-this-guide.md
 [gdfrustc]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/
 [gsearchdocs]: https://www.google.com/search?q=site:doc.rust-lang.org+your+query+here
 [stddocs]: https://doc.rust-lang.org/std
@@ -592,5 +592,5 @@ are:
 [rustforge]: https://forge.rust-lang.org/
 [tlgba]: https://tomlee.co/2014/04/a-more-detailed-tour-of-the-rust-compiler/
 [ro]: https://www.rustaceans.org/
-[rctd]: https://rustc-dev-guide.rust-lang.org/tests/intro.html
+[rctd]: tests/intro.md
 [cheatsheet]: https://bors.rust-lang.org/

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -105,8 +105,8 @@ for stabilization in a checklist, e.g.,
 
 - [ ] Implement the RFC. (CC @rust-lang/compiler -- can anyone write
       up mentoring instructions?)
-- [ ] Adjust the documentation. ([See instructions on rustc-dev-guide.](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs))
-- [ ] Stabilize the feature. ([See instructions on rustc-dev-guide.](https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr))
+- [ ] Adjust the documentation. ([See instructions on rustc-dev-guide.](stabilization_guide.md#documentation-prs))
+- [ ] Stabilize the feature. ([See instructions on rustc-dev-guide.](stabilization_guide.md#stabilization-pr))
 ```
 
 ##  Stability in code

--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -88,7 +88,7 @@ iteration, this represents a compile error.  Here is the [algorithm][original]:
         0. Put the macro back in the queue
         1. Continue to next iteration...
 
-[defpath]: https://rustc-dev-guide.rust-lang.org/hir.html?highlight=def,path#identifiers-in-the-hir
+[defpath]: hir.md#identifiers-in-the-hir
 [`NodeId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/node_id/struct.NodeId.html
 [`InvocationCollector`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/expand/struct.InvocationCollector.html
 [`DefId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.DefId.html

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -8,8 +8,8 @@ to do, so compilation is faster. Note that since MIR is generic (not
 effective; we can optimize the generic version, so all of the monomorphizations
 are cheaper!
 
-[mir]: https://rustc-dev-guide.rust-lang.org/mir/index.html
-[monomorph]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html#mono
+[mir]: /mir/index.md
+[monomorph]: /appendix/glossary.md#mono
 
 MIR optimizations run after borrow checking. We run a series of optimization
 passes over the MIR to improve it. Some passes are required to run on all code,
@@ -22,9 +22,9 @@ run and that some validation has occurred. Then, it [steals][steal] the MIR,
 optimizes it, and returns the improved MIR.
 
 [optmir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/fn.optimized_mir.html
-[query]: https://rustc-dev-guide.rust-lang.org/query.html
-[defid]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html#def-id
-[steal]: https://rustc-dev-guide.rust-lang.org/mir/passes.html?highlight=steal#stealing
+[query]: /query.md
+[defid]: /appendix/glossary.md#def-id
+[steal]: /mir/passes.md#stealing
 
 ## Quickstart for adding a new optimization
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -136,21 +136,21 @@ binary.
 
 [String interning]: https://en.wikipedia.org/wiki/String_interning
 [`rustc_lexer`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/index.html
-[`rustc_driver`]: https://rustc-dev-guide.rust-lang.org/rustc-driver.html
+[`rustc_driver`]: rustc-driver.md
 [`rustc_interface::Config`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/interface/struct.Config.html
-[lex]: https://rustc-dev-guide.rust-lang.org/the-parser.html
+[lex]: the-parser.md
 [`StringReader`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/lexer/struct.StringReader.html
 [`rustc_parse`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/index.html
 [parser]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/index.html
 [hir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/index.html
-[*type inference*]: https://rustc-dev-guide.rust-lang.org/type-inference.html
-[*trait solving*]: https://rustc-dev-guide.rust-lang.org/traits/resolution.html
-[*type checking*]: https://rustc-dev-guide.rust-lang.org/type-checking.html
-[mir]: https://rustc-dev-guide.rust-lang.org/mir/index.html
-[borrow checking]: https://rustc-dev-guide.rust-lang.org/borrow_check.html
-[mir-opt]: https://rustc-dev-guide.rust-lang.org/mir/optimizations.html
+[*type inference*]: type-inference.md
+[*trait solving*]: traits/resolution.md
+[*type checking*]: type-checking.md
+[mir]: mir/index.md
+[borrow checking]: borrow_check.md
+[mir-opt]: mir/optimizations.md
 [`simplify_try`]: https://github.com/rust-lang/rust/pull/66282
-[codegen]: https://rustc-dev-guide.rust-lang.org/backend/codegen.html
+[codegen]: backend/codegen.md
 [parse_nonterminal]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/parser/struct.Parser.html#method.parse_nonterminal
 [parse_crate_mod]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/parser/struct.Parser.html#method.parse_crate_mod
 [parse_mod]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/parser/struct.Parser.html#method.parse_mod
@@ -364,21 +364,21 @@ For more details on bootstrapping, see
 - Where do phases diverge for cross-compilation to machine code across
   different platforms?
 -->
-  
+
 # References
 
 - Command line parsing
-  - Guide: [The Rustc Driver and Interface](https://rustc-dev-guide.rust-lang.org/rustc-driver.html)
+  - Guide: [The Rustc Driver and Interface](rustc-driver.md)
   - Driver definition: [`rustc_driver`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/)
   - Main entry point: [`rustc_session::config::build_session_options`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/config/fn.build_session_options.html)
 - Lexical Analysis: Lex the user program to a stream of tokens
-  - Guide: [Lexing and Parsing](https://rustc-dev-guide.rust-lang.org/the-parser.html)
+  - Guide: [Lexing and Parsing](the-parser.md)
   - Lexer definition: [`rustc_lexer`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/index.html)
   - Main entry point: [`rustc_lexer::first_token`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/fn.first_token.html)
 - Parsing: Parse the stream of tokens to an Abstract Syntax Tree (AST)
-  - Guide: [Lexing and Parsing](https://rustc-dev-guide.rust-lang.org/the-parser.html)
-  - Guide: [Macro Expansion](https://rustc-dev-guide.rust-lang.org/macro-expansion.html)
-  - Guide: [Name Resolution](https://rustc-dev-guide.rust-lang.org/name-resolution.html)
+  - Guide: [Lexing and Parsing](the-parser.md)
+  - Guide: [Macro Expansion](macro-expansion.md)
+  - Guide: [Name Resolution](name-resolution.md)
   - Parser definition: [`rustc_parse`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/index.html)
   - Main entry points:
     - [Entry point for first file in crate](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_interface/passes/fn.parse.html)
@@ -388,34 +388,34 @@ For more details on bootstrapping, see
   - Feature gating: **TODO**
   - Early linting: **TODO**
 - The High Level Intermediate Representation (HIR)
-  - Guide: [The HIR](https://rustc-dev-guide.rust-lang.org/hir.html)
-  - Guide: [Identifiers in the HIR](https://rustc-dev-guide.rust-lang.org/hir.html#identifiers-in-the-hir)
-  - Guide: [The HIR Map](https://rustc-dev-guide.rust-lang.org/hir.html#the-hir-map)
-  - Guide: [Lowering AST to HIR](https://rustc-dev-guide.rust-lang.org/lowering.html)
+  - Guide: [The HIR](hir.md)
+  - Guide: [Identifiers in the HIR](hir.md#identifiers-in-the-hir)
+  - Guide: [The HIR Map](hir.md#the-hir-map)
+  - Guide: [Lowering AST to HIR](lowering.md)
   - How to view HIR representation for your code `cargo rustc -- -Z unpretty=hir-tree`
   - Rustc HIR definition: [`rustc_hir`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/index.html)
   - Main entry point: **TODO**
   - Late linting: **TODO**
 - Type Inference
-  - Guide: [Type Inference](https://rustc-dev-guide.rust-lang.org/type-inference.html)
-  - Guide: [The ty Module: Representing Types](https://rustc-dev-guide.rust-lang.org/ty.html) (semantics)
+  - Guide: [Type Inference](type-inference.md)
+  - Guide: [The ty Module: Representing Types](ty.md) (semantics)
   - Main entry point (type inference): [`InferCtxtBuilder::enter`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxtBuilder.html#method.enter)
   - Main entry point (type checking bodies): [the `typeck` query](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.TyCtxt.html#method.typeck)
     - These two functions can't be decoupled.
 - The Mid Level Intermediate Representation (MIR)
-  - Guide: [The MIR (Mid level IR)](https://rustc-dev-guide.rust-lang.org/mir/index.html)
+  - Guide: [The MIR (Mid level IR)](mir/index.md)
   - Definition: [`rustc_middle/src/mir`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/index.html)
   - Definition of sources that manipulates the MIR: [`rustc_mir_build`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_build/index.html), [`rustc_mir_dataflow`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_dataflow/index.html), [`rustc_mir_transform`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/index.html)
 - The Borrow Checker
-  - Guide: [MIR Borrow Check](https://rustc-dev-guide.rust-lang.org/borrow_check.html)
+  - Guide: [MIR Borrow Check](borrow_check.md)
   - Definition: [`rustc_borrowck`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/index.html)
   - Main entry point: [`mir_borrowck` query](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/fn.mir_borrowck.html)
 - MIR Optimizations
-  - Guide: [MIR Optimizations](https://rustc-dev-guide.rust-lang.org/mir/optimizations.html)
+  - Guide: [MIR Optimizations](mir/optimizations.md)
   - Definition: [`rustc_mir_transform`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/index.html)
   - Main entry point: [`optimized_mir` query](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/fn.optimized_mir.html)
 - Code Generation
-  - Guide: [Code Generation](https://rustc-dev-guide.rust-lang.org/backend/codegen.html)
+  - Guide: [Code Generation](backend/codegen.md)
   - Generating Machine Code from LLVM IR with LLVM - **TODO: reference?**
   - Main entry point: [`rustc_codegen_ssa::base::codegen_crate`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_ssa/base/fn.codegen_crate.html)
     - This monomorphizes and produces LLVM IR for one codegen unit. It then

--- a/src/parallel-rustc.md
+++ b/src/parallel-rustc.md
@@ -29,7 +29,7 @@ independent instances of LLVM running in parallel. At the end, the linker
 is run to combine all the codegen units together into one binary. This process
 occurs in the `rustc_codegen_ssa::base` module.
 
-## Query System 
+## Query System
 
 The query model has some properties that make it actually feasible to evaluate
 multiple queries in parallel without too much of an effort:
@@ -54,7 +54,7 @@ When a query `foo` is evaluated, the cache table for `foo` is locked.
 
 ## Rustdoc
 
-As of <!-- date: 2022-05--> May 2022, there are still a number of steps 
+As of <!-- date: 2022-05--> May 2022, there are still a number of steps
 to complete before rustdoc rendering can be made parallel. More details on
 this issue can be found [here][parallel-rustdoc].
 
@@ -99,8 +99,8 @@ are a bit out of date):
 [imlist]: https://github.com/nikomatsakis/rustc-parallelization/blob/master/interior-mutability-list.md
 [irlo1]: https://internals.rust-lang.org/t/help-test-parallel-rustc/11503
 [tracking]: https://github.com/rust-lang/rust/issues/48685
-[monomorphization]:https://rustc-dev-guide.rust-lang.org/backend/monomorph.html
-[parallel-rustdoc]:https://github.com/rust-lang/rust/issues/82741
-[Arc]:https://doc.rust-lang.org/std/sync/struct.Arc.html
-[Rc]:https://doc.rust-lang.org/std/rc/struct.Rc.html
-[OwningRef]:https://doc.rust-lang.org/nightly/nightly-rustc/rustc_data_structures/owning_ref/index.html
+[monomorphization]: backend/monomorph.md
+[parallel-rustdoc]: https://github.com/rust-lang/rust/issues/82741
+[Arc]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+[Rc]: https://doc.rust-lang.org/std/rc/struct.Rc.html
+[OwningRef]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_data_structures/owning_ref/index.html


### PR DESCRIPTION
Used the following command (in fish), followed by some manual tweaking:

    sd 'https://rustc-dev-guide.rust-lang.org/(.+).html' '$1.md' (fd)
