### PR TITLE
Remove a mention to Steve on r? example

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -78,13 +78,12 @@ to review your request based on which files you changed.
 
 If you want to request that a specific person reviews your pull request, you
 can add an `r?` to the pull request description or in a comment. For example,
-[Steve][steveklabnik] usually reviews documentation changes. So if you were to
-make a documentation change, add
+if you want to ask a review to @awesome-reviewer, add
 
-    r? @steveklabnik
+    r? @awesome-reviewer
 
 to the end of the pull request description, and [@rust-highfive][rust-highfive] will assign
-[@steveklabnik][steveklabnik] instead of a random person. This is entirely optional.
+them instead of a random person. This is entirely optional.
 
 You can also assign a random reviewer from a specific team by writing `r? rust-lang/groupname`.
 So if you were making a diagnostics change, then you could get a reviewer from the diagnostics
@@ -135,7 +134,6 @@ speed the process up. Typically only small changes that are expected not to conf
 with one another are marked as "always roll up".
 
 [rust-highfive]: https://github.com/rust-highfive
-[steveklabnik]: https://github.com/steveklabnik
 [@bors]: https://github.com/bors
 [merge-queue]: https://bors.rust-lang.org/queue/rust
 


### PR DESCRIPTION
The docs changes are now reviewed by a specific team (e.g. t-libs, t-compiler) or the [docs group](https://github.com/rust-lang/highfive/blob/da54dc554f153481656f2cbbbf6591ca3cf226a1/highfive/configs/rust-lang/rust.json#L46-L50) and suggesting `r? @steveklabnik` is inaccurate (actually this is referenced by a contributor, e.g. https://togithub.com/rust-lang/rust/pull/98651#issue-1288041815). Since mentioning a specific user often gets outdated. the example should only show how you specify a reviewer. This removes a mention of Steve and replaces them with `@awesome-reviewer`, a placeholder.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>