### PR TITLE
replace misleading name

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,7 +12,7 @@
     - [Prerequisites](./building/prerequisites.md)
     - [Suggested Workflows](./building/suggested.md)
     - [Distribution artifacts](./building/build-install-distribution-artifacts.md)
-    - [Documenting Compiler](./building/compiler-documenting.md)
+    - [Building Documentation](./building/compiler-documenting.md)
     - [Rustdoc overview](./rustdoc.md)
     - [Adding a new target](./building/new-target.md)
 - [Testing the compiler](./tests/intro.md)

--- a/src/building/compiler-documenting.md
+++ b/src/building/compiler-documenting.md
@@ -1,4 +1,4 @@
-# Documenting rustc
+# Building documentation
 
 You might want to build documentation of the various components
 available like the standard library. There’s two ways to go about this.


### PR DESCRIPTION
I thought this was about documenting things, not building documentation.

Also, it's more than just building compiler documentation.