### PR TITLE
rust-analyzer is now a subtree

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -184,6 +184,7 @@ differently from other crates that are directly in this repo:
 
 * [Clippy](https://github.com/rust-lang/rust-clippy)
 * [rustfmt](https://github.com/rust-lang/rustfmt)
+* [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 
 In contrast to `submodule` dependencies
 (see below for those), the `subtree` dependencies are just regular files and directories which can

--- a/src/git.md
+++ b/src/git.md
@@ -387,7 +387,7 @@ you might want to get used to the main concepts of Git before reading this secti
 
 The `rust-lang/rust` repository uses [Git submodules] as a way to use other
 Rust projects from within the `rust` repo. Examples include Rust's fork of
-`llvm-project` and many devtools such as `cargo`, `rust-analyzer` and `rls`.
+`llvm-project` and many devtools such as `cargo` and `rls`.
 
 Those projects are developed and maintained in an separate Git (and GitHub)
 repository, and they have their own Git history/commits, issue tracker and PRs.


### PR DESCRIPTION
It used to be a submodule.

cf. https://github.com/rust-lang/rust/pull/99603

Closes https://github.com/rust-lang/rustc-dev-guide/issues/1407