### PR TITLE
Fix some links

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -63,7 +63,7 @@ If you set `download-ci-llvm = true`, in some circumstances, such as when
 updating the version of LLVM used by `rustc`, you may want to temporarily
 disable this feature. See the ["Updating LLVM" section] for more.
 
-["Updating LLVM" section]: /backend/updating-llvm.md#feature-updates
+["Updating LLVM" section]: ../backend/updating-llvm.md#feature-updates
 
 If you have already built `rustc` and you change settings related to LLVM, then you may have to
 execute `rm -rf build` for subsequent configuration changes to take effect. Note that `./x.py
@@ -254,7 +254,7 @@ For examples of the complete configuration necessary to build a target, please v
 select any target under the "Platform Support" heading on the left,
 and see the section related to building a compiler for that target.
 For targets without a corresponding page in the rustc book,
-it may be useful to [inspect the Dockerfiles](/tests/docker.md)
+it may be useful to [inspect the Dockerfiles](../tests/docker.md)
 that the Rust infrastructure itself uses to set up and configure cross-compilation.
 
 If you have followed the directions from the prior section on creating a rustup toolchain,

--- a/src/diagnostics/diagnostic-items.md
+++ b/src/diagnostics/diagnostic-items.md
@@ -142,6 +142,6 @@ who really want to take a deep dive into the topic :)
 [`TyCtxt::associated_items()`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/context/struct.TyCtxt.html#method.associated_items
 [`AssocItems`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/assoc/struct.AssocItems.html
 [`clippy_utils::ty::get_iterator_item_ty()`]: https://github.com/rust-lang/rust-clippy/blob/305177342fbc622c0b3cb148467bab4b9524c934/clippy_utils/src/ty.rs#L55-L72
-[clippy-Common-tools-for-writing-lints]: https://github.com/rust-lang/rust-clippy/blob/master/doc/common_tools_writing_lints.md
+[clippy-Common-tools-for-writing-lints]: https://doc.rust-lang.org/nightly/clippy/development/common_tools_writing_lints.html
 [rust#60966]: https://github.com/rust-lang/rust/pull/60966
 [rust-clippy#5393]: https://github.com/rust-lang/rust-clippy/issues/5393

--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -427,12 +427,12 @@ Some important data structures/interfaces here:
 - [`SyntaxExtensionKind`] - expander functions may have several different
   signatures (take one token stream, or two, or a piece of AST, etc). This is
   an enum that lists them.
-- [`ProcMacro`]/[`TTMacroExpander`]/[`AttrProcMacro`]/[`MultiItemModifier`] -
+- [`BangProcMacro`]/[`TTMacroExpander`]/[`AttrProcMacro`]/[`MultiItemModifier`] -
   traits representing the expander function signatures.
 
 [`SyntaxExtension`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/struct.SyntaxExtension.html
 [`SyntaxExtensionKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/enum.SyntaxExtensionKind.html
-[`ProcMacro`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.ProcMacro.html
+[`BangProcMacro`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.BangProcMacro.html
 [`TTMacroExpander`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.TTMacroExpander.html
 [`AttrProcMacro`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.AttrProcMacro.html
 [`MultiItemModifier`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_expand/base/trait.MultiItemModifier.html

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -8,8 +8,8 @@ to do, so compilation is faster. Note that since MIR is generic (not
 effective; we can optimize the generic version, so all of the monomorphizations
 are cheaper!
 
-[mir]: /mir/index.md
-[monomorph]: /appendix/glossary.md#mono
+[mir]: ../mir/index.md
+[monomorph]: ../appendix/glossary.md#mono
 
 MIR optimizations run after borrow checking. We run a series of optimization
 passes over the MIR to improve it. Some passes are required to run on all code,
@@ -22,9 +22,9 @@ run and that some validation has occurred. Then, it [steals][steal] the MIR,
 optimizes it, and returns the improved MIR.
 
 [optmir]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/fn.optimized_mir.html
-[query]: /query.md
-[defid]: /appendix/glossary.md#def-id
-[steal]: /mir/passes.md#stealing
+[query]: ../query.md
+[defid]: ../appendix/glossary.md#def-id
+[steal]: ../mir/passes.md#stealing
 
 ## Quickstart for adding a new optimization
 

--- a/src/name-resolution.md
+++ b/src/name-resolution.md
@@ -45,7 +45,7 @@ namespaces and therefore can co-exist.
 The name resolution in Rust is a two-phase process. In the first phase, which runs
 during macro expansion, we build a tree of modules and resolve imports. Macro
 expansion and name resolution communicate with each other via the
-[`ResolverAstLowering`] trait.
+[`ResolverAstLoweringExt`] trait.
 
 The input to the second phase is the syntax tree, produced by parsing input
 files and expanding macros. This phase produces links from all the names in the
@@ -61,7 +61,7 @@ The name resolution lives in the `rustc_resolve` crate, with the meat in
 `lib.rs` and some helpers or symbol-type specific logic in the other modules.
 
 [`Resolver::resolve_crate`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_resolve/struct.Resolver.html#method.resolve_crate
-[`ResolverAstLowering`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_lowering/trait.ResolverAstLowering.html
+[`ResolverAstLoweringExt`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_lowering/trait.ResolverAstLoweringExt.html
 
 ## Namespaces
 

--- a/src/serialization.md
+++ b/src/serialization.md
@@ -123,22 +123,22 @@ is in the cache, then instead of serializing the type as usual, the byte offset
 within the file being written is encoded instead. A similar scheme is used for
 `ty::Predicate`.
 
-## `Lazy<T>`
+## `LazyValue<T>`
 
 Crate metadata is initially loaded before the `TyCtxt<'tcx>` is created, so
 some deserialization needs to be deferred from the initial loading of metadata.
-The [`Lazy<T>`] type wraps the (relative) offset in the crate metadata where a
-`T` has been serialized.
+The [`LazyValue<T>`] type wraps the (relative) offset in the crate metadata where a
+`T` has been serialized. There are also some variants, [`LazyArray<T>`] and [`LazyTable<I, T>`].
 
-The `Lazy<[T]>` and `Lazy<Table<I, T>>` type provide some functionality over
+The `Lazy<[T]>` and `LazyTable<I, T>` type provide some functionality over
 `Lazy<Vec<T>>` and `Lazy<HashMap<I, T>>`:
 
-- It's possible to encode a `Lazy<[T]>` directly from an iterator, without
+- It's possible to encode a `LazyArray<T>` directly from an iterator, without
   first collecting into a `Vec<T>`.
-- Indexing into a `Lazy<Table<I, T>>` does not require decoding entries other
+- Indexing into a `LazyTable<I, T>` does not require decoding entries other
   than the one being read.
 
-**note**: `Lazy<T>` does not cache its value after being deserialized the first
+**note**: `LazyValue<T>` does not cache its value after being deserialized the first
 time. Instead the query system is the main way of caching these results.
 
 ## Specialization
@@ -155,7 +155,9 @@ for `Encodable<CacheEncoder>`.
 [serialize]: https://en.wikipedia.org/wiki/Serialization
 
 [`CrateInfo`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_ssa/struct.CrateInfo.html
-[`Lazy<T>`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/struct.Lazy.html
+[`LazyArray<T>`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/struct.LazyValue.html
+[`LazyTable<I, T>`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/struct.LazyValue.html
+[`LazyValue<T>`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/struct.LazyValue.html
 [`RefDecodable`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/codec/trait.RefDecodable.html
 [`rustc_metadata::rmeta::decoder::DecodeContext`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/decoder/struct.DecodeContext.html
 [`rustc_metadata::rmeta::encoder::EncodeContext`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_metadata/rmeta/encoder/struct.EncodeContext.html


### PR DESCRIPTION
The related rust-lang/rust changes:
- https://github.com/rust-lang/rust/pull/97291
- https://github.com/rust-lang/rust/pull/97004
- https://github.com/rust-lang/rust/pull/98106

Also, this makes some links to relative, see https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/33
Fixes #1410
Signed-off-by: Yuki Okushi <jtitor@2k36.org>
