### PR TITLE
Add bootstrapping diagram

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -18,7 +18,25 @@ rustc, then uses it to compile the new compiler.
 
 ## Stages of bootstrapping
 
-Compiling `rustc` is done in stages.
+Compiling `rustc` is done in stages. Here's a diagram, adapted from Joshua Nelson's
+[talk on bootstrapping][rustconf22-talk] at RustConf 2022, with detailed explanations below.
+The `A`, `B`, `C`, and `D` show the ordering of the stages of bootstrapping.
+
+[rustconf22-talk]: https://rustconf.com/schedule#bootstrapping-the-once-and-future-compiler
+
+```mermaid
+graph TD
+    s0c["stage0 compiler (1.63)"] -->|A| s0l("stage0 std (1.64)");
+    s0c & s0l --- stepb[ ]:::empty;
+    stepb -->|B| s0ca["stage0 compiler artifacts (1.64)"];
+    s0ca -->|copy| s1c["stage1 compiler (1.64)"];
+    s1c -->|C| s1l("stage1 std (1.64)");
+    s1c & s1l --- stepd[ ]:::empty;
+    stepd -->|D| s1ca["stage1 compiler artifacts (1.64)"];
+    s1ca -->|copy| s2c["stage2 compiler"];
+
+    classDef empty width:0px,height:0px;
+```
 
 ### Stage 0
 

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -20,22 +20,27 @@ rustc, then uses it to compile the new compiler.
 
 Compiling `rustc` is done in stages. Here's a diagram, adapted from Joshua Nelson's
 [talk on bootstrapping][rustconf22-talk] at RustConf 2022, with detailed explanations below.
+
 The `A`, `B`, `C`, and `D` show the ordering of the stages of bootstrapping.
+<span style="background-color: yellow">Yellow</span> nodes are built with the stage0 compiler, and
+<span style="background-color: lightgreen">green</span> nodes are built with the stage1 compiler.
 
 [rustconf22-talk]: https://rustconf.com/schedule#bootstrapping-the-once-and-future-compiler
 
 ```mermaid
 graph TD
-    s0c["stage0 compiler (1.63)"] -->|A| s0l("stage0 std (1.64)");
+    s0c["stage0 compiler (1.63)"] -->|A| s0l("stage0 std (1.64)"):::with-s0c;
     s0c & s0l --- stepb[ ]:::empty;
-    stepb -->|B| s0ca["stage0 compiler artifacts (1.64)"];
-    s0ca -->|copy| s1c["stage1 compiler (1.64)"];
-    s1c -->|C| s1l("stage1 std (1.64)");
+    stepb -->|B| s0ca["stage0 compiler artifacts (1.64)"]:::with-s0c;
+    s0ca -->|copy| s1c["stage1 compiler (1.64)"]:::with-s0c;
+    s1c -->|C| s1l("stage1 std (1.64)"):::with-s1c;
     s1c & s1l --- stepd[ ]:::empty;
-    stepd -->|D| s1ca["stage1 compiler artifacts (1.64)"];
-    s1ca -->|copy| s2c["stage2 compiler"];
+    stepd -->|D| s1ca["stage1 compiler artifacts (1.64)"]:::with-s1c;
+    s1ca -->|copy| s2c["stage2 compiler"]:::with-s1c;
 
     classDef empty width:0px,height:0px;
+    classDef with-s0c fill: yellow;
+    classDef with-s1c fill: lightgreen, color: black;
 ```
 
 ### Stage 0

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -22,14 +22,15 @@ Compiling `rustc` is done in stages. Here's a diagram, adapted from Joshua Nelso
 [talk on bootstrapping][rustconf22-talk] at RustConf 2022, with detailed explanations below.
 
 The `A`, `B`, `C`, and `D` show the ordering of the stages of bootstrapping.
-<span style="background-color: yellow">Yellow</span> nodes are built with the stage0 compiler, and
+<span style="background-color: lightblue">Blue</span> nodes are downloaded,
+<span style="background-color: yellow">yellow</span> nodes are built with the stage0 compiler, and
 <span style="background-color: lightgreen">green</span> nodes are built with the stage1 compiler.
 
 [rustconf22-talk]: https://rustconf.com/schedule#bootstrapping-the-once-and-future-compiler
 
 ```mermaid
 graph TD
-    s0c["stage0 compiler (1.63)"] -->|A| s0l("stage0 std (1.64)"):::with-s0c;
+    s0c["stage0 compiler (1.63)"]:::downloaded -->|A| s0l("stage0 std (1.64)"):::with-s0c;
     s0c & s0l --- stepb[ ]:::empty;
     stepb -->|B| s0ca["stage0 compiler artifacts (1.64)"]:::with-s0c;
     s0ca -->|copy| s1c["stage1 compiler (1.64)"]:::with-s0c;
@@ -39,8 +40,9 @@ graph TD
     s1ca -->|copy| s2c["stage2 compiler"]:::with-s1c;
 
     classDef empty width:0px,height:0px;
+    classDef downloaded fill: lightblue;
     classDef with-s0c fill: yellow;
-    classDef with-s1c fill: lightgreen, color: black;
+    classDef with-s1c fill: lightgreen;
 ```
 
 ### Stage 0


### PR DESCRIPTION
Closes #1419.

This diagram is based on the diagram in Joshua Nelson's talk on
bootstrapping at RustConf 2022 [1]. I converted it to Mermaid and made
some tweaks to simplify it and bring it closer to bootstrap's
terminology, and then Ralf Jung added nodes for copying artifacts.

[1]: https://rustconf.com/schedule#bootstrapping-the-once-and-future-compiler

Co-authored-by: Joshua Nelson <github@jyn.dev>
Co-authored-by: Ralf Jung <post@ralfj.de>

r? @jyn514
