### PR TITLE
Update for removal of RLS

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -365,7 +365,7 @@ This flag has the following effects:
 
 Code which does not use `-Z force-unstable-if-unmarked` should include the
 `#![feature(rustc_private)]` crate attribute to access these force-unstable
-crates. This is needed for things that link `rustc`, such as `miri`, `rls`, or
+crates. This is needed for things that link `rustc`, such as `miri` or
 `clippy`.
 
 You can find more discussion about sysroots in:

--- a/src/building/new-target.md
+++ b/src/building/new-target.md
@@ -102,15 +102,11 @@ unreleased version of `libc`, you can add it to the top-level
 
 ```diff
 diff --git a/Cargo.toml b/Cargo.toml
-index be15e50e2bc..4fb1248ba99 100644
+index 1e83f05e0ca..4d0172071c1 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -66,10 +66,11 @@ cargo = { path = "src/tools/cargo" }
+@@ -113,6 +113,8 @@ cargo-util = { path = "src/tools/cargo/crates/cargo-util" }
  [patch.crates-io]
- # Similar to Cargo above we want the RLS to use a vendored version of `rustfmt`
- # that we're shipping as well (to ensure that the rustfmt in RLS and the
- # `rustfmt` executable are the same exact version).
- rustfmt-nightly = { path = "src/tools/rustfmt" }
 +libc = { git = "https://github.com/rust-lang/libc", rev = "0bf7ce340699dcbacabdf5f16a242d2219a49ee0" }
 
  # See comments in `src/tools/rustc-workspace-hack/README.md` for what's going on

--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -388,10 +388,8 @@ In addition to telling the user exactly _why_ their code is wrong, it's
 oftentimes furthermore possible to tell them how to fix it. To this end,
 `DiagnosticBuilder` offers a structured suggestions API, which formats code
 suggestions pleasingly in the terminal, or (when the `--error-format json` flag
-is passed) as JSON for consumption by tools, most notably the [Rust Language
-Server][rls] and [`rustfix`][rustfix].
+is passed) as JSON for consumption by tools like [`rustfix`][rustfix].
 
-[rls]: https://github.com/rust-lang/rls
 [rustfix]: https://github.com/rust-lang/rustfix
 
 Not all suggestions should be applied mechanically, they have a degree of
@@ -757,7 +755,7 @@ then dumped into the `Session::buffered_lints` used by the rest of the compiler.
 
 The compiler accepts an `--error-format json` flag to output
 diagnostics as JSON objects (for the benefit of tools such as `cargo
-fix` or the RLS). It looks like this:
+fix`). It looks like this:
 
 ```console
 $ rustc json_error_demo.rs --error-format json
@@ -771,7 +769,7 @@ object, but the series of lines taken together is, unfortunately, not
 valid JSON, thwarting tools and tricks (such as [piping to `python3 -m
 json.tool`](https://docs.python.org/3/library/json.html#module-json.tool))
 that require such. (One speculates that this was intentional for LSP
-performance purposes, so that each line/object can be sent to RLS as
+performance purposes, so that each line/object can be sent as
 it is flushed?)
 
 Also note the "rendered" field, which contains the "human" output as a

--- a/src/git.md
+++ b/src/git.md
@@ -149,7 +149,7 @@ Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git restore <file>..." to discard changes in working directory)
 	modified:   src/tools/cargo (new commits)
-	modified:   src/tools/rls (new commits)
+	modified:   src/tools/miri (new commits)
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ```
@@ -391,7 +391,7 @@ you might want to get used to the main concepts of Git before reading this secti
 
 The `rust-lang/rust` repository uses [Git submodules] as a way to use other
 Rust projects from within the `rust` repo. Examples include Rust's fork of
-`llvm-project` and many devtools such as `cargo` and `rls`.
+`llvm-project` and many devtools such as `cargo` and `miri`.
 
 Those projects are developed and maintained in an separate Git (and GitHub)
 repository, and they have their own Git history/commits, issue tracker and PRs.
@@ -434,6 +434,5 @@ exist and that they correspond to some sort of embedded subrepository dependency
 that Git can nicely and fairly conveniently handle for us.
 
 [Git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[`rust-toolstate`]: https://rust-lang-nursery.github.io/rust-toolstate/
 [`rust-lang/miri`]: https://github.com/rust-lang/miri
 [miri-update]: https://github.com/rust-lang/rust/pull/77500/files

--- a/src/name-resolution.md
+++ b/src/name-resolution.md
@@ -174,7 +174,7 @@ Still, it probably provides useful first guidepost to what happens in there.
   following stages of compilation?
 * Who calls it and how it is actually used.
 * Is it a pass and then the result is only used, or can it be computed
-  incrementally (e.g. for RLS)?
+  incrementally?
 * The overall strategy description is a bit vague.
 * Where does the name `Rib` come from?
 * Does this thing have its own tests, or is it tested only as part of some e2e

--- a/src/overview.md
+++ b/src/overview.md
@@ -190,7 +190,7 @@ satisfy/optimize for. For example,
   the input programs says they do, and should continue to do so despite the
   tremendous amount of change constantly going on.
 - Integration: a number of other tools need to use the compiler in
-  various ways (e.g. cargo, clippy, miri, RLS) that must be supported.
+  various ways (e.g. cargo, clippy, miri) that must be supported.
 - Compiler stability: the compiler should not crash or fail ungracefully on the
   stable channel.
 - Rust stability: the compiler must respect Rust's stability guarantees by not

--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -7,7 +7,7 @@ using the interface defined in the [`rustc_interface`] crate.
 The `rustc_interface` crate provides external users with an (unstable) API
 for running code at particular times during the compilation process, allowing
 third parties to effectively use `rustc`'s internals as a library for
-analyzing a crate or emulating the compiler in-process (e.g. the RLS or rustdoc).
+analyzing a crate or emulating the compiler in-process (e.g. rustdoc).
 
 For those using `rustc` as a library, the [`rustc_interface::run_compiler()`][i_rc]
 function is the main entrypoint to the compiler. It takes a configuration for the compiler

--- a/src/tests/intro.md
+++ b/src/tests/intro.md
@@ -115,7 +115,7 @@ will unpack, build, and run all tests.
 ### Tool tests
 
 Packages that are included with Rust have all of their tests run as well.
-This includes things such as cargo, clippy, rustfmt, rls, miri, bootstrap
+This includes things such as cargo, clippy, rustfmt, miri, bootstrap
 (testing the Rust build system itself), etc.
 
 Most of the tools are located in the [`src/tools`] directory.


### PR DESCRIPTION
RLS has been removed as of https://github.com/rust-lang/rust/pull/100863. This updates the guide to remove information related to it.