### PR TITLE
Add reference for updating Windows PATH and fix typo

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -36,8 +36,10 @@ winget install -e Python.Python.3
 winget install -e Kitware.CMake
 ```
 
-If any of those is installed already, winget will detect it.
-Then edit your systems `PATH` variable and add: `C:\Program Files\CMake\bin`.
+If any of those is installed already, winget will detect it. Then edit your system's `PATH` variable
+and add: `C:\Program Files\CMake\bin`. See
+[this guide on editing the system `PATH`](https://www.java.com/en/download/help/path.html) from the
+Java documentation.
 
 For more information about building on Windows,
 see [the `rust-lang/rust` README](https://github.com/rust-lang/rust#building-on-windows).


### PR DESCRIPTION
Yes, the reference is a page on Java's documentation but that's the most complete and most official looking reference I could find.