### PR TITLE
Add symbol-addition to the how-to for new features

### DIFF
--- a/src/feature-gates.md
+++ b/src/feature-gates.md
@@ -9,9 +9,9 @@ modifying feature gates.
 See ["Stability in code"] for help with adding a new feature; this section just
 covers how to add the feature gate *declaration*.
 
-Add the feature name to `rustc_span/src/symbol.rs` in the `Symbols {...}` block.
+First, add the feature name to `rustc_span/src/symbol.rs` in the `Symbols {...}` block.
 
-Add a feature gate declaration to `rustc_feature/src/active.rs` in the active
+Then, add a feature gate declaration to `rustc_feature/src/active.rs` in the active
 `declare_features` block:
 
 ```rust,ignore

--- a/src/feature-gates.md
+++ b/src/feature-gates.md
@@ -9,6 +9,8 @@ modifying feature gates.
 See ["Stability in code"] for help with adding a new feature; this section just
 covers how to add the feature gate *declaration*.
 
+Add the feature name to `rustc_span/src/symbol.rs` in the `Symbols {...}` block.
+
 Add a feature gate declaration to `rustc_feature/src/active.rs` in the active
 `declare_features` block:
 

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -123,9 +123,9 @@ a new unstable feature:
 2. Pick a name for the feature gate (for RFCs, use the name
    in the RFC).
 
-3. Add a feature gate declaration to `rustc_feature/src/active.rs`
-   in the active `declare_features` block. See [here][add-feature-gate] for
-   detailed instructions.
+3. Add a feature gate declaration to `rustc_feature/src/active.rs` in the active
+   `declare_features` block, and add the feature gate keyword to
+   `rustc_span/src/symbol.rs`. See [here][add-feature-gate] for detailed instructions.
 
 4. Prevent usage of the new feature unless the feature gate is set.
    You can check it in most places in the compiler using the


### PR DESCRIPTION
I don't know if I'm holding it wrong, but without these steps, I get the following error, for example:

```
error[E0425]: cannot find value `manually_drop_attr` in module `sym`                                                                                                                                                [47/1826]
   --> compiler/rustc_feature/src/active.rs:436:14
    |
436 |     (active, manually_drop_attr, "1.64.0", Some(100344), None),
    |              ^^^^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `manually_drop`
    |
   ::: /usr/local/google/home/devinj/local_programming/rust-compiler/compiler/rustc_span/src/symbol.rs:23:1
    |
23  | symbols! {
    | -------- similarly named constant `manually_drop` defined here
```