### PR TITLE
[Diagnostics] - Update docs to match renamed Diagnostics traits and macros

### DIFF
--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -314,10 +314,10 @@ reporting errors.
 
 [errors]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_errors/index.html
 
-Diagnostics can be implemented as types which implement the `SessionDiagnostic`
+Diagnostics can be implemented as types which implement the `IntoDiagnostic`
 trait. This is preferred for new diagnostics as it enforces a separation
 between diagnostic emitting logic and the main code paths. For less-complex
-diagnostics, the `SessionDiagnostic` trait can be derived -- see [Diagnostic
+diagnostics, the `IntoDiagnostic` trait can be derived -- see [Diagnostic
 structs][diagnostic-structs]. Within the trait implementation, the APIs
 described below can be used as normal.
 

--- a/src/diagnostics/translation.md
+++ b/src/diagnostics/translation.md
@@ -11,7 +11,7 @@ There are two ways of writing translatable diagnostics:
    diagnostic structs). See [the diagnostic and subdiagnostic structs
    documentation](./diagnostic-structs.md).
 2. Using typed identifiers with `DiagnosticBuilder` APIs (in
-   `SessionDiagnostic` implementations).
+   `Diagnostic` implementations).
 
 When adding or changing a translatable diagnostic, you don't need to worry
 about the translations, only updating the original English message. Currently,


### PR DESCRIPTION
Renamed Diagnostics/Subdiagnostics traits and macros in https://github.com/rust-lang/rust/pull/101558

Cc @rust-lang/wg-diagnostics