### PR TITLE
Fix path to `rustfmt` in Suggested Workflows

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -33,7 +33,7 @@ you can write: <!-- date-check: apr 2022 --><!-- the date comment is for the edi
         "--json-output"
     ],
     "rust-analyzer.rustfmt.overrideCommand": [
-        "./build/$TARGET_TRIPLE/stage0/bin/rustfmt",
+        "./build/$TARGET_TRIPLE/stage0-tools-bin/rustfmt",
         "--edition=2021"
     ],
     "rust-analyzer.procMacro.enable": true,


### PR DESCRIPTION
Was pairing with a new contributor the other day and we realized the path to `rustfmt` was wrong.

I think it also might be the case that users now have to manually build stage0 `rustfmt` by doing `./x.py build --stage 0 src/tools/rustfmt`. It doesn't seem to get built when doing `./x.py build` on a compiler config.