### PR TITLE
Update r-a config suggestions

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -36,6 +36,7 @@ you can write: <!-- date-check: apr 2022 --><!-- the date comment is for the edi
         "./build/$TARGET_TRIPLE/stage0/bin/rustfmt",
         "--edition=2021"
     ],
+    "rust-analyzer.procMacro.server": "./build/$TARGET_TRIPLE/stage0/libexec/rust-analyzer-proc-macro-srv",
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
@@ -44,6 +45,7 @@ you can write: <!-- date-check: apr 2022 --><!-- the date comment is for the edi
         "check",
         "--json-output"
     ],
+    "rust-analyzer.cargo.sysroot": "./build/$TARGET_TRIPLE/stage0-sysroot",
     "rust-analyzer.rustc.source": "./Cargo.toml",
 }
 ```


### PR DESCRIPTION
The proc-macro server path is required for proc-macros to properly work in r-a when working on rustc.
Pointing the sysroot to the stage0 one is more correct than using the system installed one.

Related PRs in rust-analyzer:
https://github.com/rust-lang/rust-analyzer/pull/13327
https://github.com/rust-lang/rust-analyzer/pull/13326

Note, these configs only work with the next r-a release, that is tomorrows nightly, or next monday's stable release!