### PR TITLE
Update running tests with the new flags

### DIFF
--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -245,13 +245,19 @@ The binary will be created at
 `./build/$HOST_ARCH/stage2-tools/$TARGET_ARCH/release/remote-test-server`. Copy
 this over to the remote machine.
 
-On the remote machine, run the `remote-test-server` with the `remote` argument
-(and optionally `-v` for verbose output). Output should look like this:
+On the remote machine, run the `remote-test-server` with the `--bind
+0.0.0.0:12345` flag (and optionally `-v` for verbose output). Output should
+look like this:
 ```sh
-$ ./remote-test-server -v remote
+$ ./remote-test-server -v --bind 0.0.0.0:12345
 starting test server
 listening on 0.0.0.0:12345!
 ```
+
+Note that binding the server to 0.0.0.0 will allow all hosts able to reach your
+machine to execute arbitrary code on your machine. We strongly recommend either
+setting up a firewall to block external access to port 12345, or to use a more
+restrictive IP address when binding.
 
 You can test if the `remote-test-server` is working by connecting to it and
 sending `ping\n`. It should reply `pong`:


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/102193 changed the flags you need to pass to run `remote-test-server`, and this PR updates the documentation to reflect that.