### PR TITLE
diagnostic structs: derive on enum

### DIFF
--- a/src/diagnostics/diagnostic-structs.md
+++ b/src/diagnostics/diagnostic-structs.md
@@ -145,7 +145,7 @@ tcx.sess.emit_err(FieldAlreadyDeclared {
 following attributes:
 
 - `#[diag(slug, code = "...")]`
-  - _Applied to struct._
+  - _Applied to struct or enum variant._
   - _Mandatory_
   - Defines the text and error code to be associated with the diagnostic.
   - Slug (_Mandatory_)


### PR DESCRIPTION
rust-lang/rust#102189 added support for enums to the diagnostic derive, so this documentation needs updating.