### PR TITLE
.gitattributes: Mark minified javascript as binary to filter greps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto eol=lf
 
+# git grep shouldn't match entries in huge minified javascript
+*.min.js binary
+
 # Older git versions try to fix line endings on images, this prevents it.
 *.png binary
 *.jpg binary


### PR DESCRIPTION
When doing a git grep (of rustc-dev-guide or of rust-lang/rust with
--recurse-submodules), if the grep happens to match within the minified
javascript, the resulting long single lines can cause a text pager or
editor to slow down and distract from more useful matches.

Minified javascript isn't formatted for human consumption, by
definition, so mark it as binary, which causes git grep to instead just
state that it matches without printing the matching "line".
