### PR TITLE
Add missing prerequisite for some Linux distros

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -9,6 +9,7 @@ Before building the compiler, you need the following things installed:
 * `git`
 * `ssl` which comes in `libssl-dev` or `openssl-devel`
 * `pkg-config` if you are compiling on Linux and targeting Linux
+* `libstdc++-static` may be required on some Linux distributions such as Fedora and Ubuntu
 
 If building LLVM from source (the default), you'll need additional tools:
 


### PR DESCRIPTION
Fedora and Ubuntu users have reported missing `libstdc++-static` when attempting to build the compiler.