### PR TITLE
Add sample CodeLLDB launch.json

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -312,7 +312,7 @@ error: aborting due to previous error
 ## Configuring CodeLLDB for debugging `rustc`
 
 If you are using VSCode, and have edited your `config.toml` to request debugging
-level 1 or 2 for the parts of the code you're interested in, then you *should* be
+level 1 or 2 for the parts of the code you're interested in, then you should be
 able to use the [CodeLLDB] extension in VSCode to debug it.
 
 Here is a sample `launch.json` file, being used to run a stage 1 compiler direct

--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -307,3 +307,37 @@ error: aborting due to previous error
 ```
 
 [`Layout`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_target/abi/struct.Layout.html
+
+
+## Configuring CodeLLDB for debugging `rustc`
+
+If you are using VSCode, and have edited your `config.toml` to request debugging
+level 1 or 2 for the parts of the code you're interested in, then you *should* be
+able to use the [CodeLLDB] extension in VSCode to debug it.
+
+Here is a sample `launch.json` file, being used to run a stage 1 compiler direct
+from the directory where it is built (does not have to be "installed"):
+
+```javascript
+// .vscode/launch.json
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "lldb",
+        "request": "launch",
+        "name": "Launch",
+        "args": [],  // array of string command-line arguments to pass to compiler
+        "program": "${workspaceFolder}/build/x86_64-unknown-linux-gnu/stage1/bin/rustc",
+        "windows": {  // applicable if using windows
+            "program": "${workspaceFolder}/build/x86_64-pc-windows-msvc/stage1/bin/rustc.exe"
+        },
+        "cwd": "${workspaceFolder}",  // current working directory at program start
+        "stopOnEntry": false,
+        "sourceLanguages": ["rust"]
+      }
+    ]
+  }
+```
+
+[CodeLLDB]: https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb

--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -328,7 +328,7 @@ from the directory where it is built (does not have to be "installed"):
         "request": "launch",
         "name": "Launch",
         "args": [],  // array of string command-line arguments to pass to compiler
-        "program": "${workspaceFolder}/build/x86_64-unknown-linux-gnu/stage1/bin/rustc",
+        "program": "${workspaceFolder}/build/TARGET/stage1/bin/rustc",
         "windows": {  // applicable if using windows
             "program": "${workspaceFolder}/build/x86_64-pc-windows-msvc/stage1/bin/rustc.exe"
         },


### PR DESCRIPTION
There is a section with [instructions for setting up source analyzer in VSCode](https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc), but nothing for setting up debugging with CodeLLDB.  This adds a sample configuration that may not be ideal, but appears to work for me.

To source highlight the snippet, uses JavaScript instead of JSON so that comments do not show up as errors highlighted in red (VSCode allows comments).

*(I'm not using Windows... I saw the given pattern from another launch.json and just included it.  Someone on Windows should edit that to be correct if it's not.)*