### PR TITLE
Update rust-analyzer suggestions

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -39,6 +39,7 @@ you can write: <!-- date-check: apr 2022 --><!-- the date comment is for the edi
     "rust-analyzer.procMacro.server": "./build/$TARGET_TRIPLE/stage0/libexec/rust-analyzer-proc-macro-srv",
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.cargo.buildScripts.enable": true,
+    "rust-analyzer.cargo.buildScripts.invocationLocation": "root",
     "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "python3",

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -39,6 +39,7 @@ you can write: <!-- date-check: apr 2022 --><!-- the date comment is for the edi
     "rust-analyzer.procMacro.server": "./build/$TARGET_TRIPLE/stage0/libexec/rust-analyzer-proc-macro-srv",
     "rust-analyzer.procMacro.enable": true,
     "rust-analyzer.cargo.buildScripts.enable": true,
+    "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "python3",
         "x.py",


### PR DESCRIPTION
This setting will cause r-a to invoke the build script command only once in the root of the project instead of once per workspace which causes problems when the `linkedProjects` settings is used to target other workspaces in the repo.

In theory the same setting could be applied to `checkOnSave`, but for that to work `x.py` needs to fix up the paths of diagnostics to be relative to the project root instead of the workspace roots the diagnostics are emitted from.

This depends on https://github.com/rust-lang/rust-analyzer/pull/13128 which will have the next stable r-a release on coming monday / nightly in ~2 hours