### PR TITLE
miri is no longer a submodule but a subtree.

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -183,6 +183,7 @@ As a developer to this repository, you don't have to treat the following externa
 differently from other crates that are directly in this repo:
 
 * [Clippy](https://github.com/rust-lang/rust-clippy)
+* [Miri](https://github.com/rust-lang/miri)
 * [rustfmt](https://github.com/rust-lang/rustfmt)
 * [rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 
@@ -257,12 +258,12 @@ some of them are optional (like [Miri]).
 Usage of submodules is discussed more in the [Using Git
 chapter](git.md#git-submodules).
 
-Some of the submodules are allowed to be in a "broken" state where they either
-don't build or their tests don't pass. These include [Miri] and the
-documentation books like [The Rust Reference]. Maintainers of these projects
-will be notified when the project is in a broken state, and they should fix
-them as soon as possible. The current status is tracked on the [toolstate
-website]. More information may be found on the Forge [Toolstate chapter].
+Some of the submodules are allowed to be in a "broken" state where they
+either don't build or their tests don't pass, e.g. the documentation books
+like [The Rust Reference]. Maintainers of these projects will be notified
+when the project is in a broken state, and they should fix them as soon
+as possible. The current status is tracked on the [toolstate website].
+More information may be found on the Forge [Toolstate chapter].
 
 Breakage is not allowed in the beta and stable channels, and must be addressed
 before the PR is merged. They are also not allowed to be broken on master in
@@ -270,7 +271,6 @@ the week leading up to the beta cut.
 
 [git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 [`.gitmodules`]: https://github.com/rust-lang/rust/blob/master/.gitmodules
-[Miri]: https://github.com/rust-lang/miri
 [The Rust Reference]: https://github.com/rust-lang/reference/
 [toolstate website]: https://rust-lang-nursery.github.io/rust-toolstate/
 [Toolstate chapter]: https://forge.rust-lang.org/infra/toolstate.html
@@ -309,8 +309,8 @@ Here are those same steps in detail:
    from resetting to the original branch after you make your changes. If you
    need to [update any submodules to their latest versions](#updating-submodules),
    see the section of this file about that for more information.
-2. (optional) Run `./x.py test src/tools/miri` (substituting the submodule
-   that broke for `miri`). Fix any errors in the submodule (and possibly others).
+2. (optional) Run `./x.py test src/tools/cargo` (substituting the submodule
+   that broke for `cargo`). Fix any errors in the submodule (and possibly others).
 3. (optional) Make commits for your changes and send them to upstream repositories as a PR.
 4. (optional) Maintainers of these submodules will **not** merge the PR. The PR can't be
    merged because CI will be broken. You'll want to write a message on the PR referencing
@@ -321,6 +321,12 @@ Here are those same steps in detail:
 8. (optional) Send a PR to rust-lang/rust updating the submodule.
 
 #### Updating submodules
+
+(As of <!-- date-check --> Sept 2022 `miri` is no longer a submodule but a subtree. The following
+instructions are still broadly correct for updating submodules in general. For a more specific
+example you can also see the steps for [upgrading llvm][upgrading-llvm].)
+
+[upgrading-llvm]: https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html
 
 These instructions are specific to updating `miri`, however they may apply
 to the other submodules as well. Please help by improving these instructions

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -320,29 +320,6 @@ Here are those same steps in detail:
 7. (optional) Help land your PR on the upstream repository now that your changes are in nightly.
 8. (optional) Send a PR to rust-lang/rust updating the submodule.
 
-#### Updating submodules
-
-(As of <!-- date-check --> Sept 2022 `miri` is no longer a submodule but a subtree. The following
-instructions are still broadly correct for updating submodules in general. For a more specific
-example you can also see the steps for [upgrading llvm][upgrading-llvm].)
-
-[upgrading-llvm]: https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html
-
-These instructions are specific to updating `miri`, however they may apply
-to the other submodules as well. Please help by improving these instructions
-if you find any discrepancies or special cases that need to be addressed.
-
-To update the `miri` submodule, start by running the appropriate
-[`git submodule` command](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
-For example, to update to the latest commit on the remote master branch,
-you may want to run:
-```
-git submodule update --remote src/tools/miri
-```
-If you run `./x.py build` now, and you are lucky, it may just work.
-
-To add these changes to a commit, use `git add src/tools/miri` and commit the
-change. You can the push and open a PR.
 
 ## Writing Documentation
 

--- a/src/git.md
+++ b/src/git.md
@@ -176,7 +176,7 @@ There is a workaround in [the issue][#77620-workaround].
 [#77620]: https://github.com/rust-lang/rust/issues/77620
 [#77620-workaround]: https://github.com/rust-lang/rust/issues/77620#issuecomment-705228229
 
-(Note that as of <!-- date-check --> Sept 2022 `miri` is a subtree and not a submodule.)
+(Note that as of Sept 2022 `miri` is a subtree and not a submodule.)
 
 ## Rebasing and Conflicts
 

--- a/src/git.md
+++ b/src/git.md
@@ -148,8 +148,8 @@ Your branch is up to date with 'origin/master'.
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git restore <file>..." to discard changes in working directory)
+	modified:   src/llvm-project (new commits)
 	modified:   src/tools/cargo (new commits)
-	modified:   src/tools/miri (new commits)
 
 no changes added to commit (use "git add" and/or "git commit -a")
 ```
@@ -175,6 +175,8 @@ There is a workaround in [the issue][#77620-workaround].
 
 [#77620]: https://github.com/rust-lang/rust/issues/77620
 [#77620-workaround]: https://github.com/rust-lang/rust/issues/77620#issuecomment-705228229
+
+(Note that as of <!-- date-check --> Sept 2022 `miri` is a subtree and not a submodule.)
 
 ## Rebasing and Conflicts
 
@@ -391,41 +393,41 @@ you might want to get used to the main concepts of Git before reading this secti
 
 The `rust-lang/rust` repository uses [Git submodules] as a way to use other
 Rust projects from within the `rust` repo. Examples include Rust's fork of
-`llvm-project` and many devtools such as `cargo` and `miri`.
+`llvm-project`, `cargo`  and libraries like `stdarch` and `backtrace`.
 
 Those projects are developed and maintained in an separate Git (and GitHub)
 repository, and they have their own Git history/commits, issue tracker and PRs.
 Submodules allow us to create some sort of embedded sub-repository inside the
 `rust` repository and use them like they were directories in the `rust` repository.
 
-Take `miri` for example. `miri` is maintained in the [`rust-lang/miri`] repository,
-but it is used in `rust-lang/rust` by the compiler for const evaluation. We bring it
-in `rust` as a submodule, in the `src/tools/miri` folder.
+Take `llvm-project` for example. `llvm-project` is maintained in the [`rust-lang/llvm-project`]
+repository, but it is used in `rust-lang/rust` by the compiler for code generation and
+optimization. We bring it in `rust` as a submodule, in the `src/llvm-project` folder.
 
 The contents of submodules are ignored by Git: submodules are in some sense isolated
-from the rest of the repository. However, if you try to `cd src/tools/miri` and then
+from the rest of the repository. However, if you try to `cd src/llvm-project` and then
 run `git status`:
 
 ```
-HEAD detached at 3fafb835
+HEAD detached at 9567f08afc943
 nothing to commit, working tree clean
 ```
 
-As far as git is concerned, you are no longer in the `rust` repo, but in the `miri` repo.
+As far as git is concerned, you are no longer in the `rust` repo, but in the `llvm-project` repo.
 You will notice that we are in "detached HEAD" state, i.e. not on a branch but on a
 particular commit.
 
 This is because, like any dependency, we want to be able to control which version to use.
 Submodules allow us to do just that: every submodule is "pinned" to a certain
 commit, which doesn't change unless modified manually. If you use `git checkout <commit>`
-in the `miri` directory and go back to the `rust` directory, you can stage this
-change like any other, e.g. by running `git add src/tools/miri`. (Note that if
+in the `llvm-project` directory and go back to the `rust` directory, you can stage this
+change like any other, e.g. by running `git add src/llvm-project`. (Note that if
 you *don't* stage the change to commit, then you run the risk that running
 `x.py` will just undo your change by switching back to the previous commit when
 it automatically "updates" the submodules.)
 
 This version selection is usually done by the maintainers of the project, and
-looks like [this][miri-update].
+looks like [this][llvm-update].
 
 Git submodules take some time to get used to, so don't worry if it isn't perfectly
 clear yet. You will rarely have to use them directly and, again, you don't need
@@ -434,5 +436,5 @@ exist and that they correspond to some sort of embedded subrepository dependency
 that Git can nicely and fairly conveniently handle for us.
 
 [Git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[`rust-lang/miri`]: https://github.com/rust-lang/miri
-[miri-update]: https://github.com/rust-lang/rust/pull/77500/files
+[`rust-lang/llvm-project`]: https://github.com/rust-lang/llvm-project
+[llvm-update]: https://github.com/rust-lang/rust/pull/99464/files


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/pull/102028 miri is now subtree.