### PR TITLE
Update for highfive transition.

### DIFF
--- a/src/compiler-team.md
+++ b/src/compiler-team.md
@@ -111,20 +111,22 @@ The guidelines for reviewers are as follows:
 
 [Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
 
-### high-five
+### Reviewer rotation
 
-Once you have r+ rights, you can also be added to the [high-five][hi5]
-rotation. high-five is the bot that assigns incoming PRs to
-reviewers. If you are added, you will be randomly selected to review
+Once you have r+ rights, you can also be added to the [reviewer rotation].
+[triagebot] is the bot that [automatically assigns] incoming PRs to reviewers.
+If you are added, you will be randomly selected to review
 PRs. If you find you are assigned a PR that you don't feel comfortable
 reviewing, you can also leave a comment like `r? @so-and-so` to assign
 to someone else — if you don't know who to request, just write `r?
 @nikomatsakis for reassignment` and @nikomatsakis will pick someone
 for you.
 
-[hi5]: https://github.com/rust-highfive
+[reviewer rotation]: https://github.com/rust-lang/rust/blob/36285c5de8915ecc00d91ae0baa79a87ed5858d5/triagebot.toml#L528-L577
+[triagebot]: https://github.com/rust-lang/triagebot/
+[automatically assigns]: https://github.com/rust-lang/triagebot/wiki/Assignment
 
-Getting on the high-five list is much appreciated as it lowers the
+Getting on the reviewer rotation is much appreciated as it lowers the
 review burden for all of us! However, if you don't have time to give
 people timely feedback on their PRs, it may be better that you don't
 get on the list.

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -73,7 +73,7 @@ when contributing to Rust under [the git section](./git.md).
 ### r?
 
 All pull requests are reviewed by another person. We have a bot,
-[@rust-highfive][rust-highfive], that will automatically assign a random person
+[@rustbot], that will automatically assign a random person
 to review your request based on which files you changed.
 
 If you want to request that a specific person reviews your pull request, you
@@ -82,7 +82,7 @@ if you want to ask a review to @awesome-reviewer, add
 
     r? @awesome-reviewer
 
-to the end of the pull request description, and [@rust-highfive][rust-highfive] will assign
+to the end of the pull request description, and [@rustbot] will assign
 them instead of a random person. This is entirely optional.
 
 You can also assign a random reviewer from a specific team by writing `r? rust-lang/groupname`.
@@ -91,8 +91,10 @@ team by adding:
 
     r? rust-lang/diagnostics
 
-For a full list of possible `groupname` check the `groups` section at the
-[rust highfive config file](https://github.com/rust-lang/highfive/blob/master/highfive/configs/rust-lang/rust.json).
+For a full list of possible `groupname` check the `adhoc_groups` section at the
+[triagebot.toml config file](https://github.com/rust-lang/rust/blob/master/triagebot.toml)
+or the list of teams in the [rust-lang teams
+database](https://github.com/rust-lang/team/tree/master/teams).
 
 ### CI
 
@@ -133,7 +135,7 @@ Changes that are rolled up are tested and merged alongside other PRs, to
 speed the process up. Typically only small changes that are expected not to conflict
 with one another are marked as "always roll up".
 
-[rust-highfive]: https://github.com/rust-highfive
+[@rustbot]: https://github.com/rustbot
 [@bors]: https://github.com/bors
 [merge-queue]: https://bors.rust-lang.org/queue/rust
 

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -156,7 +156,7 @@ highlights, but there are a lot more details, which we will link to below.
 
 ### Code Review
 
-When you open a PR on the `rust-lang/rust` repo, a bot called `@rust-highfive` will
+When you open a PR on the `rust-lang/rust` repo, a bot called `@rustbot` will
 automatically assign a reviewer to the PR based on which files you changed.
 The reviewer is the person that will approve the PR to be tested and merged.
 If you want a specific reviewer (e.g. a team member you've been working with),


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/pull/103492, `rust-lang/rust` no longer uses highfive to handle reviewer rotation. Triagebot has token over this responsibility. This PR updates the documentation for this change.