### PR TITLE
Remove `--bless` from pre-push hook suggestion

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -8,8 +8,9 @@ to make your life easier.
 CI will automatically fail your build if it doesn't pass `tidy`, our
 internal tool for ensuring code quality. If you'd like, you can install a
 [Git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
-that will automatically run `./x.py test tidy --bless` on each push, to ensure
-your code is up to par. If you decide later that this behavior is
+that will automatically run `./x.py test tidy` on each push, to ensure
+your code is up to par. If the hook fails then run `./x.py test tidy --bless`
+and commit the changes. If you decide later that the pre-push behavior is
 undesirable, you can delete the `pre-push` file in `.git/hooks`.
 
 A prebuilt git hook lives at [`src/etc/pre-push.sh`](https://github.com/rust-lang/rust/blob/master/src/etc/pre-push.sh) which can be copied into your `.git/hooks` folder as `pre-push` (without the `.sh` extension!).


### PR DESCRIPTION
According to https://github.com/rust-lang/rust/commit/8873e33806487a0fb12143772b1a3c1544edbe0b

> Running with --bless causes the push to succeed if there are fixable
formatting changes, but the changes don't make it into the push.
>
> We should have the user rerun with --bless (or x.py fmt) and commit the
changes themselves (they might want to amend a particular commit, for instance).

So update the hook documentation with that in mind.