### PR TITLE
Fix a broken design docs link about unused substs bug

### DIFF
--- a/src/constants.md
+++ b/src/constants.md
@@ -79,4 +79,4 @@ the constant doesn't use them in any way. This can cause
 [`ty::Const`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.Const.html
 [`ty::ConstKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.ConstKind.html
 [`ty::TyKind`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/enum.TyKind.html
-[pcg-unused-substs]: https://github.com/rust-lang/project-const-generics/blob/master/design-docs/anon-const-substs.md#unused-substs
+[pcg-unused-substs]: https://github.com/rust-lang/project-const-generics/issues/33


### PR DESCRIPTION
https://github.com/rust-lang/project-const-generics/pull/21 removed the link. This replaces it with an issue link mentioned on the design docs.
Fixes #1498

Signed-off-by: Yuki Okushi <jtitor@2k36.org>