### PR TITLE
Update path for `try_mark_green` implementation

### DIFF
--- a/src/queries/incremental-compilation-in-detail.md
+++ b/src/queries/incremental-compilation-in-detail.md
@@ -177,7 +177,7 @@ fn try_mark_green(tcx, current_node) -> bool {
 }
 
 // Note: The actual implementation can be found in
-//       compiler/rustc_middle/src/dep_graph/graph.rs
+//       compiler/rustc_query_system/src/dep_graph/graph.rs
 ```
 
 By using red-green marking we can avoid the devastating cumulative effect of


### PR DESCRIPTION
Updates the location of the `try_mark_green` algorithm from `compiler/rustc_middle/src/dep_graph/graph.rs` to [`compiler/rustc_middle/src/dep_graph/graph.rs`](https://github.com/rust-lang/rust/blob/stable/compiler/rustc_query_system/src/dep_graph/graph.rs#L574) .