### PR TITLE
chore: Update `actions/github-script` to v6

### DIFF
--- a/.github/workflows/date-check.yml
+++ b/.github/workflows/date-check.yml
@@ -27,9 +27,8 @@ jobs:
           cargo run -- ../../src/ > ../../date-check-output.txt
 
       - name: Open issue
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const fs = require('fs');
 
@@ -37,7 +36,7 @@ jobs:
             const title = rawText.split('\n')[0];
             if (title != 'empty') {
                 const body = rawText.split('\n').slice(1).join('\n');
-                github.issues.create({
+                github.rest.issues.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   title,


### PR DESCRIPTION
v5 requires to migrate from `github.issues` to `github.rest.issues`, and v6 updates Node.js image to v16.
Ref. https://github.com/actions/github-script#breaking-changes

This also removes `github_token` input as `GITHUB_TOKEN` will be used by default: https://github.com/actions/github-script#using-a-separate-github-token

Signed-off-by: Yuki Okushi <jtitor@2k36.org>