### PR TITLE
fix: Fix broken links

### DIFF
--- a/src/appendix/background.md
+++ b/src/appendix/background.md
@@ -328,5 +328,5 @@ does not.
 - [nLab](https://ncatlab.org/nlab/show/HomePage)
 
 ## Misc Papers and Blog Posts
-- [Programming in Martin-Löf's Type Theory](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.118.6683&rep=rep1&type=pdf)
+- [Programming in Martin-Löf's Type Theory](https://www.researchgate.net/publication/213877272_Programming_in_Martin-Lof's_Type_Theory)
 - [Polymorphism, Subtyping, and Type Inference in MLsub](https://dl.acm.org/doi/10.1145/3093333.3009882)

--- a/src/appendix/bibliography.md
+++ b/src/appendix/bibliography.md
@@ -23,7 +23,7 @@ Rust, as well as publications about Rust.
 * [Scheduling multithreaded computations by work stealing](http://supertech.csail.mit.edu/papers/steal.pdf)
 * [Thread scheduling for multiprogramming multiprocessors](https://www.eecis.udel.edu/%7Ecavazos/cisc879-spring2008/papers/arora98thread.pdf)
 * [The data locality of work stealing](http://www.aladdin.cs.cmu.edu/papers/pdfs/y2000/locality_spaa00.pdf)
-* [Dynamic circular work stealing deque](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.170.1097&rep=rep1&type=pdf) - The Chase/Lev deque
+* [Dynamic circular work stealing deque](https://patents.google.com/patent/US7346753B2/en) - The Chase/Lev deque
 * [Work-first and help-first scheduling policies for async-finish task parallelism](https://dl.acm.org/doi/10.1109/IPDPS.2009.5161079) - More general than fully-strict work stealing
 * [A Java fork/join calamity](https://web.archive.org/web/20190904045322/http://www.coopsoft.com/ar/CalamityArticle.html) - critique of Java's fork/join library, particularly its application of work stealing to non-strict computation
 * [Scheduling techniques for concurrent systems](https://www.stanford.edu/~ouster/cgi-bin/papers/coscheduling.pdf)
@@ -81,7 +81,7 @@ Rust, as well as publications about Rust.
 * [Ownership is Theft: Experiences Building an Embedded OS in Rust - Amit Levy, et. al.](https://amitlevy.com/papers/tock-plos2015.pdf)
 * [You can't spell trust without Rust](https://raw.githubusercontent.com/Gankro/thesis/master/thesis.pdf). Alexis Beingessner's master's thesis.
 * [Rust-Bio: a fast and safe bioinformatics library](https://academic.oup.com/bioinformatics/article/32/3/444/1743419). Johannes Köster
-* [Safe, Correct, and Fast Low-Level Networking](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.704.1768). Robert Clipsham's master's thesis.
+* [Safe, Correct, and Fast Low-Level Networking](https://octarineparrot.com/assets/msci_paper.pdf). Robert Clipsham's master's thesis.
 * [Formalizing Rust traits](https://open.library.ubc.ca/cIRcle/collections/ubctheses/24/items/1.0220521). Jonatan Milewski's master's thesis.
 * [Rust as a Language for High Performance GC Implementation](https://users.cecs.anu.edu.au/~steveb/downloads/pdf/rust-ismm-2016.pdf)
 * [Simple Verification of Rust Programs via Functional Purification](https://github.com/Kha/electrolysis). Sebastian Ullrich's master's thesis.

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -273,6 +273,7 @@ Breakage is not allowed in the beta and stable channels, and must be addressed
 before the PR is merged. They are also not allowed to be broken on master in
 the week leading up to the beta cut.
 
+[Miri]: https://github.com/rust-lang/miri
 [git submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
 [`.gitmodules`]: https://github.com/rust-lang/rust/blob/master/.gitmodules
 [The Rust Reference]: https://github.com/rust-lang/reference/

--- a/src/overview.md
+++ b/src/overview.md
@@ -374,7 +374,7 @@ For more details on bootstrapping, see
 - Lexical Analysis: Lex the user program to a stream of tokens
   - Guide: [Lexing and Parsing](the-parser.md)
   - Lexer definition: [`rustc_lexer`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/index.html)
-  - Main entry point: [`rustc_lexer::first_token`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/fn.first_token.html)
+  - Main entry point: [`rustc_lexer::cursor::Cursor::advance_token`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/cursor/struct.Cursor.html#method.advance_token)
 - Parsing: Parse the stream of tokens to an Abstract Syntax Tree (AST)
   - Guide: [Lexing and Parsing](the-parser.md)
   - Guide: [Macro Expansion](macro-expansion.md)

--- a/src/query.md
+++ b/src/query.md
@@ -223,7 +223,7 @@ Let's go over these elements one by one:
 - **Query modifiers:** various flags and options that customize how the
   query is processed (mostly with respect to [incremental compilation][incrcomp]).
 
-[Key]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_query_impl/keys/trait.Key.html
+[Key]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/query/keys/trait.Key.html
 [incrcomp]: queries/incremental-compilation-in-detail.html#query-modifiers
 
 So, to add a query:

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -96,7 +96,7 @@ You should see an error message, something like this:
 
 > error: /rust/src/test/ui/async-await/await-without-async.rs:7: unexpected
 > error: '7:10: 7:16: `await` is only allowed inside `async` functions and
-> blocks [E0728]'
+> blocks E0728'
 
 ### Step 3. Add error annotations
 

--- a/src/type-checking.md
+++ b/src/type-checking.md
@@ -4,7 +4,7 @@ The [`rustc_typeck`][typeck] crate contains the source for "type collection"
 and "type checking", as well as a few other bits of related functionality. (It
 draws heavily on the [type inference] and [trait solving].)
 
-[typeck]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_typeck/index.html
+[typeck]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/index.html
 [type inference]: ./type-inference.md
 [trait solving]: ./traits/resolution.md
 
@@ -39,6 +39,6 @@ type *checking*).
 For more details, see the [`collect`][collect] module.
 
 [queries]: ./query.md
-[collect]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_typeck/collect/
+[collect]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/collect/index.html
 
 **TODO**: actually talk about type checking... [#1161](https://github.com/rust-lang/rustc-dev-guide/issues/1161)


### PR DESCRIPTION
This replaces a bunch of broken links. A few things I'd like to mention:
- citeseerx.ist.psu.edu's PDF links are broken, I searched alternatives on DuckDuckGo but I haven't made sure all the websites are reliable. Any suggestions are welcome!
- https://github.com/rust-lang/rust/pull/102302 changed the logic and `first_token` no longer exists. I chose `advance_token` but `next_token` might be suitable.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>