### PR TITLE
Fix small inaccuracy in monomorph page

### DIFF
--- a/src/backend/monomorph.md
+++ b/src/backend/monomorph.md
@@ -10,7 +10,7 @@ execute.
 Different languages handle this problem differently. For example, in some
 languages, such as Java, we may not know the most precise type of value until
 runtime. In the case of Java, this is ok because (almost) all variables are
-reference values anyway (i.e. pointers to a stack allocated object). This
+reference values anyway (i.e. pointers to a heap allocated object). This
 flexibility comes at the cost of performance, since all accesses to an object
 must dereference a pointer.
 


### PR DESCRIPTION
Just fixing a small inaccuracy. Pretty sure we meant to say heap here :) 