### PR TITLE
Add Neovim configuration information

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rustdocs][rustdocs].
 To build a local static HTML site, install [`mdbook`](https://github.com/rust-lang/mdBook) with:
 
 ```
-> cargo install mdbook mdbook-linkcheck mdbook-toc
+> cargo install mdbook mdbook-linkcheck mdbook-toc mdbook-mermaid
 ```
 
 and execute the following command in the root of the repository:

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -27,6 +27,44 @@ you to create a `.vscode/settings.json` file which will configure Visual Studio 
 This will ask `rust-analyzer` to use `./x.py check` to check the sources, and the
 stage 0 rustfmt to format them.
 
+
+For Neovim users there are several options for configuring for rustc. You can use the native LSP server and make your own logic for changing the rust-analyzer configuration to the above. You can also use [nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for project-local configuration files. This plugin allows for the above JSON to be directly put in to a file located at `rust/.nlsp-settings/rust_analyzer.json`. If you use [coc-rust-analyzer](https://github.com/fannheyward/coc-rust-analyzer) you can also use the above JSON, but placed in `rust/.vim/coc-settings.json`.
+
+Below is the Lua needed to configure the native Neovim LSP the same as the above VSCode configuration
+
+```lua
+{
+    ["rust-analyzer"] = {
+        checkOnSave = {
+            overrideCommand = {
+                {"python3", "x.py", "check", "--json-output"}
+            }
+        },
+        rustfmt = {
+            overrideCommand = {
+                {"./build/host/stage0/bin/rustfmt", "--edition=2021"}
+            }
+        },
+        procMacro = {
+            server = "./build/host/stage0/libexec/rust-analyzer-proc-macro-srv",
+            enable = true
+        },
+        cargo = {
+            buildScripts = {
+                enable = true,
+                invocationLocation = "root",
+                invocationStrategy = "once",
+                overrideCommand = {"python3", "x.py", "check", "--json-output"}
+            },
+            sysroot = "./build/host/stage0-sysroot"
+        },
+        rustc = {
+            source = "./Cargo.toml"
+        }
+    }
+}
+```
+
 If you have enough free disk space and you would like to be able to run `x.py` commands while
 rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
 `overrideCommand` to avoid x.py locking.

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -28,9 +28,16 @@ This will ask `rust-analyzer` to use `./x.py check` to check the sources, and th
 stage 0 rustfmt to format them.
 
 
-For Neovim users there are several options for configuring for rustc. You can use the native LSP server and make your own logic for changing the rust-analyzer configuration to the above. You can also use [nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for project-local configuration files. This plugin allows for the above JSON to be directly put in to a file located at `rust/.nlsp-settings/rust_analyzer.json`. If you use [coc-rust-analyzer](https://github.com/fannheyward/coc-rust-analyzer) you can also use the above JSON, but placed in `rust/.vim/coc-settings.json`.
+For Neovim users there are several options for configuring for rustc. You can use the native LSP 
+server and make your own logic for changing the rust-analyzer configuration to the above. You can 
+also use [nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for 
+project-local configuration files. This plugin allows for the above JSON to be directly put in to 
+a file located at `rust/.nlsp-settings/rust_analyzer.json`. If you use 
+[coc-rust-analyzer](https://github.com/fannheyward/coc-rust-analyzer) you can also use the above 
+JSON, but placed in `rust/.vim/coc-settings.json`.
 
-Below is the Lua needed to configure the native Neovim LSP the same as the above VSCode configuration
+Below is the Lua needed to configure the native Neovim LSP the same as the above VSCode 
+configuration
 
 ```lua
 {

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -65,49 +65,18 @@ Rust-Analyzer to already be configured with Neovim. Steps for this can be
 [found here](https://rust-analyzer.github.io/manual.html#nvim-lsp).
 
 1. First install the plugin. This can be done by following the steps in the README.
-2. Run `x.py setup`, which will have a prompt for it to create a `.vscode/settings.json` file. `neoconf`
-is able to read and update Rust-Analyzer settings automatically when the project is opened when this
-file is detected.
+2. Run `x.py setup`, which will have a prompt for it to create a `.vscode/settings.json` file. 
+`neoconf` is able to read and update Rust-Analyzer settings automatically when the project is 
+opened when this file is detected.
 
 If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
 `.vim/coc-settings.json` and copy the settings from 
 [this file](https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json).
 
-Another way is without a plugin, and creating your own logic in your configuration. The required 
-Lua for doing so is below.
-
-```lua
-{
-    ["rust-analyzer"] = {
-        checkOnSave = {
-            overrideCommand = {
-                {"python3", "x.py", "check", "--json-output"}
-            }
-        },
-        rustfmt = {
-            overrideCommand = {
-                {"./build/host/stage0/bin/rustfmt", "--edition=2021"}
-            }
-        },
-        procMacro = {
-            server = "./build/host/stage0/libexec/rust-analyzer-proc-macro-srv",
-            enable = true
-        },
-        cargo = {
-            buildScripts = {
-                enable = true,
-                invocationLocation = "root",
-                invocationStrategy = "once",
-                overrideCommand = {"python3", "x.py", "check", "--json-output"}
-            },
-            sysroot = "./build/host/stage0-sysroot"
-        },
-        rustc = {
-            source = "./Cargo.toml"
-        }
-    }
-}
-```
+Another way is without a plugin, and creating your own logic in your configuration. To do this you 
+must translate the JSON to Lua yourself. The translation is 1:1 and fairly straight-forward. It 
+must be put in the `["rust-analyzer"]` key of the setup table, which is 
+[shown here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer)
 
 ## Check, check, and check again
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -19,6 +19,8 @@ You can also install the hook as a step of running `./x.py setup`!
 
 ## Configuring `rust-analyzer` for `rustc`
 
+### Visual Studio Code
+
 `rust-analyzer` can help you check and format your code whenever you save
 a file. By default, `rust-analyzer` runs the `cargo check` and `rustfmt`
 commands, but you can override these commands to use more adapted versions
@@ -27,20 +29,49 @@ you to create a `.vscode/settings.json` file which will configure Visual Studio 
 This will ask `rust-analyzer` to use `./x.py check` to check the sources, and the
 stage 0 rustfmt to format them.
 
+If you have enough free disk space and you would like to be able to run `x.py` commands while
+rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
+`overrideCommand` to avoid x.py locking.
+
+If running `./x.py check` on save is inconvenient, in VS Code you can use a [Build
+Task] instead:
+
+```JSON
+// .vscode/tasks.json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "./x.py check",
+            "command": "./x.py check",
+            "type": "shell",
+            "problemMatcher": "$rustc",
+            "presentation": { "clear": true },
+            "group": { "kind": "build", "isDefault": true }
+        }
+    ]
+}
+```
+
+[Build Task]: https://code.visualstudio.com/docs/editor/tasks
+
+
+### Neovim
 
 For Neovim users there are several options for configuring for rustc. The easiest way is by using 
-[nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for project-local
-configuration files with the native LSP. The steps for how to use it are below.
+[neoconf.nvim](https://github.com/folke/neoconf.nvim/), which allows for project-local
+configuration files with the native LSP. The steps for how to use it are below. Note that requires 
+Rust-Analyzer to already be configured with Neovim. Steps for this can be 
+[found here](https://rust-analyzer.github.io/manual.html#nvim-lsp).
 
-1. First install the plugin
-2. Run `:LspSettings local rust_analyzer` while the rust repo is open.
+1. First install the plugin. This can be done by following the steps in the README.
+2. Run `x.py setup`, which will have a prompt for it to create a `.vscode/settings.json` file. `neoconf`
+is able to read and update Rust-Analyzer settings automatically when the project is opened when this
+file is detected.
 
-This will create and open a JSON file to put the above JSON in.
-
-3. Open a Rust buffer that causes Rust Analyzer to attach.
-4. Run `:LspSettings update rust_analyzer` 
-
-The final step must be repeated every time you open Neovim after you open a Rust buffer.
+If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
+`.vim/coc-settings.json` and copy the settings from 
+[this file](https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json).
 
 Another way is without a plugin, and creating your own logic in your configuration. The required 
 Lua for doing so is below.
@@ -77,35 +108,6 @@ Lua for doing so is below.
     }
 }
 ```
-
-If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
-`.vim/coc-settings.json` and copy the settings from [this file](https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json).
-
-If you have enough free disk space and you would like to be able to run `x.py` commands while
-rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
-`overrideCommand` to avoid x.py locking.
-
-If running `./x.py check` on save is inconvenient, in VS Code you can use a [Build
-Task] instead:
-
-```JSON
-// .vscode/tasks.json
-{
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "./x.py check",
-            "command": "./x.py check",
-            "type": "shell",
-            "problemMatcher": "$rustc",
-            "presentation": { "clear": true },
-            "group": { "kind": "build", "isDefault": true }
-        }
-    ]
-}
-```
-
-[Build Task]: https://code.visualstudio.com/docs/editor/tasks
 
 ## Check, check, and check again
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -30,9 +30,17 @@ stage 0 rustfmt to format them.
 
 For Neovim users there are several options for configuring for rustc. The easiest way is by using 
 [nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for project-local
-configuration files with the native LSP. First install the plugin by however you manage your 
-plugins. Then run `:LspSettings local rust_analyzer` to create a JSON configuration file. Then 
-just paste the above JSON in.
+configuration files with the native LSP. The steps for how to use it are below.
+
+1. First install the plugin
+2. Run `:LspSettings local rust_analyzer` while the rust repo is open.
+
+This will create and open a JSON file to put the above JSON in.
+
+3. Open a Rust buffer that causes Rust Analyzer to attach.
+4. Run `:LspSettings update rust_analyzer` 
+
+The final step must be repeated every time you open Neovim after you open a Rust buffer.
 
 Another way is without a plugin, and creating your own logic in your configuration. The required 
 Lua for doing so is below.

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -78,6 +78,12 @@ must translate the JSON to Lua yourself. The translation is 1:1 and fairly strai
 must be put in the `["rust-analyzer"]` key of the setup table, which is 
 [shown here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#rust_analyzer)
 
+If you would like to use the build task that is described above, you may either make your own 
+command in your config, or you can install a plugin such as 
+[overseer.nvim](https://github.com/stevearc/overseer.nvim) that can [read VSCode's `task.json` 
+files](https://github.com/stevearc/overseer.nvim/blob/master/doc/guides.md#vs-code-tasks), and 
+follow the same instructions as above.
+
 ## Check, check, and check again
 
 When doing simple refactorings, it can be useful to run `./x.py check`

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -28,16 +28,14 @@ This will ask `rust-analyzer` to use `./x.py check` to check the sources, and th
 stage 0 rustfmt to format them.
 
 
-For Neovim users there are several options for configuring for rustc. You can use the native LSP 
-server and make your own logic for changing the rust-analyzer configuration to the above. You can 
-also use [nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for 
-project-local configuration files. This plugin allows for the above JSON to be directly put in to 
-a file located at `rust/.nlsp-settings/rust_analyzer.json`. If you use 
-[coc-rust-analyzer](https://github.com/fannheyward/coc-rust-analyzer) you can also use the above 
-JSON, but placed in `rust/.vim/coc-settings.json`.
+For Neovim users there are several options for configuring for rustc. The easiest way is by using 
+[nlsp-settings](https://github.com/tamago324/nlsp-settings.nvim), which allows for project-local
+configuration files with the native LSP. First install the plugin by however you manage your 
+plugins. Then run `:LspSettings local rust_analyzer` to create a JSON configuration file. Then 
+just paste the above JSON in.
 
-Below is the Lua needed to configure the native Neovim LSP the same as the above VSCode 
-configuration
+Another way is without a plugin, and creating your own logic in your configuration. The required 
+Lua for doing so is below.
 
 ```lua
 {
@@ -72,12 +70,12 @@ configuration
 }
 ```
 
+If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
+`.vim/coc-settings.json` and copy the settings from [this file](https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json).
+
 If you have enough free disk space and you would like to be able to run `x.py` commands while
 rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
 `overrideCommand` to avoid x.py locking.
-
-If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
-`.vim/coc-settings.json` and copy the settings from [this file](https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json).
 
 If running `./x.py check` on save is inconvenient, in VS Code you can use a [Build
 Task] instead:


### PR DESCRIPTION
The JSON provided for VSCode works with coc and nlsp-settings. This is verified by
https://github.com/fannheyward/coc-rust-analyzer#configurations for coc, and feeding the JSON in to this schema
https://github.com/tamago324/nlsp-settings.nvim/blob/main/schemas/_generated/rust_analyzer.json for validating nlsp-settings.

The Lua translation is straight-forward and is how all rust-analyzer settings must be used with native nvim lsp.

Note that I just moved and my main computer that has nvim setup on it is not unpacked so I did not test these. But I believe they should work, and I think I've actually done something like this in the past.