### PR TITLE
Add a citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+message: If you use this guide, please cite it using these metadata.
+title: Rust Compiler Development Guide (rustc-dev-guide)
+abstract: A guide to developing the Rust compiler (rustc)
+authors:
+  - name: "The Rust Project Developers"
+date-released: "2018-01-16"
+license: "MIT OR Apache-2.0"
+repository-code: "https://github.com/rust-lang/rustc-dev-guide"

--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,7 @@
 [book]
-title = "Guide to Rustc Development"
-author = "Rustc developers"
-description = "A guide to developing rustc"
+title = "Rust Compiler Development Guide"
+author = "The Rust Project Developers"
+description = "A guide to developing the Rust compiler (rustc)"
 
 [build]
 create-missing = false


### PR DESCRIPTION
Fixes #1534
This places a CFF file following https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files to add citation metadata.
Some data is taken from https://github.com/rust-lang/rustc-dev-guide/blob/master/book.toml.
The release date is taken from https://github.com/rust-lang/rustc-dev-guide/commit/27ec0dc6d6e5afb7a4848ed00b457d24ec12b8f3.

cc @rust-lang/wg-rustc-dev-guide I'm not familiar with citations at all, any feedback is greatly welcome!

Signed-off-by: Yuki Okushi <jtitor@2k36.org>