### PR TITLE
fix examples for rustc 1.68.0-nightly (935dc0721 2022-12-19) (#1556)

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -3,7 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
-// version: 1.62.0-nightly (7c4b47696 2022-04-30)
+// version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_error_codes;
 extern crate rustc_errors;
@@ -50,7 +50,6 @@ fn main() {
         output_dir: None,  // Option<PathBuf>
         output_file: None, // Option<PathBuf>
         file_loader: None, // Option<Box<dyn FileLoader + Send + Sync>>
-        diagnostic_output: rustc_session::DiagnosticOutput::Default,
         lint_caps: FxHashMap::default(), // FxHashMap<lint::LintId, lint::Level>
         // This is a callback from the driver that is called when [`ParseSess`] is created.
         parse_sess_created: None, //Option<Box<dyn FnOnce(&mut ParseSess) + Send>>

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -64,7 +64,7 @@ fn main() {
 }
 "
             .into(),
-        },        
+        },
         crate_cfg: rustc_hash::FxHashSet::default(),
         crate_check_cfg: CheckCfg::default(),
         input_path: None,

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -3,7 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
-// version: 1.62.0-nightly (7c4b47696 2022-04-30)
+// version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_error_codes;
 extern crate rustc_errors;
@@ -64,11 +64,7 @@ fn main() {
 }
 "
             .into(),
-        },
-        // Redirect the diagnostic output of the compiler to a buffer.
-        diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
-            buffer.clone(),
-        ))),
+        },        
         crate_cfg: rustc_hash::FxHashSet::default(),
         crate_check_cfg: CheckCfg::default(),
         input_path: None,

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -42,7 +42,7 @@ fn main() {
 }
 "#
             .to_string(),
-        },        
+        },
         crate_cfg: rustc_hash::FxHashSet::default(),
         crate_check_cfg: CheckCfg::default(),
         input_path: None,

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -3,7 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
-// version: 1.62.0-nightly (7c4b47696 2022-04-30)
+// version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_ast_pretty;
 extern crate rustc_error_codes;
@@ -42,8 +42,7 @@ fn main() {
 }
 "#
             .to_string(),
-        },
-        diagnostic_output: rustc_session::DiagnosticOutput::Default,
+        },        
         crate_cfg: rustc_hash::FxHashSet::default(),
         crate_check_cfg: CheckCfg::default(),
         input_path: None,

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -7,7 +7,7 @@
 To get diagnostics from the compiler,
 configure `rustc_interface::Config` to output diagnostic to a buffer,
 and run `TyCtxt.analysis`. The following was tested
-with <!-- date-check: June 2022 --> `nightly-2022-06-05` (See [here][example]
+with <!-- date-check: Jan 2023 --> `nightly-2022-12-19` (See [here][example]
 for the complete example):
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs
@@ -24,11 +24,7 @@ let config = rustc_interface::Config {
             ),
         },
         /* other config */
-    },
-    // Redirect the diagnostic output of the compiler to a buffer.
-    diagnostic_output: rustc_session::DiagnosticOutput::Raw(Box::from(DiagnosticSink(
-        buffer.clone(),
-    ))),
+    },   
     /* other config */
 };
 rustc_interface::run_compiler(config, |compiler| {

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -5,7 +5,7 @@
 ## Getting the type of an expression
 
 To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`.
-The following was tested with <!-- date-check: June 2022 --> `nightly-2022-06-05`
+The following was tested with <!-- date-check: Jan 2023 --> `nightly-2022-12-19`
 (see [here][example] for the complete example):
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs


### PR DESCRIPTION
because `diagnostic_output: DiagnosticOutput`  is removed from `rustc_interface::Config` type by commit https://github.com/rust-lang/rust/commit/641f8249f99b407af7e5376b098323926eab1696, the examples are no longer compiled.
This PR is to fix it for the latest nightly rustc as today 1.68.0-nightly (935dc0721 2022-12-19)

Closes https://github.com/rust-lang/rustc-dev-guide/issues/1556