### PR TITLE
Use ephemeral PAT for linkcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       MDBOOK_TOC_VERSION: 0.9.0
       DEPLOY_DIR: book/html
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/book.toml
+++ b/book.toml
@@ -40,6 +40,9 @@ exclude = [
 cache-timeout = 86400
 warning-policy = "error"
 
+[output.linkcheck.http-headers]
+'github\.com' = ["Accept: application/vnd.github+json", "Authorization: Bearer $GITHUB_TOKEN"]
+
 [output.html.redirect]
 "/compiletest.html" = "tests/compiletest.html"
 "/diagnostics/sessiondiagnostic.html" = "diagnostics/diagnostic-structs.html"


### PR DESCRIPTION
This tries to fix the notorious 429 failure using [GHA's ephemeral PAT](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).

Signed-off-by: Yuki Okushi <jtitor@2k36.org>