### PR TITLE
Update rustfmt path

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -34,7 +34,7 @@ you can write: <!-- date-check: nov 2022 --><!-- the date comment is for the edi
         "--json-output"
     ],
     "rust-analyzer.rustfmt.overrideCommand": [
-        "./build/host/stage0/bin/rustfmt",
+        "./build/host/rustfmt/bin/rustfmt",
         "--edition=2021"
     ],
     "rust-analyzer.procMacro.server": "./build/host/stage0/libexec/rust-analyzer-proc-macro-srv",


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/pull/107297#discussion_r1092764740, the change broke the rust-analyzer config. Hence, changing the docs to match the new path