### PR TITLE
Highlight the nightly version needed to compile the examples

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -3,6 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
+// You need the below nightly version to compile:
 // version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_error_codes;

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -3,6 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
+// You need the below nightly version to compile:
 // version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_error_codes;

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -3,6 +3,7 @@
 // NOTE: For the example to compile, you will need to first run the following:
 //   rustup component add rustc-dev llvm-tools-preview
 
+// You need the below nightly version to compile:
 // version: rustc 1.68.0-nightly (935dc0721 2022-12-19)
 
 extern crate rustc_ast_pretty;

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -6,9 +6,11 @@
 
 To get diagnostics from the compiler,
 configure `rustc_interface::Config` to output diagnostic to a buffer,
-and run `TyCtxt.analysis`. The following was tested
-with <!-- date-check: Jan 2023 --> `nightly-2022-12-19` (See [here][example]
-for the complete example):
+and run `TyCtxt.analysis`.
+
+> **Note**: We expect you to compile the example
+> with <!-- date-check: Jan 2023 --> `nightly-2022-12-19` (See [here][example]
+> for the complete example)
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs
 
@@ -24,7 +26,7 @@ let config = rustc_interface::Config {
             ),
         },
         /* other config */
-    },   
+    },
     /* other config */
 };
 rustc_interface::run_compiler(config, |compiler| {

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -5,8 +5,10 @@
 ## Getting the type of an expression
 
 To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`.
-The following was tested with <!-- date-check: Jan 2023 --> `nightly-2022-12-19`
-(see [here][example] for the complete example):
+
+> **Note**: We expect you to compile the example
+> with <!-- date-check: Jan 2023 --> `nightly-2022-12-19`
+> (see [here][example] for the complete example)
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs
 

--- a/src/rustc-driver.md
+++ b/src/rustc-driver.md
@@ -16,6 +16,9 @@ configuration and passes it to the closure. Inside the closure, you can use the 
 to drive queries to compile a crate and get the results. This is what the `rustc_driver` does too.
 You can see a minimal example of how to use `rustc_interface` [here][example].
 
+> **Note**: As changes can be made to the rustc internal APIs at any time,
+> we expect you to compile the example with <!-- date-check: Jan 2023 --> `nightly-2022-12-19`.
+
 You can see what queries are currently available through the rustdocs for [`Compiler`].
 You can see an example of how to use them by looking at the `rustc_driver` implementation,
 specifically the [`rustc_driver::run_compiler` function][rd_rc] (not to be confused with


### PR DESCRIPTION
Readers didn't notice the examples need a specific nightly version. Indeed other versions _can_ work, but it introduces some confusion like https://github.com/rust-lang/rustc-dev-guide/issues/1556 and #1581. This emphasizes the nightly version to use.
A partial revert of https://github.com/rust-lang/rustc-dev-guide/pull/1373.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>