### PR TITLE
Do not add accept header on linkcheck

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -41,7 +41,7 @@ cache-timeout = 86400
 warning-policy = "error"
 
 [output.linkcheck.http-headers]
-'github\.com' = ["Accept: application/vnd.github+json", "Authorization: Bearer $GITHUB_TOKEN"]
+'github\.com' = ["Authorization: Bearer $GITHUB_TOKEN"]
 
 [output.html.redirect]
 "/compiletest.html" = "tests/compiletest.html"


### PR DESCRIPTION
It seems that this header causes "406 Not Acceptable" failures: https://github.com/rust-lang/rustc-dev-guide/actions/runs/4092776683/jobs/7057742900