### PR TITLE
update examples for rustc 1.69.0-nightly (e1eaa2d5d 2023-02-06)

### DIFF
--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -12,6 +12,7 @@ extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_driver;
 
 use rustc_errors::registry;
 use rustc_session::config::{self, CheckCfg};
@@ -67,7 +68,6 @@ fn main() {
         },
         crate_cfg: rustc_hash::FxHashSet::default(),
         crate_check_cfg: CheckCfg::default(),
-        input_path: None,
         output_dir: None,
         output_file: None,
         file_loader: None,
@@ -80,7 +80,7 @@ fn main() {
     };
     rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {
-            queries.global_ctxt().unwrap().take().enter(|tcx| {
+            queries.global_ctxt().unwrap().enter(|tcx| {
                 // Run the analysis phase on the local crate to trigger the type error.
                 let _ = tcx.analysis(());
             });

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -7,7 +7,7 @@
 To get diagnostics from the compiler,
 configure `rustc_interface::Config` to output diagnostic to a buffer,
 and run `TyCtxt.analysis`. The following was tested
-with <!-- date-check: Jan 2023 --> `nightly-2022-12-19` (See [here][example]
+with <!-- date-check: Feb 2023 --> `nightly-2023-02-06` (See [here][example]
 for the complete example):
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-getting-diagnostics.rs
@@ -29,7 +29,7 @@ let config = rustc_interface::Config {
 };
 rustc_interface::run_compiler(config, |compiler| {
     compiler.enter(|queries| {
-        queries.global_ctxt().unwrap().take().enter(|tcx| {
+        queries.global_ctxt().unwrap().enter(|tcx| {
             // Run the analysis phase on the local crate to trigger the type error.
             let _ = tcx.analysis(());
         });

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -5,7 +5,7 @@
 ## Getting the type of an expression
 
 To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`.
-The following was tested with <!-- date-check: Jan 2023 --> `nightly-2022-12-19`
+The following was tested with <!-- date-check: Feb 2023 --> `nightly-2023-02-06`
 (see [here][example] for the complete example):
 
 [example]: https://github.com/rust-lang/rustc-dev-guide/blob/master/examples/rustc-driver-interacting-with-the-ast.rs
@@ -22,7 +22,7 @@ let config = rustc_interface::Config {
 rustc_interface::run_compiler(config, |compiler| {
     compiler.enter(|queries| {
         // Analyze the crate and inspect the types under the cursor.
-        queries.global_ctxt().unwrap().take().enter(|tcx| {
+        queries.global_ctxt().unwrap().enter(|tcx| {
             // Every compilation contains a single crate.
             let hir_krate = tcx.hir();
             // Iterate over the top-level items in the crate, looking for the main function.
@@ -35,9 +35,9 @@ rustc_interface::run_compiler(config, |compiler| {
                         if let rustc_hir::StmtKind::Local(local) = block.stmts[0].kind {
                             if let Some(expr) = local.init {
                                 let hir_id = expr.hir_id; // hir_id identifies the string "Hello, world!"
-                                let def_id = tcx.hir().local_def_id(item.hir_id()); // def_id identifies the main function
+                                let def_id = item.hir_id().owner.def_id; // def_id identifies the main function
                                 let ty = tcx.typeck(def_id).node_type(hir_id);
-                                println!("{:?}: {:?}", expr, ty);
+                                println!("{expr:#?}: {ty:?}");
                             }
                         }
                     }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustc-dev-guide/issues/1581

Updated examples with the 1.69.0-nightly (e1eaa2d5d 2023-02-06).
