### PR TITLE
Add link to vscode settings in Rust repo

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -28,10 +28,16 @@ of these tools when hacking on `rustc`. For example, `x.py setup` will prompt
 you to create a `.vscode/settings.json` file which will configure Visual Studio code.
 This will ask `rust-analyzer` to use `./x.py check` to check the sources, and the
 stage 0 rustfmt to format them.
+The recommended `rust-analyzer` settings live at [`src/etc/vscode_settings.json`].
 
 If you have enough free disk space and you would like to be able to run `x.py` commands while
 rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
 `overrideCommand` to avoid x.py locking.
+
+If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
+`.vim/coc-settings.json` and copy the settings from [`src/etc/vscode_settings.json`].
+
+[`src/etc/vscode_settings.json`]: https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json
 
 If running `./x.py check` on save is inconvenient, in VS Code you can use a [Build
 Task] instead:


### PR DESCRIPTION
cc @RalfJung, @jyn514 

I'm not sure if 'the above file' is ambiguous here or if I should just duplicate the link.

Also, if https://github.com/rust-lang/rust/pull/107848 is accepted, it might be nice to specifically ask users to run `x.py setup hook`/`x.py setup vscode` in these two sections of this page.