### PR TITLE
have checkboxes only point to date-check lines in files

### DIFF
--- a/ci/date-check/src/main.rs
+++ b/ci/date-check/src/main.rs
@@ -170,7 +170,7 @@ fn main() {
 
         for (path, dates) in dates_by_file {
             println!(
-                "- [ ] {}",
+                "- {}",
                 path.strip_prefix(&root_dir_path).unwrap_or(&path).display(),
             );
             for (line, date) in dates {


### PR DESCRIPTION
They currently also point to filenames, which is redundant.

current

- [ ] thir.md
  - [ ] line 7: 2022-04
  - [ ] line 60: 2022-08
- [ ] traits/chalk.md
  - [ ] line 4: 2022-05

proposed

- thir.md
  - [ ] line 7: 2022-04
  - [ ] line 60: 2022-08
- traits/chalk.md
  - [ ] line 4: 2022-05
