### PR TITLE
Add detail to contributing guide

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -96,6 +96,21 @@ For a full list of possible `groupname` check the `adhoc_groups` section at the
 or the list of teams in the [rust-lang teams
 database](https://github.com/rust-lang/team/tree/master/teams).
 
+---
+
+**Please note**: Our pool of pull requests reviewers is often working at capacity, many of them are
+contributing on a volunteer basis. In order to minimize review delays, pull request authors
+and assigned reviewers should ensure that the review label (`S-waiting-on-review` and
+`S-waiting-on-author`) stays updated, invoking these commands when appropriate:
+
+`@rustbot author`: the review is finished, PR author should check the comments and take action
+accordingly
+
+`@rustbot review`: the author is ready for a review, this PR will be queued again in the reviewer's
+queue
+
+---
+
 ### CI
 
 In addition to being reviewed by a human, pull requests are automatically tested


### PR DESCRIPTION
We are trying to improve on the pull request review flow. This patch add additional info on how to use the review flags during the lifecycle of a pull request.

Discussed during T-compiler meeting ([comment](https://rust-lang.zulipchat.com/#narrow/stream/238009-t-compiler.2Fmeetings/topic/.5Bsteering.5D.202023-02-17.20review.20latency.20compiler-team.23589/near/328505647)).

thanks!

r? @JohnTitor 