### PR TITLE
Remove mention to lexer/parser refactoring

### DIFF
--- a/src/the-parser.md
+++ b/src/the-parser.md
@@ -1,8 +1,5 @@
 # Lexing and Parsing
 
-As of <!-- date-check --> January 2021, the lexer and parser are undergoing
-refactoring to allow extracting them into libraries.
-
 The very first thing the compiler does is take the program (in Unicode
 characters) and turn it into something the compiler can work with more
 conveniently than strings. This happens in two stages: Lexing and Parsing.


### PR DESCRIPTION
This removes the mention of lexer/parser refactoring.
AFAIK, there is no MCP, project, initiative, or anything else, and the work is done on a best-efforts basis.
That is, such refactoring happens on other parts of the compiler, and we can say it's just normal work, so I don't think it makes much sense to do the date check (actually, no one has asked "why hasn't it been updated" before).

cc #1627