### PR TITLE
Update date reference about infer context variables

### DIFF
--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -68,7 +68,7 @@ inference works, or perhaps this blog post on
 [Unification in the Chalk project]: http://smallcultfollowing.com/babysteps/blog/2017/03/25/unification-in-chalk-part-1/
 
 All told, the inference context stores five kinds of inference variables
-(as of <!-- date-check --> June 2021):
+(as of <!-- date-check --> March 2023):
 
 - Type variables, which come in three varieties:
   - General type variables (the most common). These can be unified with any


### PR DESCRIPTION
This hasn't been changed since 2021, see https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxtInner.html.

cc #1627