### PR TITLE
Update explnation about `Body.basic_blocks`

### DIFF
--- a/src/identifiers.md
+++ b/src/identifiers.md
@@ -65,8 +65,7 @@ See the [HIR chapter][hir-map] for more detailed information.
 
 - [`BasicBlock`] identifies a *basic block*. It points to an instance of
   [`BasicBlockData`], which can be retrieved by indexing into
-  [`Body::basic_blocks()`] (note that you must call a function; the field is
-  private).
+  [`Body.basic_blocks`].
 
 - [`Local`] identifies a local variable in a function. Its associated data is in
   [`LocalDecl`], which can be retrieved by indexing into [`Body.local_decls`].
@@ -93,7 +92,7 @@ See the [HIR chapter][hir-map] for more detailed information.
 
 [`BasicBlock`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.BasicBlock.html
 [`BasicBlockData`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.BasicBlockData.html
-[`Body::basic_blocks()`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#method.basic_blocks
+[`Body.basic_blocks`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.basic_blocks
 [`Local`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Local.html
 [`LocalDecl`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.LocalDecl.html
 [`Body.local_decls`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.local_decls


### PR DESCRIPTION
The field was made `pub` by https://github.com/rust-lang/rust/pull/98930 and #99027 removed the method.
Fixes https://github.com/rust-lang/rustc-dev-guide/issues/1626