### PR TITLE
Add documentation for RUSTC_EMIT

### DIFF
--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -366,16 +366,16 @@ recompiling all dependencies.
 `CARGOFLAGS_NOT_BOOTSTRAP` work analogously to `RUSTFLAGS_BOOTSTRAP`.
 
 `RUSTC_EMIT` will cause `bootstrap` to pass `--emit` arguments on to `rustc`.
-You can specify which `--emit` formats which are used with a comma separated list prefixed with
+You can specify which `--emit` formats are used with a comma separated list prefixed with
 a crate name and `=`, for example: `rustc_arena=llvm-ir,asm`.
 You can also substitute `*` for the crate name to apply it to all crates.
 You can combine multiple such specifiers by seperating them with semi-colons like
 `rustc_arena=llvm-ir,asm;rustc_span=asm;*=llvm-bc`.
-Currently `rustc` supports `asm`, `llvm-bc`, `llvm-ir`,
+Currently, `rustc` supports `asm`, `llvm-bc`, `llvm-ir`,
 `obj`, `metadata`, `link`, `dep-info`, and `mir` as `--emit` formats.
 The emitted files will be stored inside the `emit`
-directory in the target specific build directory.
-`RUSTC_EMIT` will not cause `bootstrap` to rebuild any crates so you may need to modify
+directory in the target-specific build directory.
+`RUSTC_EMIT` will not cause `bootstrap` to rebuild any crates, so you may need to modify
 one of the source files of the crates you're interested in.
 
 `--test-args` will pass arguments through to the test runner. For `tests/ui`, this is

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -371,9 +371,12 @@ a crate name and `=`, for example: `rustc_arena=llvm-ir,asm`.
 You can also substitute `*` for the crate name to apply it to all crates.
 You can combine multiple such specifiers by seperating them with semi-colons like
 `rustc_arena=llvm-ir,asm;rustc_span=asm;*=llvm-bc`.
-The emitted files will be stored inside the `emit` directory in the target specific build directory.
-`RUSTC_EMIT` will not cause `bootstrap` to rebuild any crates so you may need to modify the crates
-you're interested in.
+Currently `rustc` supports `asm`, `llvm-bc`, `llvm-ir`,
+`obj`, `metadata`, `link`, `dep-info`, and `mir` as `--emit` formats.
+The emitted files will be stored inside the `emit`
+directory in the target specific build directory.
+`RUSTC_EMIT` will not cause `bootstrap` to rebuild any crates so you may need to modify
+one of the source files of the crates you're interested in.
 
 `--test-args` will pass arguments through to the test runner. For `tests/ui`, this is
 compiletest; for unit tests and doctests this is the `libtest` runner. Most test runner accept

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -365,6 +365,16 @@ recompiling all dependencies.
 `CARGOFLAGS` will pass arguments to cargo itself (e.g. `--timings`). `CARGOFLAGS_BOOTSTRAP` and
 `CARGOFLAGS_NOT_BOOTSTRAP` work analogously to `RUSTFLAGS_BOOTSTRAP`.
 
+`RUSTC_EMIT` will cause `bootstrap` to pass `--emit` arguments on to `rustc`.
+You can specify which `--emit` formats which are used with a comma separated list prefixed with
+a crate name and `=`, for example: `rustc_arena=llvm-ir,asm`.
+You can also substitute `*` for the crate name to apply it to all crates.
+You can combine multiple such specifiers by seperating them with semi-colons like
+`rustc_arena=llvm-ir,asm;rustc_span=asm;*=llvm-bc`.
+The emitted files will be stored inside the `emit` directory in the target specific build directory.
+`RUSTC_EMIT` will not cause `bootstrap` to rebuild any crates so you may need to modify the crates
+you're interested in.
+
 `--test-args` will pass arguments through to the test runner. For `tests/ui`, this is
 compiletest; for unit tests and doctests this is the `libtest` runner. Most test runner accept
 `--help`, which you can use to find out the options accepted by the runner.


### PR DESCRIPTION
This adds documentation for https://github.com/rust-lang/rust/pull/108365.