### PR TITLE
Fix Rust Analyzer settings location

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -24,20 +24,20 @@ You can also install the hook as a step of running `./x.py setup`!
 `rust-analyzer` can help you check and format your code whenever you save
 a file. By default, `rust-analyzer` runs the `cargo check` and `rustfmt`
 commands, but you can override these commands to use more adapted versions
-of these tools when hacking on `rustc`. For example, `x.py setup` will prompt
+of these tools when hacking on `rustc`. For example, `x.py setup vscode` will prompt
 you to create a `.vscode/settings.json` file which will configure Visual Studio code.
 This will ask `rust-analyzer` to use `./x.py check` to check the sources, and the
 stage 0 rustfmt to format them.
-The recommended `rust-analyzer` settings live at [`src/etc/vscode_settings.json`].
+The recommended `rust-analyzer` settings live at [`src/etc/rust_analyzer_settings.json`].
 
 If you have enough free disk space and you would like to be able to run `x.py` commands while
 rust-analyzer runs in the background, you can also add `--build-dir build-rust-analyzer` to the
 `overrideCommand` to avoid x.py locking.
 
 If you're running `coc.nvim`, you can use `:CocLocalConfig` to create a
-`.vim/coc-settings.json` and copy the settings from [`src/etc/vscode_settings.json`].
+`.vim/coc-settings.json` and copy the settings from [`src/etc/rust_analyzer_settings.json`].
 
-[`src/etc/vscode_settings.json`]: https://github.com/rust-lang/rust/blob/master/src/etc/vscode_settings.json
+[`src/etc/rust_analyzer_settings.json`]: https://github.com/rust-lang/rust/blob/master/src/etc/rust_analyzer_settings.json
 
 If running `./x.py check` on save is inconvenient, in VS Code you can use a [Build
 Task] instead:


### PR DESCRIPTION
This file was moved in https://github.com/rust-lang/rust/pull/108618.
Also as of https://github.com/rust-lang/rust/pull/107848, `x setup vscode` runs this step specifically.