### PR TITLE
Rename `config.toml.example` to `config.example.toml`

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -45,7 +45,7 @@ You can install it with `cargo install --path src/tools/x`.
 To start, run `./x.py setup`. This will do some initialization and create a
 `config.toml` for you with reasonable defaults.
 
-Alternatively, you can write `config.toml` by hand. See `config.toml.example` for all the available
+Alternatively, you can write `config.toml` by hand. See `config.example.toml` for all the available
 settings and explanations of them. See `src/bootstrap/defaults` for common settings to change.
 
 If you have already built `rustc` and you change settings related to LLVM, then you may have to
@@ -188,7 +188,7 @@ Note that building for some targets requires having external dependencies instal
 (e.g. building musl targets requires a local copy of musl).
 Any target-specific configuration (e.g. the path to a local copy of musl)
 will need to be provided by your `config.toml`.
-Please see `config.toml.example` for information on target-specific configuration keys.
+Please see `config.example.toml` for information on target-specific configuration keys.
 
 For examples of the complete configuration necessary to build a target, please visit
 [the rustc book](https://doc.rust-lang.org/rustc/platform-support.html),

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -259,8 +259,8 @@ If you're using nix, you can use the following nix-shell to work on Rust:
 
 # This file contains a development shell for working on rustc.
 let
-  # Build configuration for rust-lang/rust. Based on `config.toml.example` from
-  # `1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5`.
+  # Build configuration for rust-lang/rust. Based on `config.example.toml` (then called
+  # `config.toml.example`) from `1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5`
   config = pkgs.writeText "rustc-config" ''
     profile = "compiler" # you may want to choose a different profile, like `library` or `tools`
     changelog-seen = 2
@@ -289,7 +289,7 @@ let
       # Files that are ignored by ripgrep when searching.
       ignoreFile = pkgs.writeText "rustc-rgignore" ''
         configure
-        config.toml.example
+        config.example.toml
         x.py
         LICENSE-MIT
         LICENSE-APACHE

--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -42,7 +42,7 @@ otherwise you need to disable new symbol-mangling-version in `config.toml`.
 new-symbol-mangling = false
 ```
 
-> See the comments in `config.toml.example` for more info.
+> See the comments in `config.example.toml` for more info.
 
 You will need to rebuild the compiler after changing any configuration option.
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -325,7 +325,7 @@ there's no need to block on tools changes going upstream.
 Here are those same steps in detail:
 
 1. (optional) First, if it doesn't exist already, create a `config.toml` by copying
-   `config.toml.example` in the root directory of the Rust repository.
+   `config.example.toml` in the root directory of the Rust repository.
    Set `submodules = false` in the `[build]` section. This will prevent `x.py`
    from resetting to the original branch after you make your changes. If you
    need to [update any submodules to their latest versions](#updating-submodules),


### PR DESCRIPTION
Corresponds to https://github.com/rust-lang/rust/pull/109031. Should not land if that one doesn't.