### PR TITLE
Fix "crate disambiguator" in libs-and-metadata.md

### DIFF
--- a/src/backend/libs-and-metadata.md
+++ b/src/backend/libs-and-metadata.md
@@ -103,8 +103,7 @@ The hash includes a variety of elements:
 * Hashes of the HIR nodes.
 * All of the upstream crate hashes.
 * All of the source filenames.
-* Hashes of certain command-line flags (like `-C metadata` via the [Crate
-  Disambiguator](#crate-disambiguator), and all CLI options marked with
+* Hashes of certain command-line flags (like `-C metadata` via the [Stable Crate Id](#stable-crate-id), and all CLI options marked with
   `[TRACKED]`).
 
 See [`compute_hir_hash`] for where the hash is actually computed.


### PR DESCRIPTION
"Crate disambiguator" is now called "Stable Crate Id" (see [this commit](https://github.com/rust-lang/rustc-dev-guide/commit/93422c21baca585dc88357ec886a48f6ddc7d665)).

A broken link using the obselete name is updated. No more occurrence of "crate disambiguator" remains.