### PR TITLE
Add locale_resources

### DIFF
--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -44,6 +44,7 @@ fn main() {
         output_dir: None,
         output_file: None,
         file_loader: None,
+        locale_resources: rustc_driver::DEFAULT_LOCALE_RESOURCES,
         lint_caps: rustc_hash::FxHashMap::default(),
         parse_sess_created: None,
         register_lints: None,


### PR DESCRIPTION
After adding this field it works in: `rustc 1.70.0-nightly (a266f1199 2023-03-22)`