### PR TITLE
Don't require $GITHUB_TOKEN to build locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ To build a local static HTML site, install [`mdbook`](https://github.com/rust-la
 and execute the following command in the root of the repository:
 
 ```
-> mdbook build
+> mdbook build --open
 ```
 
-The build files are found in the `book` directory.
+The build files are found in the `book/html` directory.
 
 ### Link Validations
 

--- a/book.toml
+++ b/book.toml
@@ -43,9 +43,6 @@ exclude = [
 cache-timeout = 86400
 warning-policy = "error"
 
-[output.linkcheck.http-headers]
-'github\.com' = ["Authorization: Bearer $GITHUB_TOKEN"]
-
 [output.html.redirect]
 "/compiletest.html" = "tests/compiletest.html"
 "/diagnostics/sessiondiagnostic.html" = "diagnostic-structs.html"

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -3,12 +3,16 @@
 set -e
 set -o pipefail
 
+set_github_token() {
+  jq '.config.output.linkcheck."http-headers"."github\\.com" = ["Authorization: Bearer $GITHUB_TOKEN"]'
+}
+
 # https://docs.github.com/en/actions/reference/environment-variables
 if [ "$GITHUB_EVENT_NAME" = "schedule" ] ; then # running in scheduled job
   FLAGS=""
+  USE_TOKEN=1
 
   echo "Doing full link check."
-  set -x
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ] ; then # running in PR CI build
   if [ -z "$BASE_SHA" ]; then
     echo "error: unexpected state: BASE_SHA must be non-empty in CI"
@@ -17,9 +21,9 @@ elif [ "$GITHUB_EVENT_NAME" = "pull_request" ] ; then # running in PR CI build
 
   CHANGED_FILES=$(git diff --name-only $BASE_SHA... | tr '\n' ' ')
   FLAGS="--no-cache -f $CHANGED_FILES"
+  USE_TOKEN=1
 
   echo "Checking files changed since $BASE_SHA: $CHANGED_FILES"
-  set -x
 else # running locally
   COMMIT_RANGE=master...
   CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE | tr '\n' ' ')
@@ -28,4 +32,10 @@ else # running locally
   echo "Checking files changed in $COMMIT_RANGE: $CHANGED_FILES"
 fi
 
-exec mdbook-linkcheck $FLAGS
+echo "exec mdbook-linkcheck $FLAGS"
+if [ "$USE_TOKEN" = 1 ]; then
+  config=$(set_github_token)
+  exec mdbook-linkcheck $FLAGS <<<"$config"
+else
+  exec mdbook-linkcheck $FLAGS
+fi


### PR DESCRIPTION
Mdbook currently gives a hard error if it's not set in the environment:
```
[2023-03-25T22:52:13Z ERROR mdbook_linkcheck::config] Unable to interpolate "authorization: Bearer $GITHUB_TOKEN" because Failed to retrieve `GITHUB_TOKEN` env var: environment variable not found
```

Dynamically add it in `linkcheck.sh` to avoid requiring it when we don't need it.