### PR TITLE
Update some links and information for cargo-bisect-rustc

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -269,7 +269,7 @@ on *why* it was changed.  See [this tutorial][bisect-tutorial] on how to use
 it.
 
 [bisect]: https://github.com/rust-lang/cargo-bisect-rustc
-[bisect-tutorial]: https://github.com/rust-lang/cargo-bisect-rustc/blob/master/TUTORIAL.md
+[bisect-tutorial]: https://rust-lang.github.io/cargo-bisect-rustc/tutorial.html
 
 ## Downloading Artifacts from Rust's CI
 

--- a/src/fuzzing.md
+++ b/src/fuzzing.md
@@ -87,7 +87,7 @@ Here are a few things you can do to help the Rust project after filing an ICE.
 - Minimize the test case (see below)
 - Add the minimal test case to [Glacier][glacier]
 
-[bisect]: https://github.com/rust-lang/cargo-bisect-rustc/blob/master/TUTORIAL.md
+[bisect]: https://rust-lang.github.io/cargo-bisect-rustc/
 
 ## Minimization
 

--- a/src/notification-groups/cleanup-crew.md
+++ b/src/notification-groups/cleanup-crew.md
@@ -77,11 +77,13 @@ various builds of rustc. For recent regressions, it is even able to
 use the builds from our CI to track down the regression to a specific
 PR; for older regressions, it will simply identify a nightly.
 
-To learn to use [cargo-bisect-rustc], check out [this blog
-post][learn], which gives a quick introduction to how it works. You
-can also ask questions at the Zulip stream
-[`#t-compiler/cargo-bisect-rustc`][zcbr], or help in improving the tool.
+To learn to use [cargo-bisect-rustc], check out [this blog post][learn], which
+gives a quick introduction to how it works. Additionally, there is a [Guide]
+which goes into more detail on how to use it. You can also ask questions at
+the Zulip stream [`#t-compiler/cargo-bisect-rustc`][zcbr], or help in
+improving the tool.
 
 [cargo-bisect-rustc]: https://github.com/rust-lang/cargo-bisect-rustc/
 [learn]: https://blog.rust-lang.org/inside-rust/2019/12/18/bisecting-rust-compiler.html
 [zcbr]: https://rust-lang.zulipchat.com/#narrow/stream/217417-t-compiler.2Fcargo-bisect-rustc
+[Guide]: https://rust-lang.github.io/cargo-bisect-rustc/

--- a/src/notification-groups/cleanup-crew.md
+++ b/src/notification-groups/cleanup-crew.md
@@ -85,30 +85,3 @@ can also ask questions at the Zulip stream
 [cargo-bisect-rustc]: https://github.com/rust-lang/cargo-bisect-rustc/
 [learn]: https://blog.rust-lang.org/inside-rust/2019/12/18/bisecting-rust-compiler.html
 [zcbr]: https://rust-lang.zulipchat.com/#narrow/stream/217417-t-compiler.2Fcargo-bisect-rustc
-
-### identifying the range of PRs in a nightly
-
-If the regression occurred more than 90 days ago, then
-cargo-bisect-rustc will not able to identify the particular PR that
-caused the regression, just the nightly build. In that case, we can
-identify the set of PRs that this corresponds to by using the git
-history. 
-
-The command `rustc +nightly -vV` will cause rustc to output a number
-of useful bits of version info, including the `commit-hash`. Given the
-commit-hash of two nightly versions, you can find all of PRs that have
-landed in between by taking the following steps:
-
-1. Go to an update checkout of the [rust-lang/rust] repository
-2. Execute the command `git log --author=bors --format=oneline SHA1..SHA2`
-  * This will list out all of the commits by bors, which is our merge bot
-  * Each commit corresponds to one PR, and information about the PR should be in the description
-3. Copy and paste that information into the bug report
-
-Often, just eye-balling the PR descriptions (which are included in the
-commit messages) will give you a good idea which one likely caused the
-problem. But if you're unsure feel free to just ping the compiler team
-(`@rust-lang/compiler`) or else to ping the authors of the PR
-themselves.
-
-[rust-lang/rust]: https://github.com/rust-lang/rust/


### PR DESCRIPTION
This updates some links for cargo-bisect-rustc which has a new documentation guide.
