### PR TITLE
Make REUSE ignore section heading as a copyright statement

### DIFF
--- a/src/conventions.md
+++ b/src/conventions.md
@@ -29,7 +29,10 @@ pass the <!-- date-check: nov 2022 --> `--edition=2021` argument yourself when c
 
 <a name="copyright"></a>
 
+<!-- REUSE-IgnoreStart -->
+<!-- Prevent REUSE from interpreting the heading as a copyright notice -->
 ### Copyright notice
+<!-- REUSE-IgnoreEnd -->
 
 In the past, files began with a copyright and license notice. Please **omit**
 this notice for new files licensed under the standard terms (dual


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust/issues/99414 I'm implementing support for REUSE in the rust-lang/rust repository (of which this repository is a submodule) to automatically gather licensing information.

Unfortunately REUSE is occasionally too eager to find copyright statements, and in this case it's marking `src/conventions.md` as being copyrighted by `notice`. This PR adds ignore comments to prevent that from happening.