### PR TITLE
Various improvements to `check_line_lengths.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         if: github.event_name != 'push'
         run: |
           shopt -s globstar
-          MAX_LINE_LENGTH=100 bash ci/check_line_lengths.sh src/**/*.md
+          MAX_LINE_LENGTH=100 bash ci/lengthcheck.sh src/**/*.md
 
       - name: Install latest nightly Rust toolchain
         if: steps.mdbook-cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -67,20 +67,20 @@ including the `<!-- toc -->` marker at the place where you want the TOC.
 ### Pre-commit script
 
 We also test that line lengths are less than 100 columns. To test this locally,
-you can run `ci/check_line_lengths.sh`.
+you can run `ci/lengthcheck.sh`.
 
 You can also set this to run automatically.
 
 On Linux:
 
 ```bash
-ln -s ../../ci/check_line_lengths.sh .git/hooks/pre-commit
+ln -s ../../ci/lengthcheck.sh .git/hooks/pre-commit
 ```
 
 On Windows:
 
 ```powershell
-New-Item -Path .git/hooks/pre-commit -ItemType HardLink -Value <absolute_path/to/check_line_lengths.sh>
+New-Item -Path .git/hooks/pre-commit -ItemType HardLink -Value $(Resolve-Path ci/lengthcheck.sh)
 ```
 
 ## How to fix toolstate failures

--- a/ci/check_line_lengths.sh
+++ b/ci/check_line_lengths.sh
@@ -10,8 +10,7 @@ if [ "$MAX_LINE_LENGTH" == "" ]; then
 fi
 
 if [ "$1" == "" ]; then
-  shopt -s globstar
-  files=( src/**/*.md )
+  files=( src/*.md src/*/*.md src/*/*/*.md )
 else
   files=( "$@" )
 fi

--- a/ci/check_line_lengths.sh
+++ b/ci/check_line_lengths.sh
@@ -21,7 +21,6 @@ echo "Offending files and lines:"
 (( bad_lines = 0 ))
 (( inside_block = 0 ))
 for file in "${files[@]}"; do
-  echo "$file"
   (( line_no = 0 ))
   while IFS="" read -r line || [[ -n "$line" ]] ; do
     (( line_no++ ))
@@ -33,7 +32,7 @@ for file in "${files[@]}"; do
         && ! [[ "$line" =~ " | "|"-|-"|"://"|"]:"|\[\^[^\ ]+\]: ]] \
         && (( "${#line}" > $MAX_LINE_LENGTH )) ; then
       (( bad_lines++ ))
-      echo -e "\t$line_no : $line"
+      echo -e "\t$file:$line_no : $line"
     fi
   done < "$file"
 done

--- a/ci/lengthcheck.sh
+++ b/ci/lengthcheck.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Check files for lines that are too long.
+
 if [ "$1" == "--help" ]; then
   echo 'Usage:' "[MAX_LINE_LENGTH=n] $0 [file ...]"
   exit 1

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -311,7 +311,7 @@ There are issues for beginners and advanced compiler devs alike!
 Just a few things to keep in mind:
 
 - Please limit line length to 100 characters. This is enforced by CI, and you can run the checks
-  locally with `ci/check_line_lengths.sh`.
+  locally with `ci/lengthcheck.sh`.
 
 - When contributing text to the guide, please contextualize the information with some time period
   and/or a reason so that the reader knows how much to trust or mistrust the information.


### PR DESCRIPTION
- Add compatibility for bash 3, which is the default on MacOS
- Make error messages less verbose and clickable in VSCode
- Rename check_line_lengths.sh to lengthcheck.sh

  The rename allows using tab completion to run the script. Before, `ci/check`
would stop because of the ambiguity between `check-in.sh` and
`check_line_lengths.sh`.

- Fix the powershell example in the readme to work without changes.