### PR TITLE
Fix links in how-to-build-and-run.md

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -99,10 +99,10 @@ Also, note that `x.py` supports all kinds of path suffixes for `compiler`, `libr
 and `src/tools` directories. So, you can simply run `x.py test tidy` instead of
 `x.py test src/tools/tidy`. Or, `x.py build std` instead of `x.py build library/std`.
 
-[rust-analyzer]: ./building/suggested.html#configuring-rust-analyzer-for-rustc
+[rust-analyzer]: suggested.html#configuring-rust-analyzer-for-rustc
 
-See the chapters on [building](./building/how-to-build-and-run.md),
-[testing](./tests/intro.md), and [rustdoc](./rustdoc.md) for more details.
+See the chapters on [building](how-to-build-and-run),
+[testing](../tests/intro), and [rustdoc](../rustdoc) for more details.
 
 ### Building the compiler
 


### PR DESCRIPTION
Four links were broken, either pointing to the wrong url or the wrong extension (or both). This fixes the links.