### PR TITLE
Define more lint terms.

### DIFF
--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -582,7 +582,7 @@ More information about lint registration can be found in the [LintStore]
 chapter.
 
 [deprecated plugin system]: https://doc.rust-lang.org/nightly/unstable-book/language-features/plugin.html
-[LintStore]: lintstore.md
+[LintStore]: diagnostics/lintstore.md
 
 ### Declaring a lint
 


### PR DESCRIPTION
This adds some explicit definitions of various terms used in the lint chapters *before* they are used. It can be confusing when the text uses terminology that is not defined (or is not defined until much later).

This uses some text taken from a comment by @Nilstrieb.
