### PR TITLE
Use unpretty for debugging Hir

### DIFF
--- a/src/hir-debugging.md
+++ b/src/hir-debugging.md
@@ -3,6 +3,6 @@
 The `-Z unpretty=hir-tree` flag will dump out the HIR.
 
 If you are trying to correlate `NodeId`s or `DefId`s with source code, the
-`--pretty expanded,identified` flag may be useful.
+`-Z unpretty=expanded,identified` flag may be useful.
 
 TODO: anything else? [#1159](https://github.com/rust-lang/rustc-dev-guide/issues/1159)


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/83491

`--pretty` has been removed.
