### PR TITLE
Include information about setup defaults in how-to-build guide

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -67,8 +67,11 @@ You can install it with `cargo install --path src/tools/x`.
 
 ## Create a `config.toml`
 
-To start, run `./x.py setup`. This will do some initialization and create a
-`config.toml` for you with reasonable defaults.
+To start, run `./x.py setup` and select the `compiler` defaults. This will do some initialization
+and create a `config.toml` for you with reasonable defaults. If you use a different default (which
+you'll likely want to do if you want to contribute to an area of rust other than the compiler, such
+as rustdoc), make sure to read information about that default (located in `src/bootstrap/defaults`)
+as the build process may be different for other defaults.
 
 Alternatively, you can write `config.toml` by hand. See `config.example.toml` for all the available
 settings and explanations of them. See `src/bootstrap/defaults` for common settings to change.


### PR DESCRIPTION
Currently, [the how to build and run guide](https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html) of the rustc dev guide doesn't mention anything about the default options you are given when running `./x.py setup`:

```
Welcome to the Rust project! What do you want to do with x.py?
a) library: Contribute to the standard library
b) compiler: Contribute to the compiler itself
c) codegen: Contribute to the compiler, and also modify LLVM or codegen
d) tools: Contribute to tools which depend on the compiler, but do not modify it directly (e.g. rustdoc, clippy, miri)
e) dist: Install Rust from source
f) none: Do not modify `config.toml`
Please choose one (a/b/c/d/e/f):
```

This could lead to frustration for new users (like myself) who do not fully understand how the defaults affect the build process (see https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Unable.20to.20compile.20rustc.20MSVC).

To resolve this, this PR makes a small modification can be made to the `` Create a `config.toml` `` section to:

- Mention which defaults the rest of the how-to guide uses.
- Mention where information about the other defaults can be found.