### PR TITLE
Update triagebot links.

### DIFF
--- a/src/compiler-team.md
+++ b/src/compiler-team.md
@@ -124,7 +124,7 @@ for you.
 
 [reviewer rotation]: https://github.com/rust-lang/rust/blob/36285c5de8915ecc00d91ae0baa79a87ed5858d5/triagebot.toml#L528-L577
 [triagebot]: https://github.com/rust-lang/triagebot/
-[automatically assigns]: https://github.com/rust-lang/triagebot/wiki/Assignment
+[automatically assigns]: https://forge.rust-lang.org/triagebot/pr-assignment.html
 
 Getting on the reviewer rotation is much appreciated as it lowers the
 review burden for all of us! However, if you don't have time to give

--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -14,7 +14,7 @@ Of course, you don't have to wait for new issues to be tagged! If you
 prefer, you can use the Github label for a notification group to
 search for existing issues that haven't been claimed yet.
 
-[claim the issue]: https://github.com/rust-lang/triagebot/wiki/Assignment
+[claim the issue]: https://forge.rust-lang.org/triagebot/issue-assignment.html
 
 ## List of notification groups
 
@@ -95,5 +95,5 @@ or contributors, and is typically done as part of compiler team
 triage.**
 
 [rustbot]: https://github.com/rust-lang/triagebot/
-[`ping`]: https://github.com/rust-lang/triagebot/wiki/Pinging
+[`ping`]: https://forge.rust-lang.org/triagebot/pinging.html
 [`triagebot.toml`]: https://github.com/rust-lang/rust/blob/master/triagebot.toml

--- a/src/rustbot.md
+++ b/src/rustbot.md
@@ -44,13 +44,13 @@ the `@rustbot` command will look like this:
     @rustbot label -S-waiting-on-author +S-waiting-on-review
 
 The syntax for this command is pretty loose, so there are other variants of this
-command invocation. For more details, see [the wiki page about labeling][labeling].
+command invocation. For more details, see [the docs page about labeling][labeling].
 
-[labeling]: https://github.com/rust-lang/triagebot/wiki/Labeling
+[labeling]: https://forge.rust-lang.org/triagebot/labeling.html
 
 ## Other commands
 
-If you are interested in seeing what `@rustbot` is capable of, check out its [wiki],
+If you are interested in seeing what `@rustbot` is capable of, check out its [documentation],
 which is meant as a reference for the bot and should be kept up to date every time the
 bot gets an upgrade.
 
@@ -58,6 +58,6 @@ bot gets an upgrade.
 existing commands or suggestions for new commands, feel free to reach out
 [on Zulip][zulip] or file an issue in [the triagebot repository][repo]
 
-[wiki]: https://github.com/rust-lang/triagebot/wiki
+[documentation]: https://forge.rust-lang.org/triagebot/index.html
 [zulip]: https://rust-lang.zulipchat.com/#narrow/stream/224082-t-release.2Ftriagebot
 [repo]: https://github.com/rust-lang/triagebot/


### PR DESCRIPTION
The triagebot documentation has moved to the forge as part of https://github.com/rust-lang/rust-forge/pull/687. This updates the links to the new locations.