### PR TITLE
fix(how-to-build-and-run): remove a wrong paragraph

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -5,9 +5,6 @@
 The compiler is built using a tool called `x.py`. You will need to
 have Python installed to run it.
 
-For instructions on how to install Python and other prerequisites,
-see [the `rust-lang/rust` README][readme].
-
 ## Get the source code
 
 The main repository is [`rust-lang/rust`][repo]. This contains the compiler,
@@ -15,7 +12,6 @@ the standard library (including `core`, `alloc`, `test`, `proc_macro`, etc),
 and a bunch of tools (e.g. `rustdoc`, the bootstrapping infrastructure, etc).
 
 [repo]: https://github.com/rust-lang/rust
-[readme]: https://github.com/rust-lang/rust#building-on-a-unix-like-system
 
 The very first step to work on `rustc` is to clone the repository:
 


### PR DESCRIPTION
This paragraph says that given README section have instructions on how to install Python and other prerequisites but it doesn't.

Other than that "Dependencies" section in the README is already given in this section of the rustc-dev-guide: https://rustc-dev-guide.rust-lang.org/building/prerequisites.html#dependencies So this paragraph seems not necessary.