### PR TITLE
fix(visitor.md): fix a type name in a code sample

### DIFF
--- a/src/mir/visitor.md
+++ b/src/mir/visitor.md
@@ -23,7 +23,7 @@ struct MyVisitor<...> {
 and you then implement the `Visitor` or `MutVisitor` trait for that type:
 
 ```rust,ignore
-impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
+impl<'tcx> MutVisitor<'tcx> for MyVisitor {
     fn visit_foo(&mut self, ...) {
         ...
         self.super_foo(...);


### PR DESCRIPTION
From the context, it is understood that this type is `MyVisitor`, not `NoLandingPads`.