### PR TITLE
Suggest enabling patch-binaries-for-nix in `shell.nix`

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -282,6 +282,7 @@ let
     changelog-seen = 2
 
     [build]
+    patch-binaries-for-nix = true
     # The path to (or name of) the GDB executable to use. This is only used for
     # executing the debuginfo test suite.
     gdb = "${pkgs.gdb}/bin/gdb"


### PR DESCRIPTION
Bootstraps nix detection isn't always perfect. For example in these two cases:
- https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Bootstrapping.20on.20NixOS
- https://github.com/rust-lang/rust/issues/115073