### PR TITLE
Update minor how-to-build-and-run.md spelling mistake

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -65,7 +65,7 @@ Also, using `x` rather than `x.py` is recommended as:
 Notice that this is not absolute, for instance, using Nushell in VSCode on Win10,
 typing `x` or `./x` still open the `x.py` in editor rather invoke the program :)
 
-In the rest of this guilde, we use `x` rather than `x.py` directly. The following
+In the rest of this guide, we use `x` rather than `x.py` directly. The following
 command:
 
 ```bash


### PR DESCRIPTION
As of <!-- date-check --> Aug 2023, found:
Spelling mistake "guilde" should be "guide"

This PR makes this minor correction only.

Thank you for your consideration.