### PR TITLE
The current playground link used in the page of MIR shows a optimized…

### DIFF
--- a/src/mir/index.md
+++ b/src/mir/index.md
@@ -64,7 +64,7 @@ button on the top:
 [sample-play]: https://play.rust-lang.org/?gist=30074856e62e74e91f06abd19bd72ece&version=stable
 MIR shown by above link is optimized.
 Some statements like `StorageLive` are removed in optimization.
-This happens because compiler notices the value is never accessed in the code.
+This happens because the compiler notices the value is never accessed in the code.
 We can use `rustc [filename].rs -Z mir-opt-level=0 --emit mir` to view unoptimized MIR.
 This requires the nightly toolchain.
 

--- a/src/mir/index.md
+++ b/src/mir/index.md
@@ -64,7 +64,7 @@ button on the top:
 [sample-play]: https://play.rust-lang.org/?gist=30074856e62e74e91f06abd19bd72ece&version=stable
 MIR shown by above link is optimized.
 Some statements like `StorageLive` are removed in optimization.
-This happens because compiler notices the value is never acessed in the code.
+This happens because compiler notices the value is never accessed in the code.
 We can use `rustc [filename].rs -Z mir-opt-level=0 --emit mir` to view unoptimized MIR.
 This requires the nightly toolchain.
 

--- a/src/mir/index.md
+++ b/src/mir/index.md
@@ -62,6 +62,12 @@ show you the MIR for your program. Try putting this program into play
 button on the top:
 
 [sample-play]: https://play.rust-lang.org/?gist=30074856e62e74e91f06abd19bd72ece&version=stable
+MIR shown by above link is optimized.
+Some statements like `StorageLive` are removed in optimization.
+This happens because compiler notices the value is never acessed in the code.
+We can use `rustc [filename].rs -Z mir-opt-level=0 --emit mir` to view unoptimized MIR.
+This requires the nightly toolchain.
+
 
 ```rust
 fn main() {


### PR DESCRIPTION
… version of MIR which is missing some statements. Updated to use a local command which shows unoptimized MIR which is more useful for learning.

The current playground link used in the page of MIR shows a optimized version of MIR which is missing some statements. As an example compiler sees the variable vec is never being used so it never allocates storage to it by `StorageLive` command.  `rustc [filename].rs -Z mir-opt-level=0 --emit mir ` shows an unoptimized MIR which is more useful for pedagogical purposes and is similar to the MIR code which is talked about later in the page.