### PR TITLE
Clarify that `run-coverage` only runs in some of the CI jobs

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -437,7 +437,7 @@ profiler = true
 ```
 
 This also means that they typically don't run in PR CI jobs,
-though they do run in the full set of CI jobs used for merging.
+though they do run as part of the full set of CI jobs used for merging.
 
 The tests in [`tests/run-coverage-rustdoc`] also run instrumented doctests and
 include them in the coverage report. This avoids having to build rustdoc when


### PR DESCRIPTION
I noticed this while proofreading #1790, but forgot to push it before the PR was approved.

The old text could be misread as saying that CI runs the `run-coverage` tests in *all* jobs during a merge, which is false.

The new text clarifies that they run in *some* jobs.