### PR TITLE
fix type name

### DIFF
--- a/src/serialization.md
+++ b/src/serialization.md
@@ -108,7 +108,7 @@ and `Encodable`.
 - `MetadataEncodable` and `MetadataDecodable` generate implementations that
   only allow decoding by [`rustc_metadata::rmeta::encoder::EncodeContext`] and
   [`rustc_metadata::rmeta::decoder::DecodeContext`]. These are used for types
-  that contain `rustc_metadata::rmeta::Lazy`.
+  that contain `rustc_metadata::rmeta::Lazy*`.
 - `TyEncodable` and `TyDecodable` generate implementation that apply to any
   `TyEncoder` or `TyDecoder`. These should be used for types that are only
   serialized in crate metadata and/or the incremental cache, which is most
@@ -130,7 +130,7 @@ some deserialization needs to be deferred from the initial loading of metadata.
 The [`LazyValue<T>`] type wraps the (relative) offset in the crate metadata where a
 `T` has been serialized. There are also some variants, [`LazyArray<T>`] and [`LazyTable<I, T>`].
 
-The `Lazy<[T]>` and `LazyTable<I, T>` types provide some functionality over
+The `LazyArray<[T]>` and `LazyTable<I, T>` types provide some functionality over
 `Lazy<Vec<T>>` and `Lazy<HashMap<I, T>>`:
 
 - It's possible to encode a `LazyArray<T>` directly from an iterator, without


### PR DESCRIPTION
stolen from https://github.com/rust-lang/rustc-dev-guide/pull/1758