### PR TITLE
test headers: fix `compile-flags` example

### DIFF
--- a/src/tests/headers.md
+++ b/src/tests/headers.md
@@ -190,7 +190,7 @@ The following headers are generally available, and not specific to particular
 test suites.
 
 * `compile-flags` passes extra command-line args to the compiler,
-  e.g. `compile-flags -g` which forces debuginfo to be enabled.
+  e.g. `// compile-flags: -g` which forces debuginfo to be enabled.
 * `run-flags` passes extra args to the test if the test is to be executed.
 * `edition` controls the edition the test should be compiled with
   (defaults to 2015). Example usage: `// edition:2018`.


### PR DESCRIPTION
This is more consistent with the other examples in this file such as https://github.com/rust-lang/rustc-dev-guide/blob/a13b7c28ed705891c681ce5417b3d1cdb12cecd1/src/tests/headers.md?plain=1#L196