### PR TITLE
update rustc_driver examples

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -63,6 +63,8 @@ fn main() {
         // Registry of diagnostics codes.
         registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
         make_codegen_backend: None,
+        expanded_args: Vec::new(),
+        ice_file: None,
     };
     rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -73,6 +73,8 @@ fn main() {
         override_queries: None,
         registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
         make_codegen_backend: None,
+        expanded_args: Vec::new(),
+        ice_file: None,
     };
     rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -51,6 +51,8 @@ fn main() {
         override_queries: None,
         make_codegen_backend: None,
         registry: registry::Registry::new(&rustc_error_codes::DIAGNOSTICS),
+        expanded_args: Vec::new(),
+        ice_file: None,
     };
     rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -7,7 +7,7 @@
 To get diagnostics from the compiler,
 configure `rustc_interface::Config` to output diagnostic to a buffer,
 and run `TyCtxt.analysis`. The following was tested
-with <!-- date-check: mar 2023 --> `nightly-2023-03-27`:
+with <!-- date-check: oct 2023 --> `nightly-2023-10-03`:
 
 ```rust
 {{#include ../examples/rustc-driver-getting-diagnostics.rs}}

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -5,7 +5,7 @@
 ## Getting the type of an expression
 
 To get the type of an expression, use the `global_ctxt` to get a `TyCtxt`.
-The following was tested with <!-- date-check: mar 2023 --> `nightly-2023-03-27`:
+The following was tested with <!-- date-check: oct 2023 --> `nightly-2023-10-03`:
 
 ```rust
 {{#include ../examples/rustc-driver-interacting-with-the-ast.rs}}


### PR DESCRIPTION
It's been a while since the rustc driver examples were updated and they no longer compile because new fields were added to `rustc_interface::config::Config`, so I thought I'd submit a PR to fix them up. Their values don't seem very important for the purposes of the specific examples so I just left them at their default value.