### PR TITLE
recommend `unpretty=hir` alongside `unpretty=hir-tree`

### DIFF
--- a/src/hir-debugging.md
+++ b/src/hir-debugging.md
@@ -1,6 +1,13 @@
 # HIR Debugging
 
-The `-Z unpretty=hir-tree` flag will dump out the HIR.
+Use the `-Z unpretty=hir` flag to produce a human-readable representation of the HIR.
+For cargo projects this can be done with `cargo rustc -- -Z unpretty=hir`.
+This output is useful when you need to see at a glance how your code was desugared and transformed
+during AST lowering.
+
+For a full `Debug` dump of the data in the HIR, use the `-Z unpretty=hir-tree` flag.
+This may be useful when you need to see the full structure of the HIR from the perspective of the
+compiler.
 
 If you are trying to correlate `NodeId`s or `DefId`s with source code, the
 `-Z unpretty=expanded,identified` flag may be useful.


### PR DESCRIPTION
Previously at no point in the guide did we recommend `unpretty=hir`, only `unpretty=hir-tree`. I'm not sure if `unpretty=hir` existed when this chapter was written.

related: https://github.com/rust-lang/rustc-dev-guide/issues/1159

I noticed that there's some duplicate information between here and the parent chapter https://rustc-dev-guide.rust-lang.org/hir.html I may try to merge https://rustc-dev-guide.rust-lang.org/hir-debugging.html into its parent in another PR.