### PR TITLE
[suggested.md] remove deprecated `changelog-seen` from `shell.nix`

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -277,7 +277,6 @@ let
   # `config.toml.example`) from `1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5`
   config = pkgs.writeText "rustc-config" ''
     profile = "compiler" # you may want to choose a different profile, like `library` or `tools`
-    changelog-seen = 2
 
     [build]
     patch-binaries-for-nix = true


### PR DESCRIPTION
I noticed the following warning
```
WARNING: The use of `changelog-seen` is deprecated. Please refer to `change-id` option in `config.example.toml` instead.
```

It would be nice to also resolve this warning
```
WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.
note: to silence this warning, add `change-id = 115898` at the top of `config.toml`
```
but I can't think of a sensible way to include the `change-id` in `shell.nix`