### PR TITLE
Include `glibc.static` in `shell.nix`

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -329,7 +329,7 @@ in
 pkgs.mkShell {
   name = "rustc";
   nativeBuildInputs = with pkgs; [
-    gcc9 binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
+    gcc9 binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils glibc.static
   ];
   RIPGREP_CONFIG_PATH = ripgrepConfig;
   RUST_BOOTSTRAP_CONFIG = config;


### PR DESCRIPTION
This is now required to link [tests/ui/process/nofile-limit.rs](https://github.com/rust-lang/rust/blob/724ba7fe9084e607c79e7656ac173eb617d173f5/tests/ui/process/nofile-limit.rs)