### PR TITLE
remove change-id from sample build configuration

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -277,7 +277,6 @@ let
   # `config.toml.example`) from `1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5`
   config = pkgs.writeText "rustc-config" ''
     profile = "compiler" # you may want to choose a different profile, like `library` or `tools`
-    change-id = 115898
 
     [build]
     patch-binaries-for-nix = true


### PR DESCRIPTION
Since the change-id is frequently updated alongside breaking changes in the build configuration, keeping the change-id in sample configurations synced with the latest change-id becomes challenging. To address this, we are removing the change-id from the sample configurations so that users can directly view the logs and decide whether to use it or not.

ref https://github.com/rust-lang/rust/pull/115898#issuecomment-1775909050