### PR TITLE
Update name of "active" features to "unstable"

### DIFF
--- a/src/feature-gates.md
+++ b/src/feature-gates.md
@@ -20,12 +20,12 @@ See ["Stability in code"][adding] in the "Implementing new features" section for
 
 To remove a feature gate, follow these steps:
 
-1. Remove the feature gate declaration in `rustc_feature/src/active.rs`.
+1. Remove the feature gate declaration in `rustc_feature/src/unstable.rs`.
    It will look like this:
 
    ```rust,ignore
    /// description of feature
-   (active, $feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $feature_name, "$version", Some($tracking_issue_number), $edition)
    ```
 
 2. Add a modified version of the feature gate declaration that you just
@@ -45,12 +45,12 @@ To remove a feature gate, follow these steps:
 To rename a feature gate, follow these steps (the first two are the same steps
 to follow when [removing a feature gate][removing]):
 
-1. Remove the old feature gate declaration in `rustc_feature/src/active.rs`.
+1. Remove the old feature gate declaration in `rustc_feature/src/unstable.rs`.
    It will look like this:
 
    ```rust,ignore
    /// description of feature
-   (active, $old_feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $old_feature_name, "$version", Some($tracking_issue_number), $edition)
    ```
 
 2. Add a modified version of the old feature gate declaration that you just
@@ -64,12 +64,12 @@ to follow when [removing a feature gate][removing]):
    ```
 
 3. Add a feature gate declaration with the new name to
-   `rustc_feature/src/active.rs`. It should look very similar to the old
+   `rustc_feature/src/unstable.rs`. It should look very similar to the old
    declaration:
 
    ```rust,ignore
    /// description of feature
-   (active, $new_feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $new_feature_name, "$version", Some($tracking_issue_number), $edition)
    ```
 
 

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -123,12 +123,12 @@ a new unstable feature:
 
 1. Add the feature name to `rustc_span/src/symbol.rs` in the `Symbols {...}` block.
 
-1. Add a feature gate declaration to `rustc_feature/src/active.rs` in the active
+1. Add a feature gate declaration to `rustc_feature/src/unstable.rs` in the unstable
    `declare_features` block.
 
    ```rust ignore
    /// description of feature
-   (active, $feature_name, "CURRENT_RUSTC_VERSION", Some($tracking_issue_number), $edition)
+   (unstable, $feature_name, "CURRENT_RUSTC_VERSION", Some($tracking_issue_number), $edition)
    ```
 
    where `$edition` has the type `Option<Edition>`, and is typically just `None`. If you haven't yet
@@ -140,7 +140,7 @@ a new unstable feature:
 
    ```rust ignore
    /// Allows defining identifiers beyond ASCII.
-   (active, non_ascii_idents, "CURRENT_RUSTC_VERSION", Some(55467), None),
+   (unstable, non_ascii_idents, "CURRENT_RUSTC_VERSION", Some(55467), None),
    ```
 
    Features can be marked as incomplete, and trigger the warn-by-default [`incomplete_features`

--- a/src/stabilization_guide.md
+++ b/src/stabilization_guide.md
@@ -109,7 +109,7 @@ to stabilize, something like (this example is taken from
 
 ```rust,ignore
 // pub(restricted) visibilities (RFC 1422)
-(active, pub_restricted, "CURRENT_RUSTC_VERSION", Some(32409)),
+(unstable, pub_restricted, "CURRENT_RUSTC_VERSION", Some(32409)),
 ```
 
 The above line should be moved down to the area for "accepted"


### PR DESCRIPTION
The name for active features was changed to unstable in https://github.com/rust-lang/rust/pull/116550