### PR TITLE
Remove feature edition fields.

### DIFF
--- a/src/feature-gates.md
+++ b/src/feature-gates.md
@@ -25,7 +25,7 @@ To remove a feature gate, follow these steps:
 
    ```rust,ignore
    /// description of feature
-   (unstable, $feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $feature_name, "$version", Some($tracking_issue_number))
    ```
 
 2. Add a modified version of the feature gate declaration that you just
@@ -33,7 +33,7 @@ To remove a feature gate, follow these steps:
 
    ```rust,ignore
    /// description of feature
-   (removed, $old_feature_name, "$version", Some($tracking_issue_number), $edition,
+   (removed, $old_feature_name, "$version", Some($tracking_issue_number),
     Some("$why_it_was_removed"))
    ```
 
@@ -50,7 +50,7 @@ to follow when [removing a feature gate][removing]):
 
    ```rust,ignore
    /// description of feature
-   (unstable, $old_feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $old_feature_name, "$version", Some($tracking_issue_number))
    ```
 
 2. Add a modified version of the old feature gate declaration that you just
@@ -59,7 +59,7 @@ to follow when [removing a feature gate][removing]):
    ```rust,ignore
    /// description of feature
    /// Renamed to `$new_feature_name`
-   (removed, $old_feature_name, "$version", Some($tracking_issue_number), $edition,
+   (removed, $old_feature_name, "$version", Some($tracking_issue_number),
     Some("renamed to `$new_feature_name`"))
    ```
 
@@ -69,7 +69,7 @@ to follow when [removing a feature gate][removing]):
 
    ```rust,ignore
    /// description of feature
-   (unstable, $new_feature_name, "$version", Some($tracking_issue_number), $edition)
+   (unstable, $new_feature_name, "$version", Some($tracking_issue_number))
    ```
 
 

--- a/src/implementing_new_features.md
+++ b/src/implementing_new_features.md
@@ -128,10 +128,10 @@ a new unstable feature:
 
    ```rust ignore
    /// description of feature
-   (unstable, $feature_name, "CURRENT_RUSTC_VERSION", Some($tracking_issue_number), $edition)
+   (unstable, $feature_name, "CURRENT_RUSTC_VERSION", Some($tracking_issue_number))
    ```
 
-   where `$edition` has the type `Option<Edition>`, and is typically just `None`. If you haven't yet
+   If you haven't yet
    opened a tracking issue (e.g. because you want initial feedback on whether the feature is likely
    to be accepted), you can temporarily use `None` - but make sure to update it before the PR is
    merged!


### PR DESCRIPTION
The edition field in the feature definition was removed in https://github.com/rust-lang/rust/pull/118802, so it should no longer be specified.
