### PR TITLE
Suggest `gcc_multi` to make `mir_opts` run on nixos

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -328,7 +328,7 @@ in
 pkgs.mkShell {
   name = "rustc";
   nativeBuildInputs = with pkgs; [
-    gcc9 binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
+    gcc_multi binutils cmake ninja openssl pkgconfig python39 git curl cacert patchelf nix psutils
   ];
   RIPGREP_CONFIG_PATH = ripgrepConfig;
   RUST_BOOTSTRAP_CONFIG = config;


### PR DESCRIPTION
`./x.py test mir_opts` requires a cross-architecture toolchain. `gcc_multi` seems to have everything needed for it to run on NixOS. I hope there was no particular reason to pin `gcc9` in particular; `gcc_multi` uses the latest available `gcc`. 