### PR TITLE
Expand upon PR guidelines

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -263,6 +263,19 @@ to put the "closes #123" text in the PR description rather than the issue commit
 particularly during rebasing, citing the issue number in the commit can "spam"
 the issue in question.
 
+However, if your PR fixes a stable-to-beta or stable-to-stable regression and has
+been accepted for a beta and/or stable backport (i.e., it is marked `beta-accepted`
+and/or `stable-accepted`), please do *not* use any such keywords since we don't
+want the corresponding issue to get auto-closed once the fix lands on master.
+Please update the PR description while still mentioning the issue somewhere.
+For example, you could write `Fixes (after beta backport) #NNN.`.
+
+As for further actions, please keep a sharp look-out for a PR whose title begins with
+`[beta]` or `[stable]` and which backports the PR in question. When that one gets
+merged, the relevant issue can be closed. The closing comment should mention all
+PRs that were involved. If you don't have the permissions to close the issue, please
+leave a comment on the original PR asking the reviewer to close it for you.
+
 [labeling]: ./rustbot.md#issue-relabeling
 [closing-keywords]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -243,15 +243,19 @@ The CI will also run tidy and will fail if tidy fails.
 Rust follows a _no merge-commit policy_, meaning, when you encounter merge
 conflicts you are expected to always rebase instead of merging.  E.g. always use
 rebase when bringing the latest changes from the master branch to your feature
-branch.
+branch. If your PR contains merge commits, it will get marked as `has-merge-commits`.
+Once you have removed the merge commits, e.g., through an interactive rebase, you
+should remove the label again:
+
+    @rustbot label -has-merge-commits
+
+See [this chapter][labeling] for more details.
 
 If you encounter merge conflicts or when a reviewer asks you to perform some
 changes, your PR will get marked as `S-waiting-on-author`. When you resolve
 them, you should use `@rustbot` to mark it as `S-waiting-on-review`:
 
     @rustbot label -S-waiting-on-author +S-waiting-on-review
-
-See [this chapter][labeling] for more details.
 
 GitHub allows [closing issues using keywords][closing-keywords]. This feature
 should be used to keep the issue tracker tidy. However, it is generally preferred


### PR DESCRIPTION
### Mention label has-merge-commits

At some point we added the label <kbd>has-merge-commits</kbd> which gets automatically added if a PR has merge commits. In rust-lang/rust#119938, @Nilstrieb has made it possible for unauthorized users to remove it via `@rustbot` which makes perfect sense since it doesn't get removed automatically.

I've added a paragraph for this since we didn't mention this label at all.

### Add guidelines for backport-accepted PRs

This one codifies another case of “tribal knowledge”: Basically, one shouldn't use `Fixes #NNN` in <kbd>{stable,beta}-accepted</kbd> PRs that fix stable-to-{stable,beta} regressions. I don't think I need to further justify this but just in case I do, cc this age-old comment https://github.com/rust-lang/rust/issues/52873#issuecomment-437011639 and this recent PR rust-lang/rust#119477.