### PR TITLE
Remove outdated references to `-Z dump-mir-spanview`

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -241,24 +241,6 @@ $ dot -T pdf maybe_init_suffix.dot > maybe_init_suffix.pdf
 $ firefox maybe_init_suffix.pdf # Or your favorite pdf viewer
 ```
 
-## Viewing Spanview output (.html files)
-[viewing-spanview-output]: #viewing-spanview-output
-
-In addition to [graphviz output](#formatting-graphviz-output-dot-files), MIR debugging
-flags include an option to generate a MIR representation called `Spanview` that
-uses HTML to highlight code regions in the original source code and display
-compiler metadata associated with each region.
-[`-Z dump-mir-spanview`](./mir/debugging.md), for example, highlights spans
-associated with each MIR `Statement`, `Terminator`, and/or `BasicBlock`.
-
-These `.html` files use CSS features to dynamically expand spans obscured by
-overlapping spans, and native tooltips (based on the HTML `title` attribute) to
-reveal the actual MIR elements, as text.
-
-To view these files, simply use a modern browser, or a CSS-capable HTML preview
-feature in a modern IDE. (The default HTML preview pane in *VS Code* is known to
-work, for instance.)
-
 ## Narrowing (Bisecting) Regressions
 
 The [cargo-bisect-rustc][bisect] tool can be used as a quick and easy way to

--- a/src/mir/debugging.md
+++ b/src/mir/debugging.md
@@ -8,11 +8,6 @@ additional output formats, including:
 control-flow graph
 * `-Z dump-mir-dataflow` - dumps a `.dot` file showing the [dataflow state] at
   each point in the control-flow graph
-* `-Z dump-mir-spanview` - dumps an `.html` file that highlights the source
-spans associated with MIR elements (including mouse-over actions to reveal
-elements obscured by overlaps, and tooltips to view the MIR statements).
-This flag takes an optional value: `statement` (the default), `terminator`, or
-`block`, to generate span highlights with different levels of granularity.
 
 `-Z dump-mir=F` is a handy compiler option that will let you view the MIR for
 each function at each stage of compilation. `-Z dump-mir` takes a **filter** `F`

--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -354,9 +354,9 @@ There are several forms the `EMIT_MIR` comment can take:
 
   This is useful if you want to see how an optimization changes the MIR.
 
-* `// EMIT_MIR $MIR_PATH.dot` or `$MIR_PATH.html` — These are special cases
-  for other MIR outputs (via `-Z dump-mir-graphviz` and `-Z dump-mir-spanview`)
-  that will check that the output matches the given file.
+* `// EMIT_MIR $MIR_PATH.dot` — When using specific flags that dump additional
+  MIR data (e.g. `-Z dump-mir-graphviz` to produce `.dot` files), this will
+  check that the output matches the given file.
 
 By default 32 bit and 64 bit targets use the same dump files, which can be
 problematic in the presence of pointers in constants or other bit width


### PR DESCRIPTION
This flag was removed by <https://github.com/rust-lang/rust/pull/119566>.