### PR TITLE
Upgrade actions to use Node.js v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,21 +22,21 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # linkcheck needs the base commit.
           fetch-depth: 0
 
       - name: Cache binaries
         id: mdbook-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin
           key: ${{ runner.os }}-${{ env.MDBOOK_VERSION }}--${{ env.MDBOOK_LINKCHECK_VERSION }}--${{ env.MDBOOK_TOC_VERSION }}--${{ env.MDBOOK_MERMAID_VERSION }}
 
       - name: Cache linkcheck
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/book/linkcheck

--- a/.github/workflows/date-check.yml
+++ b/.github/workflows/date-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Ensure Rust is up-to-date
         run: |
@@ -27,7 +27,7 @@ jobs:
           cargo run -- ../../src/ > ../../date-check-output.txt
 
       - name: Open issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Account for https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/