### PR TITLE
Add link in salsa

### DIFF
--- a/src/salsa.md
+++ b/src/salsa.md
@@ -11,7 +11,7 @@ Matsakis.
 
 > As of <!-- date-check --> November 2022, although Salsa is inspired by
 > (among other things) rustc's query system, it is not used directly in rustc.
-> It _is_ used in [chalk], the library for the trait system, and extensively in
+> It _is_ used in [chalk], an implementation of  Rust's trait system, and extensively in
 > [`rust-analyzer`], the official implementation of the language server protocol for Rust, but
 > there are no  medium or long-term concrete plans to integrate it into the
 > compiler.

--- a/src/salsa.md
+++ b/src/salsa.md
@@ -11,8 +11,14 @@ Matsakis.
 
 > As of <!-- date-check --> November 2022, although Salsa is inspired by
 > (among other things) rustc's query system, it is not used directly in rustc.
-> It _is_ used in chalk and extensively in `rust-analyzer`, but there are no
-> medium or long-term concrete plans to integrate it into the compiler.
+> It _is_ used in [chalk], the library for the trait system, and extensively in
+> [`rust-analyzer`], the implementation of the language server protocol, but
+> there are no  medium or long-term concrete plans to integrate it into the
+> compiler.
+
+
+[`rust-analyzer`]: https://rust-analyzer.github.io/
+[chalk]: https://rust-lang.github.io/chalk/book/what_is_chalk.html
 
 ## What is Salsa?
 

--- a/src/salsa.md
+++ b/src/salsa.md
@@ -12,7 +12,7 @@ Matsakis.
 > As of <!-- date-check --> November 2022, although Salsa is inspired by
 > (among other things) rustc's query system, it is not used directly in rustc.
 > It _is_ used in [chalk], the library for the trait system, and extensively in
-> [`rust-analyzer`], the implementation of the language server protocol, but
+> [`rust-analyzer`], the official implementation of the language server protocol for Rust, but
 > there are no  medium or long-term concrete plans to integrate it into the
 > compiler.
 


### PR DESCRIPTION
First, this add link to chalk and rust-analyzer. 
Secondly, it gives a very short statement explaining what it is.
I assume I won't be the only reader who don't know exactly what rust-analyzer is (it analyze rust, but that's vague), and no idea what chalk is. Those few words ensure we don't need to click the link to get a slight idea. This show what kind of usage Salsa is for