### PR TITLE
Add links for arena and interning.

### DIFF
--- a/src/memory.md
+++ b/src/memory.md
@@ -6,7 +6,7 @@ it will take a lot of time and space to do so.
 
 One of the main way the compiler manages this is using [arena]s and [interning].
 
-[arena]: (https://en.wikipedia.org/w/index.php?title=Arena_allocation)
+[arena]: https://en.wikipedia.org/wiki/Region-based_memory_management
 [interning]: https://en.wikipedia.org/wiki/String_interning
 
 ## Arenas and  Interning

--- a/src/memory.md
+++ b/src/memory.md
@@ -4,7 +4,10 @@ Rustc tries to be pretty careful how it manages memory. The compiler allocates
 _a lot_ of data structures throughout compilation, and if we are not careful,
 it will take a lot of time and space to do so.
 
-One of the main way the compiler manages this is using arenas and interning.
+One of the main way the compiler manages this is using [arena]s and [interning].
+
+[arena]: (https://en.wikipedia.org/w/index.php?title=Arena_allocation)
+[interning]: https://en.wikipedia.org/wiki/String_interning
 
 ## Arenas and  Interning
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -254,7 +254,7 @@ sure that identical values (e.g. types in your program) are only allocated once
 and can be compared cheaply by comparing pointers. Many of the intermediate
 representations are interned.
 
-[arena]: https://en.wikipedia.org/w/index.php?title=Arena_allocation
+[arena]: https://en.wikipedia.org/wiki/Region-based_memory_management
 
 ### Queries
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -246,12 +246,15 @@ for different purposes:
   optimizations on it.
 
 One other thing to note is that many values in the compiler are _interned_.
-This is a performance and memory optimization in which we allocate the values
-in a special allocator called an _arena_. Then, we pass around references to
-the values allocated in the arena. This allows us to make sure that identical
-values (e.g. types in your program) are only allocated once and can be compared
-cheaply by comparing pointers. Many of the intermediate representations are
-interned.
+This is a performance and memory optimization in which we allocate the values in
+a special allocator called an
+_[arena]_. Then, we pass
+around references to the values allocated in the arena. This allows us to make
+sure that identical values (e.g. types in your program) are only allocated once
+and can be compared cheaply by comparing pointers. Many of the intermediate
+representations are interned.
+
+[arena]: https://en.wikipedia.org/w/index.php?title=Arena_allocation
 
 ### Queries
 


### PR DESCRIPTION
I suspect that people who don't already know about arenas may be interested in the wikipedia page. It may not be the best material on this topic, but I could not find anything that is specific to the arena used by rustc, and this is still a good first approach.

I also copied the link about interning from overview to memory, as the reader may have forgotten that interning was already discussed previously.  Admittedly, the wikipedia page is called string interning, but it mentions "Objects other than strings can be interned.", and still explains the idea in a useful manner.

I suspect it may also be useful to link to
https://en.wikipedia.org/wiki/Hash_consing , as it seems the standard way to ensure that each tree (in this case, the AST of a type) is unique in memory. Except that I don't know whether it's actually what Rust uses.