### PR TITLE
update link to rustc dependencies

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
 
-See [the `rust-lang/rust` README](https://github.com/rust-lang/rust#dependencies).
+See [the `rust-lang/rust` INSTALL](https://github.com/rust-lang/rust/blob/master/INSTALL.md#dependencies).
 
 ## Hardware
 


### PR DESCRIPTION
The rust repo's README was split up, so the link in the dev guide isn't pointing to the right place anymore which can make it unnecessarily difficult to find the list of denendencies, e.g. `CONTRIBUTING` doesn't list them.