### PR TITLE
Replace letters by foo, bar and buz in lexing example

### DIFF
--- a/src/the-parser.md
+++ b/src/the-parser.md
@@ -5,8 +5,8 @@ characters) and turn it into something the compiler can work with more
 conveniently than strings. This happens in two stages: Lexing and Parsing.
 
 Lexing takes strings and turns them into streams of [tokens]. For example,
-`a.b + c` would be turned into the tokens `a`, `.`, `b`, `+`, and `c`.
-The lexer lives in [`rustc_lexer`][lexer].
+`foo.bar + buz` would be turned into the tokens `foo`, `.`,
+`bar`, `+`, and `buz`.  The lexer lives in [`rustc_lexer`][lexer].
 
 [tokens]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/token/index.html
 [lexer]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lexer/index.html


### PR DESCRIPTION
The way the example is written, it may seems like the output is just a list of meaningful character. I suspect it may be helpful to readers not used to lexers to show that a token may be multiple characters long.