### PR TITLE
Improving macro expansion section

### DIFF
--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -292,13 +292,8 @@ macro_rules! foo { () => { println!(); } }
 fn main() { foo!(); }
 ```
 
-In this code, the AST nodes that are finally generated would have hierarchy:
-
-```
-root
-    expn_id_foo
-        expn_id_println
-```
+In this code, the AST nodes that are finally generated would have hierarchy
+`root -> id(foo) -> id(println)`.
 
 ### The Macro Definition Hierarchy
 
@@ -397,8 +392,9 @@ macro foo($i: ident) { $i }
 foo!(bar!(baz));
 ```
 
-For the `baz` AST node in the final output, the first hierarchy is `ROOT ->
-id(foo) -> id(bar) -> baz`, while the third hierarchy is `ROOT -> baz`.
+For the `baz` AST node in the final output, the expansion-order hierarchy is
+`ROOT -> id(foo) -> id(bar) -> baz`, while the call-site hierarchy is `ROOT ->
+baz`.
 
 ### Macro Backtraces
 


### PR DESCRIPTION
The first example is rewritten to follow the style of other examples:
* Using `id(foo)` instead of `expn_id_foo`.
* Using a single-line with arrow instead of a multi-line indented hierarchy.

If there is a diffrence and this rewritting is wrong, it would be interesting to explain it.

Also, this commit replace "first hierarchy" and "third hierarchy" by their name, ensuring it's more clear what is referred here. In particular, for the first hierarchy, it can be searched easier in the page if needed.