### PR TITLE
Clarify what rt.rs is.

### DIFF
--- a/src/panic-implementation.md
+++ b/src/panic-implementation.md
@@ -107,6 +107,7 @@ responsible for unwinding the stack, running any 'landing pads' associated
 with each frame (currently, running destructors), and transferring control
 to the `catch_unwind` frame.
 
-Note that all panics either abort the process or get caught by some call to `catch_unwind`:
-in `library/std/src/rt.rs`, the call to the user-provided
-`main` function is wrapped in `catch_unwind`.
+Note that all panics either abort the process or get caught by some call to
+`catch_unwind`. In particular, std's [runtime
+service](https://github.com/rust-lang/rust/blob/master/library/std/src/rt.rs)
+wrap the call to the user-provided `main` function is wrapped in `catch_unwind`.


### PR DESCRIPTION
Most files names are relatively explicit and probably don't need to be explicited.  However `rt.rs` is really not clear, and I believe it clarifies the text to indicate this is runtime service implementation.