### PR TITLE
Update for upcoming markdown changes.

### DIFF
--- a/src/borrow_check/drop_check.md
+++ b/src/borrow_check/drop_check.md
@@ -152,3 +152,5 @@ One possible way these inconsistencies can be fixed is by MIR building
 to be more pessimistic, probably by making `Ty::needs_drop` weaker, or
 alternatively, changing `dropck_outlives` to be more precise, requiring
 fewer regions to be live.
+
+[^core]: This is the core assumption of [#110288](https://github.com/rust-lang/rust/issues/110288) and [RFC 3417](https://github.com/rust-lang/rfcs/pull/3417).

--- a/src/building/bootstrapping.md
+++ b/src/building/bootstrapping.md
@@ -429,7 +429,7 @@ Building rustdoc for stage1 (x86_64-unknown-linux-gnu)
 These steps use the provided (downloaded, usually) compiler to compile the
 local Rust source into libraries we can use.
 
-### Copying stage0 {std,rustc}
+### Copying stage0 \{std,rustc\}
 
 This copies the library and compiler artifacts from Cargo into
 `stage0-sysroot/lib/rustlib/{target-triple}/lib`

--- a/src/llvm-coverage-instrumentation.md
+++ b/src/llvm-coverage-instrumentation.md
@@ -247,10 +247,9 @@ properly-configured variables in LLVM IR, according to very specific
 details of the [_LLVM Coverage Mapping Format_][coverage-mapping-format]
 (Version 6).[^llvm-and-covmap-versions]
 
-[^llvm-and-covmap-versions]:
-The Rust compiler (as of <!-- date-check: --> Jul 2023) supports _LLVM Coverage Mapping Format_ 6.
-The Rust compiler will automatically use the most up-to-date coverage mapping format
-version that is compatible with the compiler's built-in version of LLVM.
+[^llvm-and-covmap-versions]: The Rust compiler (as of <!-- date-check: --> Jul 2023) supports _LLVM Coverage Mapping Format_ 6.
+    The Rust compiler will automatically use the most up-to-date coverage mapping format
+    version that is compatible with the compiler's built-in version of LLVM.
 
 ```rust
 pub fn finalize<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {


### PR DESCRIPTION
An upcoming version of mdbook will have some minor changes in how it interprets markdown to better conform with the standards. The changes are:

* Fixed the missing footnote definition for `[^core]`.
* Headings now allow arbitrary attributes inside curly braces at the end to set HTML attributes. There was one heading where this caused it to be misinterpreted as an attribute. Fixed by using backslashes to avoid the attribute parsing.
* The `llvm-and-covmap-versions` footnote wasn't following GitHub-flavor footnote syntax. I adjusted it so it works in both the old and new versions.