### PR TITLE
Use different type in an example

### DIFF
--- a/src/ty.md
+++ b/src/ty.md
@@ -281,7 +281,7 @@ modules choose to import a larger or smaller set of names explicitly.
 Let's consider the example of a type like `MyStruct<u32>`, where `MyStruct` is defined like so:
 
 ```rust,ignore
-struct MyStruct<T> { x: u32, y: T }
+struct MyStruct<T> { x: str, y: T }
 ```
 
 The type `MyStruct<u32>` would be an instance of `TyKind::Adt`:

--- a/src/ty.md
+++ b/src/ty.md
@@ -281,7 +281,7 @@ modules choose to import a larger or smaller set of names explicitly.
 Let's consider the example of a type like `MyStruct<u32>`, where `MyStruct` is defined like so:
 
 ```rust,ignore
-struct MyStruct<T> { x: str, y: T }
+struct MyStruct<T> { x: u8, y: T }
 ```
 
 The type `MyStruct<u32>` would be an instance of `TyKind::Adt`:


### PR DESCRIPTION
Sentences such as «without the argument u32» were ambiguous, as there were two distincts u32. Having a single one, the one in the monomorphization of the type, remove the ambiguity.