### PR TITLE
[MCP 723] Rename AstConv to HIR ty lowering

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -97,7 +97,7 @@
     - [Feature Gate Checking](./feature-gate-ck.md)
     - [Lang Items](./lang-items.md)
 - [The HIR (High-level IR)](./hir.md)
-    - [Lowering AST to HIR](./lowering.md)
+    - [Lowering AST to HIR](./ast-lowering.md)
     - [Debugging](./hir-debugging.md)
 - [The THIR (Typed High-level IR)](./thir.md)
 - [The MIR (Mid-level IR)](./mir/index.md)

--- a/src/ast-lowering.md
+++ b/src/ast-lowering.md
@@ -1,6 +1,6 @@
-# Lowering
+# AST lowering
 
-The lowering step converts AST to [HIR](hir.html).
+The AST lowering step converts AST to [HIR](hir.html).
 This means many structures are removed if they are irrelevant
 for type analysis or similar syntax agnostic analyses. Examples
 of such structures include but are not limited to

--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -519,7 +519,7 @@ are:
     macros.
 
 - Early lint pass: Works on [AST nodes] after [macro expansion] and name
-  resolution, just before [HIR lowering]. These lints are for purely
+  resolution, just before [AST lowering]. These lints are for purely
   syntactical lints.
   - Example: The [`unused_parens`] lint checks for parenthesized-expressions
     in situations where they are not needed, like an `if` condition.
@@ -550,7 +550,7 @@ compiler](#linting-early-in-the-compiler).
 
 
 [AST nodes]: the-parser.md
-[HIR lowering]: lowering.md
+[AST lowering]: ast-lowering.md
 [HIR nodes]: hir.md
 [MIR nodes]: mir/index.md
 [macro expansion]: macro-expansion.md

--- a/src/overview.md
+++ b/src/overview.md
@@ -83,7 +83,7 @@ returned from the parser while the standard [`Diag`] API is used
 for error handling. Generally Rust's compiler will try to recover from errors
 by parsing a superset of Rust's grammar, while also emitting an error type.
 
-### `HIR` lowering
+### `AST` lowering
 
 Next the `AST` is converted into [High-Level Intermediate Representation
 (`HIR`)][hir], a more compiler-friendly representation of the `AST`. This process
@@ -410,7 +410,7 @@ For more details on bootstrapping, see
   - Guide: [The HIR](hir.md)
   - Guide: [Identifiers in the HIR](hir.md#identifiers-in-the-hir)
   - Guide: [The `HIR` Map](hir.md#the-hir-map)
-  - Guide: [Lowering `AST` to HIR](lowering.md)
+  - Guide: [Lowering `AST` to `HIR`](ast-lowering.md)
   - How to view `HIR` representation for your code `cargo rustc -- -Z unpretty=hir-tree`
   - Rustc `HIR` definition: [`rustc_hir`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/index.html)
   - Main entry point: **TODO**

--- a/src/turbofishing-and-early-late-bound.md
+++ b/src/turbofishing-and-early-late-bound.md
@@ -113,8 +113,8 @@ fn main() {
     accepts_fn(f);
 }
 ```
-Maybe we can just special case astconv for `_`/`'_` arguments for late bound parameters somehow
-and have it not mean the same thing as `_` for early bound parameters. Regardless I think we
-would need a solution that would allow writing the above code even if it was done by some new
-syntax such as havign to write `late::<k#no_argument, 'static>` (naturally `k#no_argument`
-would only make sense as an argument to late bound parameters).
+Maybe we can just special case HIR ty lowering for `_`/`'_` arguments for late bound
+parameters somehow and have it not mean the same thing as `_` for early bound parameters.
+Regardless I think we would need a solution that would allow writing the above code even
+if it was done by some new syntax such as having to write `late::<k#no_argument, 'static>`
+(naturally `k#no_argument` would only make sense as an argument to late bound parameters).

--- a/src/ty.md
+++ b/src/ty.md
@@ -73,12 +73,12 @@ HIR is built directly from the AST, so it happens before any `ty::Ty` is produce
 HIR is built, some basic type inference and type checking is done. During the type inference, we
 figure out what the `ty::Ty` of everything is and we also check if the type of something is
 ambiguous. The `ty::Ty` is then used for type checking while making sure everything has the
-expected type. The [`astconv` module][astconv] is where the code responsible for converting a
-`rustc_hir::Ty` into a `ty::Ty` is located. The main routine used is `ast_ty_to_ty`. This occurs
-during the type-checking phase, but also in other parts of the compiler that want to ask
+expected type. The [`hir_ty_lowering` module][hir_ty_lowering] is where the code responsible for
+lowering a `rustc_hir::Ty` to a `ty::Ty` is located. The main routine used is `lower_ty`.
+This occurs during the type-checking phase, but also in other parts of the compiler that want to ask
 questions like "what argument types does this function expect?"
 
-[astconv]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/astconv/index.html
+[hir_ty_lowering]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir_analysis/hir_ty_lowering/index.html
 
 **How semantics drive the two instances of `Ty`**
 


### PR DESCRIPTION
See rust-lang/compiler-team#723.
~~Blocked on rust-lang/rust#120926~~ (merged).