### PR TITLE
Update rustdoc build instructions

### DIFF
--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -44,8 +44,8 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
 * Run `./x setup tools` before getting started. This will configure `x`
   with nice settings for developing rustdoc and other tools, including
   downloading a copy of rustc rather than building it.
-* Use `./x check src/tools/rustdoc` to quickly check for compile errors.
-* Use `./x build` to make a usable
+* Use `./x check rustdoc` to quickly check for compile errors.
+* Use `./x build library rustdoc` to make a usable
   rustdoc you can run on other projects.
   * Add `library/test` to be able to use `rustdoc --test`.
   * Run `rustup toolchain link stage2 build/host/stage2` to add a


### PR DESCRIPTION
I don't know when exactly this was changed since I effectively took a break from hacking on rustdoc for a few months until last month. I faintly remember a smaller `bootstrap` PR that might've affected this.

Basically from what I can tell under `profile = "tools"`, you now need to explicitly build the sysroot together with `rustdoc` via `./x b library rustdoc` whereas before you could just do `./x b`. I think this was an intentional change.

A month ago when I came back to rustdoc dev I first thought my build environment was beyond broken, lol.
Through trial-and-error I figured out the aforementioned bootstrap invocation. Note that separate invocations à la `./x b library; ./x b` or `./x b library; ./x b rustdoc` don't work either, the sysroot still wouldn't be available to rustdoc (at least that's what I remember from my experiments from four weeks ago).

Maybe I've totally missed something and I'm doing it absolutely wrong ^^ and the build instructions from the dev-guide still work for you. If so, please do tell.

cc @GuillaumeGomez, @notriddle, @onur-ozkan
