### PR TITLE
Added zlib in suggested nix-shell environment script

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -282,10 +282,14 @@ pkgs.mkShell {
     binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
   ];
   buildInputs = with pkgs; [
-    openssl glibc.out glibc.static
+    openssl glibc.out glibc.static zlib
   ];
   # Avoid creating text files for ICEs.
   RUSTC_ICE = "0";
+
+  shellHook = ''
+    export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
+  '';
 }
 ```
 


### PR DESCRIPTION
I tried to build rustc on a new nixOS installation using a nix-shell. The provided script wasn't sufficient, I had to include `zlib` and include the lib in the path.