### PR TITLE
typos

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -69,13 +69,13 @@ Task] instead:
 
 For Neovim users there are several options for configuring for rustc. The easiest way is by using 
 [neoconf.nvim](https://github.com/folke/neoconf.nvim/), which allows for project-local
-configuration files with the native LSP. The steps for how to use it are below. Note that requires 
-Rust-Analyzer to already be configured with Neovim. Steps for this can be 
-[found here](https://rust-analyzer.github.io/manual.html#nvim-lsp).
+configuration files with the native LSP. The steps for how to use it are below.
+Note that they require rust-analyzer to already be configured with Neovim.
+Steps for this can be [found here](https://rust-analyzer.github.io/manual.html#nvim-lsp).
 
 1. First install the plugin. This can be done by following the steps in the README.
 2. Run `x setup`, which will have a prompt for it to create a `.vscode/settings.json` file.
-   `neoconf` is able to read and update Rust-Analyzer settings automatically when the project is
+   `neoconf` is able to read and update rust-analyzer settings automatically when the project is
    opened when this file is detected.
 
 If you're running `coc.nvim`,


### PR DESCRIPTION
Also
- use proper case for rust-analyzer
- reformat a bit, for sembr