### PR TITLE
Correct an example

### DIFF
--- a/src/early-late-bound-summary.md
+++ b/src/early-late-bound-summary.md
@@ -3,7 +3,7 @@
 This section discusses what it means for generic parameters to be early or late bound.
 
 ```rust
-fn foo<'a, T>(b: &'a u32) -> &'a u32 { a }
+fn id_u32<'a, T>(b: &'a u32) -> &'a u32 { b }
 //     ^^  ^early bound
 //     ^^
 //     ^^late bound


### PR DESCRIPTION
The function, as written, is not valid. `a` is not bounded. Given the parameter and the return type, I assume we are considering the identity function for u32. In this case, the return value should be `b`. As I was touching this code, I considered also changing the function name, for the sake of the clarity.