### PR TITLE
Fix broken link in chapter '1. How to build and run the compiler'

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -51,7 +51,7 @@ compiler and standard library.
 This chapter focuses on the basics to be productive, but
 if you want to learn more about `x.py`, [read this chapter][bootstrap].
 
-[bootstrap]: ./bootstrapping.md
+[bootstrap]: ./bootstrapping/intro.md
 
 Also, using `x` rather than `x.py` is recommended as:
 


### PR DESCRIPTION
The 'read this chapter' link under the 'What is x.py?' section returned a Document not found (404) error.