### PR TITLE
Explicitly mention compiletest directives are supported in rmake.rs

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -396,6 +396,9 @@ with the `run_make_support` library linked in.
 If you need new utilities or functionality, consider extending and improving
 the [`run_make_support`] library.
 
+Compiletest directives like `//@ only-<target>` or `//@ ignore-<target>` are supported in
+`rmake.rs`, like in UI tests.
+
 Two `run-make` tests are ported over to Rust recipes as examples:
 
 - <https://github.com/rust-lang/rust/tree/master/tests/run-make/CURRENT_RUSTC_VERSION>


### PR DESCRIPTION
I completely forgot that this was supported myself (`Makefile`s also support these directives, but they take the form of `# <directive>` instead).