### PR TITLE
Add documentation for check-cfg by-default in UI tests

### DIFF
--- a/src/tests/headers.md
+++ b/src/tests/headers.md
@@ -91,6 +91,7 @@ found in [`header.rs`] from the compiletest source.
     * [`error-pattern`](ui.md#error-pattern) — errors not on a line
     * `incremental` — incremental tests not in the incremental test-suite
     * `no-prefer-dynamic` — don't use `-C prefer-dynamic`, don't build as a dylib
+    * `no-auto-check-cfg` — disable auto check-cfg (only for `--check-cfg` tests)
     * `force-host` — build only for the host target
     * [`revisions`](compiletest.md#revisions) — compile multiple times
     * [`forbid-output`](compiletest.md#incremental-tests) — incremental cfail rejects output pattern

--- a/src/tests/ui.md
+++ b/src/tests/ui.md
@@ -363,7 +363,7 @@ with the different outputs of the different revisions.
 
 > Note: cfg revisions also work inside the source code with `#[cfg]` attributes.
 > 
-> By-convention the `FALSE` cfg is used to have an always false config.
+> By convention, the `FALSE` cfg is used to have an always-false config.
 
 ## Controlling pass/fail expectations
 

--- a/src/tests/ui.md
+++ b/src/tests/ui.md
@@ -361,6 +361,9 @@ multiple `.stderr` files for the different outputs.
 In the example above, there would be a `.mir.stderr` and `.thir.stderr` file
 with the different outputs of the different revisions.
 
+> Note: cfg revisions also work inside the source code with `#[cfg]` attributes.
+> 
+> By-convention the `FALSE` cfg is used to have an always false config.
 
 ## Controlling pass/fail expectations
 


### PR DESCRIPTION
This PR adds some (very conservative) documentation for a new compiletest directive regarding check-cfg; as well as documentation regarding the use of the `FALSE` cfg as convention for an always-false config.

Related to https://github.com/rust-lang/rust/pull/124345 and shouldn't be merged before that PR.