### PR TITLE
Rename `-Z verbose` to `-Z verbose-internals`

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -52,8 +52,8 @@ The compiler has a bunch of `-Z` flags. These are unstable flags that are only
 enabled on nightly. Many of them are useful for debugging. To get a full listing
 of `-Z` flags, use `-Z help`.
 
-One useful flag is `-Z verbose`, which generally enables printing more info that
-could be useful for debugging.
+One useful flag is `-Z verbose-internals`, which generally enables printing more
+info that could be useful for debugging.
 
 ## Getting a backtrace
 [getting-a-backtrace]: #getting-a-backtrace

--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -597,7 +597,7 @@ revision. To do this, add `[revision-name]` after the `//` comment, like so:
 
 ```rust,ignore
 // A flag to pass in only for cfg `foo`:
-//@[foo]compile-flags: -Z verbose
+//@[foo]compile-flags: -Z verbose-internals
 
 #[cfg(foo)]
 fn test_foo() {


### PR DESCRIPTION
The `-Z verbose` option has been renamed to `-Z verbose-internals` in commit  b5d83619 [1] (PR #119129 [2]). This commit updates the remaining `-Z verbose` to `-Z verbose-internals`.

[1]: https://github.com/rust-lang/rust/commit/b5d8361909e9e30a11227aa773099c293a5dca55
[2]: https://github.com/rust-lang/rust/pull/119129