### PR TITLE
Update the rustc_interface examples for current rustc

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -47,7 +47,7 @@ fn main() {
         locale_resources: rustc_driver::DEFAULT_LOCALE_RESOURCES,
         lint_caps: FxHashMap::default(), // FxHashMap<lint::LintId, lint::Level>
         // This is a callback from the driver that is called when [`ParseSess`] is created.
-        parse_sess_created: None, //Option<Box<dyn FnOnce(&mut ParseSess) + Send>>
+        psess_created: None, //Option<Box<dyn FnOnce(&mut ParseSess) + Send>>
         // This is a callback from the driver that is called when we're registering lints;
         // it is called during plugin registration when we have the LintStore in a non-shared state.
         //
@@ -60,7 +60,7 @@ fn main() {
         // The second parameter is local providers and the third parameter is external providers.
         override_queries: None, // Option<fn(&Session, &mut ty::query::Providers<'_>, &mut ty::query::Providers<'_>)>
         // Registry of diagnostics codes.
-        registry: registry::Registry::new(rustc_error_codes::DIAGNOSTICS),
+        registry: registry::Registry::new(rustc_errors::codes::DIAGNOSTICS),
         make_codegen_backend: None,
         expanded_args: Vec::new(),
         ice_file: None,

--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -36,8 +36,8 @@ impl Translate for DebugEmitter {
 }
 
 impl Emitter for DebugEmitter {
-    fn emit_diagnostic(&mut self, diag: &DiagInner) {
-        self.diagnostics.lock().unwrap().push(diag.clone());
+    fn emit_diagnostic(&mut self, diag: DiagInner) {
+        self.diagnostics.lock().unwrap().push(diag);
     }
 
     fn source_map(&self) -> Option<&Arc<SourceMap>> {
@@ -76,15 +76,15 @@ fn main() {
         file_loader: None,
         locale_resources: rustc_driver::DEFAULT_LOCALE_RESOURCES,
         lint_caps: rustc_hash::FxHashMap::default(),
-        parse_sess_created: Some(Box::new(|parse_sess| {
-            parse_sess.dcx = DiagCtxt::with_emitter(Box::new(DebugEmitter {
+        psess_created: Some(Box::new(|parse_sess| {
+            parse_sess.dcx = DiagCtxt::new(Box::new(DebugEmitter {
                 source_map: parse_sess.clone_source_map(),
                 diagnostics,
             }))
         })),
         register_lints: None,
         override_queries: None,
-        registry: registry::Registry::new(rustc_error_codes::DIAGNOSTICS),
+        registry: registry::Registry::new(rustc_errors::codes::DIAGNOSTICS),
         make_codegen_backend: None,
         expanded_args: Vec::new(),
         ice_file: None,

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -45,11 +45,11 @@ fn main() {
         file_loader: None,
         locale_resources: rustc_driver::DEFAULT_LOCALE_RESOURCES,
         lint_caps: rustc_hash::FxHashMap::default(),
-        parse_sess_created: None,
+        psess_created: None,
         register_lints: None,
         override_queries: None,
         make_codegen_backend: None,
-        registry: registry::Registry::new(rustc_error_codes::DIAGNOSTICS),
+        registry: registry::Registry::new(rustc_errors::codes::DIAGNOSTICS),
         expanded_args: Vec::new(),
         ice_file: None,
         hash_untracked_state: None,
@@ -73,8 +73,8 @@ fn main() {
                     if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
                         let expr = &tcx.hir().body(body_id).value;
                         if let rustc_hir::ExprKind::Block(block, _) = expr.kind {
-                            if let rustc_hir::StmtKind::Local(local) = block.stmts[0].kind {
-                                if let Some(expr) = local.init {
+                            if let rustc_hir::StmtKind::Let(let_stmt) = block.stmts[0].kind {
+                                if let Some(expr) = let_stmt.init {
                                     let hir_id = expr.hir_id; // hir_id identifies the string "Hello, world!"
                                     let def_id = item.hir_id().owner.def_id; // def_id identifies the main function
                                     let ty = tcx.typeck(def_id).node_type(hir_id);

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -8,7 +8,7 @@ otherwise be printed to stderr.
 To get diagnostics from the compiler,
 configure [`rustc_interface::Config`] to output diagnostic to a buffer,
 and run [`TyCtxt.analysis`]. The following was tested
-with <!-- date-check: jan 2024 --> `nightly-2024-01-19`:
+with <!-- date-check: may 2024 --> `nightly-2024-05-09`:
 
 ```rust
 {{#include ../examples/rustc-driver-getting-diagnostics.rs}}

--- a/src/rustc-driver-interacting-with-the-ast.md
+++ b/src/rustc-driver-interacting-with-the-ast.md
@@ -5,7 +5,7 @@ The [`rustc_interface`] allows you to interact with Rust code at various stages 
 ## Getting the type of an expression
 
 To get the type of an expression, use the [`global_ctxt`] query to [get] a [`TyCtxt`].
-The following was tested with <!-- date-check: jan 2024 --> `nightly-2024-01-19`:
+The following was tested with <!-- date-check: may 2024 --> `nightly-2024-05-09`:
 
 ```rust
 {{#include ../examples/rustc-driver-interacting-with-the-ast.rs}}


### PR DESCRIPTION
Updates the three `rustc_interface` examples.

Tested with `rustc 1.80.0-nightly (87293c958 2024-05-08)`
