### PR TITLE
use `&` to load completions for PowerShell

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -315,7 +315,7 @@ Zsh support will also be included once issues with [`clap_complete`](https://cra
 
 You can use `source ./src/etc/completions/x.py.<extension>`
 to load completions for your shell of choice,
-or `source .\src\etc\completions\x.py.ps1` for PowerShell.
+or `& .\src\etc\completions\x.py.ps1` for PowerShell.
 Adding this to your shell's startup script (e.g. `.bashrc`) will automatically load this completion.
 
 [`src/etc/rust_analyzer_settings.json`]: https://github.com/rust-lang/rust/blob/master/src/etc/rust_analyzer_settings.json


### PR DESCRIPTION
in `src/building/suggested.md`
> You can use `source ./src/etc/completions/x.py.<extension>`
to load completions for your shell of choice,
or `source .\src\etc\completions\x.py.ps1` for PowerShell.

to my best knowledge, `source` command is available only in POSIX Shell, and PowerShell is not a POSIX Shell.
hence there is no `source` command in powershell, and you will get an error if you actually run `source .\src\etc\completions\x.py.ps1` for PowerShell.

My suggestion: use call operator(&) to load .ps1 script file for powershell.

There are some other options (e.g. dot sourcing)