### PR TITLE
Fix broken link to "Lowering"

### DIFF
--- a/src/hir.md
+++ b/src/hir.md
@@ -5,7 +5,7 @@
 The HIR – "High-Level Intermediate Representation" – is the primary IR used
 in most of rustc. It is a compiler-friendly representation of the abstract
 syntax tree (AST) that is generated after parsing, macro expansion, and name
-resolution (see [Lowering](./lowering.html) for how the HIR is created).
+resolution (see [Lowering](./ast-lowering.html) for how the HIR is created).
 Many parts of HIR resemble Rust surface syntax quite closely, with
 the exception that some of Rust's expression forms have been desugared away.
 For example, `for` loops are converted into a `loop` and do not appear in


### PR DESCRIPTION
On the page https://rustc-dev-guide.rust-lang.org/hir.html and the [source file](https://github.com/rust-lang/rustc-dev-guide/blob/79bf0ba32b243ce0d6f5b058860d5322c07bbbbe/src/hir.md) there is a link to "Lowering" which tries to lead to `https://rustc-dev-guide.rust-lang.org/lowering.html` and `src/lowering.md` respectively.

By quickly poking around I assume it should be `ast-lowering.html` now but for all I know I've misattributed.