### PR TITLE
Add Rust for Linux notification group entry

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -56,6 +56,7 @@
     - [LLVM](notification-groups/llvm.md)
     - [RISC-V](notification-groups/risc-v.md)
     - [Windows](notification-groups/windows.md)
+    - [Rust for Linux](notification-groups/rust-for-linux.md)
 - [Licenses](./licenses.md)
 - [Editions](guides/editions.md)
 

--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -25,6 +25,7 @@ Here's the list of the notification groups:
 - [LLVM](./llvm.md)
 - [RISC-V](./risc-v.md)
 - [Windows](./windows.md)
+- [Rust for Linux](./rust-for-linux.md)
 
 ## What issues are a good fit for notification groups?
 

--- a/src/notification-groups/rust-for-linux.md
+++ b/src/notification-groups/rust-for-linux.md
@@ -1,0 +1,23 @@
+# Rust for Linux notification group
+
+**Github Label:** [O-rfl] <br>
+**Ping command:** `@rustbot ping rfl`
+
+[O-rfl]: https://github.com/rust-lang/rust/labels/O-rfl
+
+This list will be used to notify [Rust for Linux (RfL)][rfl] maintainers
+when the compiler or the standard library changes in a way that would
+break Rust for Linux, since it depends on several unstable flags
+and features. The RfL maintainers should then ideally provide support
+for resolving the breakage or decide to temporarily accept the breakage
+and unblock CI by temporarily removing the RfL CI jobs.
+
+The group also has an associated Zulip stream ([`#rust-for-linux`])
+where people can go to ask questions and discuss topics related to Rust
+for Linux.
+
+If you are interested in participating, please sign up for the
+Rust for Linux group on [Zulip][`#rust-for-linux`]!
+
+[rfl]: https://rust-for-linux.com/
+[`#rust-for-linux`]: https://rust-lang.zulipchat.com/#narrow/stream/425075-rust-for-linux


### PR DESCRIPTION
Discussed [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Testing.20Rust.20for.20Linux.20in.20our.20CI).