### PR TITLE
Mention `COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS` in `needs-llvm-components` documentation

### DIFF
--- a/src/tests/headers.md
+++ b/src/tests/headers.md
@@ -170,7 +170,7 @@ The following header commands will check LLVM support:
 * `ignore-llvm-version: 9.0` — ignores a specific LLVM version
 * `ignore-llvm-version: 7.0 - 9.9.9` — ignores LLVM versions in a range (inclusive)
 * `needs-llvm-components: powerpc` — ignores if the specific LLVM component was not built.
-  Note: The test will fail on CI if the component does not exist.
+  Note: The test will fail on CI (when `COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS` is set) if the component does not exist.
 * `needs-matching-clang` — ignores if the version of clang does not match the
   LLVM version of rustc.
   These tests are always ignored unless a special environment variable,


### PR DESCRIPTION
We should mention the env var that [controls](https://github.com/rust-lang/rust/blob/76e7a0849c07d73e4d9afde8036ee8c450127cc8/src/tools/compiletest/src/header.rs#L1593) this check for better discoverability, like we already do for `needs-matching-clang` below.

cc https://github.com/rust-lang/rust/pull/125949#issuecomment-2146631862