### PR TITLE
Add run-make port initiative to the Recurring work section

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -101,6 +101,7 @@ it's easy to pick up work without a large time commitment:
 - [Rustdoc Askama Migration](https://github.com/rust-lang/rust/issues/108868)
 - [Diagnostic Translation](https://github.com/rust-lang/rust/issues/100717)
 - [Move UI tests to subdirectories](https://github.com/rust-lang/rust/issues/73494)
+- [Port run-make tests from Make to Rust](https://github.com/rust-lang/rust/issues/121876)
 
 If you find more recurring work, please feel free to add it here!
 


### PR DESCRIPTION
This is a long running project that can be picked up rather easily, so it's a good fit for this section, IMO.