### PR TITLE
run-make: add tip about quick-compile with stage0 rustc

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -404,6 +404,18 @@ Two `run-make` tests are ported over to Rust recipes as examples:
 - <https://github.com/rust-lang/rust/tree/master/tests/run-make/CURRENT_RUSTC_VERSION>
 - <https://github.com/rust-lang/rust/tree/master/tests/run-make/a-b-a-linker-guard>
 
+#### Quickly check if `rmake.rs` tests can be compiled
+
+You can quickly check if `rmake.rs` tests can be compiled without having to
+build stage1 rustc by forcing `rmake.rs` to be compiled with the stage0
+compiler:
+
+```bash
+$ COMPILETEST_FORCE_STAGE0=1 x test --stage 0 tests/run-make/<test-name>
+```
+
+Of course, some tests will not successfully *run* in this way.
+
 #### Using Makefiles (legacy)
 
 > NOTE:


### PR DESCRIPTION
@Kobzol shared a good tip about using stage0 rustc to quickly check if rmake.rs tests can be compiled in https://rust-lang.zulipchat.com/#narrow/stream/421156-gsoc/topic/Project.3A.20Rewriting.20Makefile.20Tests.20Using.20Rust/near/443637248.

This PR adds that tip to the rmake.rs section.

r? @Kobzol 