### PR TITLE
provide `libstdc++.so.6` through `LD_LIBRARY_PATH`

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -285,6 +285,10 @@ pkgs.mkShell {
   ];
   # Avoid creating text files for ICEs.
   RUSTC_ICE = "0";
+  # Provide `libstdc++.so.6` for the self-contained lld.
+  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+  ]}";
 }
 ```
 


### PR DESCRIPTION
When `rustc` uses its self-contained lld, it cannot find `libstdc++.so.6`. Instead of creating a `lld-wrapper`, I think using `LD_LIBRARY_PATH` is easier to maintain.

The relevant error message is:
```
Building stage1 library artifacts (x86_64-unknown-linux-gnu)
error: process didn't exit successfully: `/path/rust/build/bootstrap/debug/rustc /path/rust/build/bootstrap/debug/rustc -vV` (exit status: 127)
--- stderr
/path/rust/build/x86_64-unknown-linux-gnu/stage1/bin/rustc: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
```

r? @Nilstrieb