### PR TITLE
Update new target check-cfg instructions

### DIFF
--- a/src/building/new-target.md
+++ b/src/building/new-target.md
@@ -86,12 +86,18 @@ unexpected because stage0 doesn't know about the new target specification and
 we pass `--check-cfg` in order to tell it to check.
 
 To fix the errors you will need to manually add the unexpected value to the
-`EXTRA_CHECK_CFGS` list in `src/bootstrap/src/lib.rs`. Here is an example for
-adding `NEW_TARGET_OS` as `target_os`:
+different `Cargo.toml` in `library/{std,alloc,core}/Cargo.toml`. Here is an
+example for adding `NEW_TARGET_ARCH` as `target_arch`:
+
+*`library/std/Cargo.toml`*:
 ```diff
-- (Some(Mode::Std), "target_os", Some(&["watchos"])),
-+ // #[cfg(bootstrap)] NEW_TARGET_OS
-+ (Some(Mode::Std), "target_os", Some(&["watchos", "NEW_TARGET_OS"])),
+  [lints.rust.unexpected_cfgs]
+  level = "warn"
+  check-cfg = [
+      'cfg(bootstrap)',
+-      'cfg(target_arch, values("xtensa"))',
++      # #[cfg(bootstrap)] NEW_TARGET_ARCH
++      'cfg(target_arch, values("xtensa", "NEW_TARGET_ARCH"))',
 ```
 
 To use this target in bootstrap, we need to explicitly add the target triple to the `STAGE0_MISSING_TARGETS`


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/127026 we no longer want to use the `EXTRA_CHECK_CFGS` list in bootstrap. New target specific cfgs should be set directly in the appropriate `[lints.rust.unexpected_cfgs.check-cfg]` lint table in one of the `library/{std,alloc,core}/Cargo.toml`.