### PR TITLE
use "bootstrap" instead of "rustbuild"

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -356,7 +356,7 @@ in other sections:
 ### Cleaning out build directories
 
 Sometimes you need to start fresh, but this is normally not the case.
-If you need to run this then `rustbuild` is most likely not acting right and
+If you need to run this then bootstrap is most likely not acting right and
 you should file a bug as to what is going wrong. If you do need to clean
 everything up then you only need to run one command!
 

--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -75,7 +75,7 @@ does is call the `main()` that's in this crate's `lib.rs`, though.)
 * The Markdown renderer is loaded up in `html/markdown.rs`, including functions
   for extracting doctests from a given block of Markdown.
 * The tests on the structure of rustdoc HTML output are located in `tests/rustdoc`, where
-  they're handled by the test runner of rustbuild and the supplementary script
+  they're handled by the test runner of bootstrap and the supplementary script
   `src/etc/htmldocck.py`.
 
 ## Tests


### PR DESCRIPTION
Let's stick with the single name "bootstrap" to refer to the bootstrap project to avoid confusion.

cc https://github.com/rust-lang/rust/pull/127434