### PR TITLE
Fix `is_diagnostic_item()` example

### DIFF
--- a/src/diagnostics/diagnostic-items.md
+++ b/src/diagnostics/diagnostic-items.md
@@ -104,7 +104,7 @@ use rustc_span::symbol::sym;
 /// `TyCtxt::is_diagnostic_item()`
 fn example_1(cx: &LateContext<'_>, ty: Ty<'_>) -> bool {
     match ty.kind() {
-        ty::Adt(adt, _) => cx.tcx.is_diagnostic_item(sym::HashMap, adt.did),
+        ty::Adt(adt, _) => cx.tcx.is_diagnostic_item(sym::HashMap, adt.did()),
         _ => false,
     }
 }


### PR DESCRIPTION
Changed to use getter in https://github.com/rust-lang/rust/pull/94733