### PR TITLE
MIR docs: fix borked links and update style

### DIFF
--- a/src/backend/updating-llvm.md
+++ b/src/backend/updating-llvm.md
@@ -34,18 +34,18 @@ the branch we're already using. The steps for this are:
 2. Identify the branch that rustc is currently using. The `src/llvm-project`
    submodule is always pinned to a branch of the
    [rust-lang/llvm-project repository].
-3. Fork the rust-lang/llvm-project repository
-4. Check out the appropriate branch (typically named `rustc/a.b-yyyy-mm-dd`)
-5. Cherry-pick the upstream commit onto the branch
-6. Push this branch to your fork
+3. Fork the rust-lang/llvm-project repository.
+4. Check out the appropriate branch (typically named `rustc/a.b-yyyy-mm-dd`).
+5. Cherry-pick the upstream commit onto the branch.
+6. Push this branch to your fork.
 7. Send a Pull Request to rust-lang/llvm-project to the same branch as before.
    Be sure to reference the Rust and/or LLVM issue that you're fixing in the PR
    description.
-8. Wait for the PR to be merged
+8. Wait for the PR to be merged.
 9. Send a PR to rust-lang/rust updating the `src/llvm-project` submodule with
    your bugfix. This can be done locally with `git submodule update --remote
    src/llvm-project` typically.
-10. Wait for PR to be merged
+10. Wait for PR to be merged.
 
 An example PR:
 [#59089](https://github.com/rust-lang/rust/pull/59089)

--- a/src/mir/optimizations.md
+++ b/src/mir/optimizations.md
@@ -88,9 +88,9 @@ implemented in its own module of the [`rustc_mir_transform`][trans] crate.
 [trans]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/index.html
 
 Some examples of passes are:
-- `CleanupNonCodegenStatements`: remove some of the info that is only needed for
+- `CleanupPostBorrowck`: Remove some of the info that is only needed for
   analyses, rather than codegen.
-- `ConstProp`: Does [constant propagation][constprop]
+- `ConstProp`: Does [constant propagation][constprop].
 
 You can see the ["Implementors" section of the `MirPass` rustdocs][impl] for more examples.
 

--- a/src/mir/passes.md
+++ b/src/mir/passes.md
@@ -53,19 +53,19 @@ this pass into the appropriate list of passes found in a query like
 `mir_built`, `optimized_mir`, etc. (If this is an optimization, it
 should go into the `optimized_mir` list.)
 
-Another example of a simple MIR pass is [`CleanupNonCodegenStatements`][cleanup-pass], which walks
+Another example of a simple MIR pass is [`CleanupPostBorrowck`][cleanup-pass], which walks
 the MIR and removes all statements that are not relevant to code generation. As you can see from
 its [source][cleanup-source], it is defined by first defining a dummy type, a struct with no
 fields:
 
 ```rust
-pub struct CleanupNonCodegenStatements;
+pub struct CleanupPostBorrowck;
 ```
 
 for which we implement the `MirPass` trait:
 
 ```rust
-impl<'tcx> MirPass<'tcx> for CleanupNonCodegenStatements {
+impl<'tcx> MirPass<'tcx> for CleanupPostBorrowck {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         ...
     }
@@ -172,11 +172,11 @@ simply loads from a cache the second time).
 [lint1]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/check_packed_ref/struct.CheckPackedRef.html
 [lint2]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/check_const_item_mutation/struct.CheckConstItemMutation.html
 [lint3]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/function_item_references/struct.FunctionItemReferences.html
-[opt1]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/simplify/struct.SimplifyCfg.html
+[opt1]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/simplify/enum.SimplifyCfg.html
 [opt2]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/remove_unneeded_drops/struct.RemoveUnneededDrops.html
 [mirtransform]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/
 [`RemoveStorageMarkers`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/remove_storage_markers/struct.RemoveStorageMarkers.html
-[cleanup-pass]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/cleanup_post_borrowck/struct.CleanupNonCodegenStatements.html
+[cleanup-pass]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/cleanup_post_borrowck/struct.CleanupPostBorrowck.html
 [cleanup-source]: https://github.com/rust-lang/rust/blob/e2b52ff73edc8b0b7c74bc28760d618187731fe8/compiler/rustc_mir_transform/src/cleanup_post_borrowck.rs#L27
 [pass-register]: https://github.com/rust-lang/rust/blob/e2b52ff73edc8b0b7c74bc28760d618187731fe8/compiler/rustc_mir_transform/src/lib.rs#L413
 [MIR visitor]: ./visitor.html

--- a/src/mir/visitor.md
+++ b/src/mir/visitor.md
@@ -37,10 +37,11 @@ code that will execute whenever a `foo` is found. If you want to
 recursively walk the contents of the `foo`, you then invoke the
 `super_foo` method. (NB. You never want to override `super_foo`.)
 
-A very simple example of a visitor can be found in [`LocalUseVisitor`].
-By implementing `visit_local` method, this visitor counts how many times each local is mutably used.
+A very simple example of a visitor can be found in [`LocalFinder`].
+By implementing `visit_local` method, this visitor identifies local variables that
+can be candidates for reordering.
 
-[`LocalUseVisitor`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/const_debuginfo/struct.LocalUseVisitor.html
+-[`LocalFinder`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/prettify/struct.LocalFinder.html
 
 ## Traversal
 

--- a/src/profile-guided-optimization.md
+++ b/src/profile-guided-optimization.md
@@ -136,5 +136,6 @@ instrumentation artifacts show up in LLVM IR.
 
 ## Additional Information
 
-Clang's documentation contains a good overview on PGO in LLVM here:
-https://clang.llvm.org/docs/UsersManual.html#profile-guided-optimization
+Clang's documentation contains a good overview on [PGO in LLVM][llvm-pgo].
+
+[llvm-pgo]: https://clang.llvm.org/docs/UsersManual.html#profile-guided-optimization


### PR DESCRIPTION
Changes applied:
- updating-llvm.md: make consistent style in a listing
- CleanupNonCodegenStatements - renamed to CleanupPostBorrowck
- SimplifyCfg - fix link target (it is an enum now)
- LocalUseVisitor - remove the documentation as the type is already gone
- PGO in LLVM - embed link