### PR TITLE
linkcheck: fix filtering of the source files

### DIFF
--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -19,14 +19,14 @@ elif [ "$GITHUB_EVENT_NAME" = "pull_request" ] ; then # running in PR CI build
     exit 1
   fi
 
-  CHANGED_FILES=$(git diff --name-only $BASE_SHA... | tr '\n' ' ')
+  CHANGED_FILES=$(git diff --name-only $BASE_SHA... | sed 's#^src/##' | tr '\n' ' ')
   FLAGS="--no-cache -f $CHANGED_FILES"
   USE_TOKEN=1
 
   echo "Checking files changed since $BASE_SHA: $CHANGED_FILES"
 else # running locally
   COMMIT_RANGE=master...
-  CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE | tr '\n' ' ')
+  CHANGED_FILES=$(git diff --name-only $COMMIT_RANGE | sed 's#^src/##' | tr '\n' ' ')
   FLAGS="-f $CHANGED_FILES"
 
   echo "Checking files changed in $COMMIT_RANGE: $CHANGED_FILES"


### PR DESCRIPTION
If I run the `mkbook build` on top of #2017, I get the following before this PR:

```
❯ RUST_LOG=info mdbook build
2024-07-23 16:33:33 [INFO] (mdbook::book): Book building has started
2024-07-23 16:33:33 [INFO] (mdbook::book): Running the html backend
2024-07-23 16:33:33 [INFO] (mdbook::book): Running the linkcheck backend
2024-07-23 16:33:33 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
Checking files changed in master...: src/backend/updating-llvm.md src/mir/optimizations.md src/mir/passes.md src/mir/visitor.md src/profile-guided-optimization.md 
exec mdbook-linkcheck -f src/backend/updating-llvm.md src/mir/optimizations.md src/mir/passes.md src/mir/visitor.md src/profile-guided-optimization.md 
[2024-07-23T14:33:34Z INFO  mdbook_linkcheck] Started the link checker
[2024-07-23T14:33:34Z INFO  mdbook_linkcheck] Scanning book for links
[2024-07-23T14:33:34Z INFO  mdbook_linkcheck] Found 0 links (0 incomplete links)
[2024-07-23T14:33:34Z INFO  mdbook_linkcheck] No broken links found
```

as seen, the `src/` prefix is present as arguments to `mdbook_linkcheck`, but the filtering in the tool **does not** present the files with the prefix!

After my change:
```
❯ RUST_LOG=info mdbook build
2024-07-23 16:30:43 [INFO] (mdbook::book): Book building has started
2024-07-23 16:30:43 [INFO] (mdbook::book): Running the html backend
2024-07-23 16:30:44 [INFO] (mdbook::book): Running the linkcheck backend
2024-07-23 16:30:44 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
Checking files changed in master...: backend/updating-llvm.md mir/optimizations.md mir/passes.md mir/visitor.md profile-guided-optimization.md 
exec mdbook-linkcheck -f backend/updating-llvm.md mir/optimizations.md mir/passes.md mir/visitor.md profile-guided-optimization.md 
[2024-07-23T14:30:44Z INFO  mdbook_linkcheck] Started the link checker
[2024-07-23T14:30:44Z INFO  mdbook_linkcheck] Scanning book for links
[2024-07-23T14:30:44Z INFO  mdbook_linkcheck] Found 73 links (2 incomplete links)
[2024-07-23T14:30:44Z WARN  linkcheck::validation::filesystem] Not checking that the "mono" section exists in "/home/marxin/Programming/rustc-dev-guide/src/appendix/glossary.md" because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation::filesystem] Not checking that the "def-id" section exists in "/home/marxin/Programming/rustc-dev-guide/src/appendix/glossary.md" because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation::filesystem] Not checking that the "stealing" section exists in "/home/marxin/Programming/rustc-dev-guide/src/mir/passes.md" because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "what-is-profiled-guided-optimization" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "how-is-pgo-implemented-in-rustc" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "overall-workflow" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "compile-time-aspects" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "create-binaries-with-instrumentation" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "compile-binaries-where-optimizations-make-use-of-profiling-data" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "runtime-aspects" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "testing-pgo" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "additional-information" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "why-update-llvm" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "bugfix-updates" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "new-llvm-release-updates" in the current file because fragment resolution isn't implemented
[2024-07-23T14:30:44Z WARN  linkcheck::validation] Not checking "caveats-and-gotchas" in the current file because fragment resolution isn't implemented
error: It looks like "query.md" wasn't included in SUMMARY.md
   ┌─ mir/passes.md:29:19
   │
29 │ [^query]: See the [Queries](../query.md) chapter for the general concept of query.
   │                   ^^^^^^^^^^^^^^^^^^^^^^ It looks like "query.md" wasn't included in SUMMARY.md

error: It looks like "query.md" wasn't included in SUMMARY.md
    ┌─ mir/passes.md:167:16
    │
167 │ (remember that [queries are memoized](../query.html), so executing a query twice
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "query.md" wasn't included in SUMMARY.md

error: It looks like "mir/index.md" wasn't included in SUMMARY.md
  ┌─ mir/optimizations.md:3:48
  │
3 │ MIR optimizations are optimizations run on the [MIR][mir] to produce better MIR
  │                                                ^^^^^^^^^^ It looks like "mir/index.md" wasn't included in SUMMARY.md

error: It looks like "appendix/glossary.md" wasn't included in SUMMARY.md
  ┌─ mir/optimizations.md:7:1
  │
7 │ [monomorphized][monomorph] yet), these optimizations are particularly
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "appendix/glossary.md" wasn't included in SUMMARY.md

error: It looks like "query.md" wasn't included in SUMMARY.md
   ┌─ mir/optimizations.md:19:31
   │
19 │ The [`optimized_mir`][optmir] [query] is called to produce the optimized MIR
   │                               ^^^^^^^ It looks like "query.md" wasn't included in SUMMARY.md

error: It looks like "appendix/glossary.md" wasn't included in SUMMARY.md
   ┌─ mir/optimizations.md:20:13
   │
20 │ for a given [`DefId`][defid]. This query makes sure that the borrow checker has
   │             ^^^^^^^^^^^^^^^^ It looks like "appendix/glossary.md" wasn't included in SUMMARY.md

error: It looks like "llvm-coverage-instrumentation.md" wasn't included in SUMMARY.md
   ┌─ profile-guided-optimization.md:60:1
   │
60 │ [`-C instrument-coverage`](./llvm-coverage-instrumentation.md), but using these
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "llvm-coverage-instrumentation.md" wasn't included in SUMMARY.md

error: Server returned 404 Not Found for https://github.com/rust-lang/rust/tree/master/tests/run-make-fulldeps
    ┌─ profile-guided-optimization.md:138:4
    │
138 │ in [run-make tests][rmake-tests] (the relevant tests have `pgo` in their name).
    │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Server returned 404 Not Found for https://github.com/rust-lang/rust/tree/master/tests/run-make-fulldeps

error: Potential incomplete link
   ┌─ mir/visitor.md:40:52
   │
40 │ A very simple example of a visitor can be found in [`LocalFinder`].
   │                                                    ^^^^^^^^^^^^^^^ Did you forget to define a URL for ``LocalFinder``?
   │
   = hint: declare the link's URL. For example: `[`LocalFinder`]: http://example.com/`

error: Potential incomplete link
   ┌─ mir/visitor.md:44:2
   │
44 │ -[`LocalFinder`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir_transform/prettify/struct.LocalFinder.html
   │  ^^^^^^^^^^^^^^^ Did you forget to define a URL for ``LocalFinder``?
   │
   = hint: declare the link's URL. For example: `[`LocalFinder`]: http://example.com/`

[2024-07-23T14:30:44Z INFO  mdbook_linkcheck] 8 broken links found
Error: One or more incorrect links
```