### PR TITLE
Fix invalid link to toolstate documentation

### DIFF
--- a/src/tests/ci.md
+++ b/src/tests/ci.md
@@ -264,7 +264,7 @@ few days before we promote nightly to beta.
 More information is available in the [toolstate documentation].
 
 [rust-toolstate]: https://rust-lang-nursery.github.io/rust-toolstate
-[toolstate documentation]: ../toolstate.md
+[toolstate documentation]: https://forge.rust-lang.org/infra/toolstate.html
 
 [GitHub Actions]: https://github.com/rust-lang/rust/actions
 [`jobs.yml`]: https://github.com/rust-lang/rust/blob/master/src/ci/github-actions/jobs.yml


### PR DESCRIPTION
Found [here](https://github.com/rust-lang/rustc-dev-guide/pull/1972#discussion_r1689584985).

CC @marxin