### PR TITLE
Save linkcheck cache always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,13 @@ jobs:
             ~/.cargo/bin
           key: ${{ runner.os }}-${{ env.MDBOOK_VERSION }}--${{ env.MDBOOK_LINKCHECK2_VERSION }}--${{ env.MDBOOK_TOC_VERSION }}--${{ env.MDBOOK_MERMAID_VERSION }}
 
-      - name: Cache linkcheck
-        uses: actions/cache@v4
+      - name: Restore cached Linkcheck
+        if: github.event_name == 'schedule'
+        id: cache-linkcheck-restore
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/book/linkcheck
-          key: ${{ runner.os }}-${{ hashFiles('./book/linkcheck') }}
+          path: book/linkcheck/cache.json
+          key: linkcheck
 
       - name: Install latest nightly Rust toolchain
         if: steps.mdbook-cache.outputs.cache-hit != 'true'
@@ -57,7 +58,16 @@ jobs:
           cargo install mdbook-mermaid --version ${{ env.MDBOOK_MERMAID_VERSION }}
 
       - name: Check build
-        run: ENABLE_LINKCHECK=1 mdbook build
+        run: mdbook build
+        continue-on-error: true
+
+      - name: Save cached Linkcheck
+        id: cache-linkcheck-save
+        if: github.event_name == 'schedule'
+        uses: actions/cache/save@v4
+        with:
+          path: book/linkcheck/cache.json
+          key: linkcheck
 
       - name: Deploy to gh-pages
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: book/linkcheck/cache.json
-          key: linkcheck
+          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}
 
       - name: Install latest nightly Rust toolchain
         if: steps.mdbook-cache.outputs.cache-hit != 'true'
@@ -58,7 +58,7 @@ jobs:
           cargo install mdbook-mermaid --version ${{ env.MDBOOK_MERMAID_VERSION }}
 
       - name: Check build
-        run: mdbook build
+        run: ENABLE_LINKCHECK=1 mdbook build
         continue-on-error: true
 
       - name: Save cached Linkcheck
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: book/linkcheck/cache.json
-          key: linkcheck
+          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}
 
       - name: Deploy to gh-pages
         if: github.event_name == 'push'

--- a/book.toml
+++ b/book.toml
@@ -52,7 +52,9 @@ exclude = [
     # 500 is returned for HEAD request
     "code\\.visualstudio\\.com/docs/editor/tasks",
 ]
-cache-timeout = 86400
+# The scheduled CI runs every day and so we need to reuse a part of the cache
+# in order to face "Server returned 429 Too Many Requests" errors for github.com.
+cache-timeout = 90000
 warning-policy = "error"
 
 [output.html.redirect]


### PR DESCRIPTION
This PR always stores the linkcheck cache when being run as part of the scheduled CI job. Note the normal PRs ignore the cache and check only the modified files. I also extended the cache expiration time so that the Nighly job can face the congressional limit from Github.com (`"Server returned 429 Too Many Requests"`).

Hopefully, it's a viable solution.
@camelid