### PR TITLE
feat: Add section about partial clones with `git clone --filter='blob:none'`

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -25,10 +25,29 @@ git clone https://github.com/rust-lang/rust.git
 cd rust
 ```
 
+### Partial clone the repository
+
+Due to the size of the repository, cloning on a slower internet connection can take a long time,
+and requires disk space to store the full history of every file and directory.
+Instead, it is possible to tell git to perform a _partial clone_, which will only fully retrieve
+the current file contents, but will automatically retrieve further file contents when you, e.g.,
+jump back in the history.
+All git commands will continue to work as usual, at the price of requiring an internet connection
+to visit not-yet-loaded points in history.
+
+```bash
+git clone --filter='blob:none' https://github.com/rust-lang/rust.git
+cd rust
+```
+
+> **NOTE**: [This link](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/)
+> describes this type of checkout in more detail, and also compares it to other modes, such as
+> shallow cloning.
+
 ### Shallow clone the repository
 
-Due to the size of the repository, cloning on a slower internet connection can take a long time.
-To sidestep this, you can use the `--depth N` option with the `git clone` command.
+An older alternative to partial clones is to use shallow clone the repository instead.
+To do so, you can use the `--depth N` option with the `git clone` command.
 This instructs `git` to perform a "shallow clone", cloning the repository but truncating it to
 the last `N` commits.
 
@@ -43,8 +62,9 @@ cd rust
 
 > **NOTE**: A shallow clone limits which `git` commands can be run.
 > If you intend to work on and contribute to the compiler, it is
-> generally recommended to fully clone the repository [as shown above](#get-the-source-code).
-> 
+> generally recommended to fully clone the repository [as shown above](#get-the-source-code),
+> or to perform a [partial clone](#shallow-clone-the-repository) instead.
+>
 > For example, `git bisect` and `git blame` require access to the commit history,
 > so they don't work if the repository was cloned with `--depth 1`.
 


### PR DESCRIPTION
I found this option, `--filter='blob:none'`, while setting up my clone of rustc, and I think it's much nicer than a shallow clone with `--depth 1` :).

https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/ describes what it does compared to a `--depth 1` clone.

In short, as I understand it, it doesn't pull blobs per default, only on demand.
"Blobs" are all file and directory contents.
So initially, only file and directory contents for the current `HEAD` commit will be downloaded, and operations like jumping back in the git history will then automatically pull required blobs on demand.

I.e., this doesn't break git operations like a shallow clone does.

Question: Building the book locally worked fine, until I switched to a new branch.
Now `mdbook-linkcheck` throws a lot of errors about unlinked things that I a) didn't touch, and b) that seem to be linked properly. ~~Maybe due to https://github.com/rust-lang/rustc-dev-guide/commit/f15edb8f15a90d396f041a834a666871e82844ce?~~

<details>
  <summary>Log of linkcheck errors:</summary>

```terminal
❯ mdbook build
2024-08-04 20:56:34 [INFO] (mdbook::book): Book building has started
Warning: The mdbook-mermaid preprocessor was built against version 0.4.36 of mdbook, but we're being called from version 0.4.40
Warning: The mdbook-toc preprocessor was built against version 0.4.36 of mdbook, but we're being called from version 0.4.40
2024-08-04 20:56:34 [INFO] (mdbook::book): Running the html backend
Warning: The mdbook-toc preprocessor was built against version 0.4.36 of mdbook, but we're being called from version 0.4.40
2024-08-04 20:56:35 [INFO] (mdbook::book): Running the linkcheck backend
2024-08-04 20:56:35 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
Checking files changed in master...: building/how-to-build-and-run.md
exec mdbook-linkcheck -f building/how-to-build-and-run.md
error: It looks like "building/quickstart.md" wasn't included in SUMMARY.md
   ┌─ building/how-to-build-and-run.md:24:70
   │
24 │ For a less in-depth quick-start of getting the compiler running, see [quickstart](./quickstart.md).
   │                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "building/quickstart.md" wasn't included in SUMMARY.md

error: It looks like "building/bootstrapping/intro.md" wasn't included in SUMMARY.md
   ┌─ building/how-to-build-and-run.md:90:41
   │
90 │ if you want to learn more about `x.py`, [read this chapter][bootstrap].
   │                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "building/bootstrapping/intro.md" wasn't included in SUMMARY.md

error: It looks like "building/suggested.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:197:60
    │
197 │ | `./x check` | Quick check to see if most things compile; [rust-analyzer can run this automatically for you][rust-analyzer] |
    │                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "building/suggested.md" wasn't included in SUMMARY.md

error: It looks like "tests/running.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:215:1
    │
215 │ [testing](../tests/running.md) and [rustdoc](../rustdoc.md) for more details.
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "tests/running.md" wasn't included in SUMMARY.md

error: It looks like "rustdoc.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:215:36
    │
215 │ [testing](../tests/running.md) and [rustdoc](../rustdoc.md) for more details.
    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "rustdoc.md" wasn't included in SUMMARY.md

error: It looks like "building/suggested.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:244:5
    │
244 │ see [the section on avoiding rebuilds for std][keep-stage].
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "building/suggested.md" wasn't included in SUMMARY.md

error: It looks like "tests/docker.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:360:21
    │
360 │ it may be useful to [inspect the Dockerfiles](../tests/docker.md)
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "tests/docker.md" wasn't included in SUMMARY.md

error: It looks like "tests/running.md" wasn't included in SUMMARY.md
    ┌─ building/how-to-build-and-run.md:380:26
    │
380 │ - Running tests (see the [section on running tests](../tests/running.html) for
    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ It looks like "tests/running.md" wasn't included in SUMMARY.md

Error: One or more incorrect links
2024-08-04 20:56:36 [ERROR] (mdbook::renderer): Renderer exited with non-zero return code.
2024-08-04 20:56:36 [ERROR] (mdbook::utils): Error: Rendering failed
2024-08-04 20:56:36 [ERROR] (mdbook::utils):    Caused By: The "linkcheck" renderer failed
```
</details>

Edit: Ah, seems like CI is throwing them as well :)