### PR TITLE
Update index.html, 39. The MIR: fix typo

### DIFF
--- a/src/mir/index.md
+++ b/src/mir/index.md
@@ -317,7 +317,7 @@ compile-time and thus we cannot make any assumptions about them. References on t
 ignore their address and just look at the backing value. We must make sure that the pointer values
 of the references are not observable at compile time. We thus encode `&42` exactly like `42`.
 Any conversion from
-valtree back a to MIR constant value must reintroduce an actual indirection. At codegen time the
+valtree back to a MIR constant value must reintroduce an actual indirection. At codegen time the
 addresses may be deduplicated between multiple uses or not, entirely depending on arbitrary
 optimization choices.
 


### PR DESCRIPTION
line 320:
original: "valtree back a to MIR constant"
updated: "valtree back to a MIR constant"