### PR TITLE
Replace direct http links to rustc-dev-guide.rust-lang.org

### DIFF
--- a/src/borrow_check/opaque-types-region-inference-restrictions.md
+++ b/src/borrow_check/opaque-types-region-inference-restrictions.md
@@ -158,7 +158,7 @@ See [#113971] for how we used to conflate the difference.
 
 [#113971]: https://github.com/rust-lang/rust/issues/113971
 [SCC]: https://en.wikipedia.org/wiki/Strongly_connected_component
-[member constraints]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference/member_constraints.html
+[member constraints]: ./region_inference/member_constraints.md
 
 **interaction with "once modulo regions" restriction**
 In the example above, note the opaque type in the signature is `Opaque<'a>` and the one in the

--- a/src/opaque-types-impl-trait-inference.md
+++ b/src/opaque-types-impl-trait-inference.md
@@ -5,8 +5,8 @@ This kind of type inference is particularly complex because,
 unlike other kinds of type inference,
 it can work across functions and function bodies.
 
-[hidden type]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference/member_constraints.html?highlight=%22hidden%20type%22#member-constraints
-[opaque type]: https://rustc-dev-guide.rust-lang.org/opaque-types-type-alias-impl-trait.html
+[hidden type]: ./borrow_check/region_inference/member_constraints.html?highlight=%22hidden%20type%22#member-constraints
+[opaque type]: ./opaque-types-type-alias-impl-trait.md
 
 ## Running example
 

--- a/src/overview.md
+++ b/src/overview.md
@@ -72,7 +72,7 @@ following files are found in the `parser`:
 
 This naming scheme is used across many compiler stages. You will find either a
 file or directory with the same name across the parsing, lowering, type
-checking, [Typed High-level Intermediate Representation (`THIR`)] lowering, and
+checking, [Typed High-level Intermediate Representation (`THIR`)][thir] lowering, and
 [Mid-level Intermediate Representation (`MIR`)][mir] building sources.
 
 Macro-expansion, `AST`-validation, name-resolution, and early linting also take
@@ -168,7 +168,7 @@ the final binary.
 [parser]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_parse/index.html
 [rustc_parse_parser_dir]: https://github.com/rust-lang/rust/tree/master/compiler/rustc_parse/src/parser
 [String interning]: https://en.wikipedia.org/wiki/String_interning
-[Typed High-level Intermediate Representation (`THIR`)]: https://rustc-dev-guide.rust-lang.org/thir.html
+[thir]: ./thir.md
 
 ## How it does it
 

--- a/src/param_env/param_env_construction_internals.md
+++ b/src/param_env/param_env_construction_internals.md
@@ -40,7 +40,7 @@ fn foo<T: Trait + Trait>() {}
 The [next-gen trait solver][next-gen-solver] also requires this elaboration to take place.
 
 [elaborate]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/traits/util/fn.elaborate.html
-[next-gen-solver]: https://rustc-dev-guide.rust-lang.org/solve/trait-solving.html
+[next-gen-solver]: ../solve/trait-solving.md
 
 ## Normalizing all bounds
 

--- a/src/solve/opaque-types.md
+++ b/src/solve/opaque-types.md
@@ -95,7 +95,7 @@ end up leaking placeholders.
 The handling of member constraints does not change in the new solver. See the
 [relevant existing chapter][member-constraints] for that.
 
-[member-constraints]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference/member_constraints.html
+[member-constraints]: ../borrow_check/region_inference/member_constraints.md
 
 ## calling methods on opaque types
 


### PR DESCRIPTION
Use relative links to the corresponding md source files; this helps local browsing of generated docs.