### PR TITLE
Fix a link and create an implied internal link 

### DIFF
--- a/src/memory.md
+++ b/src/memory.md
@@ -49,10 +49,11 @@ represented as a slice `&'tcx [tcx.types.i32, tcx.types.u32]`).
 - [`TraitRef`], typically passed by value – a **trait reference** consists of a reference to a trait
   along with its various type parameters (including `Self`), like `i32: Display` (here, the def-id
   would reference the `Display` trait, and the args would contain `i32`). Note that `def-id` is
-  defined and discussed in depth in the `AdtDef and DefId` section.
+  defined and discussed in depth in the [`AdtDef and DefId`][adtdefid] section.
 - [`Predicate`] defines something the trait system has to prove (see `traits` module).
 
 [`GenericArgs`]: ./ty_module/generic_arguments.md#the-genericargs-type
+[adtdefid]: ./ty_module/generic_arguments.md#adtdef-and-defid
 [`TraitRef`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/type.TraitRef.html
 [`Predicate`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/struct.Predicate.html
 

--- a/src/mir/drop-elaboration.md
+++ b/src/mir/drop-elaboration.md
@@ -192,4 +192,4 @@ known to be uninitialized) to run these checks.
 [reference-drop]: https://doc.rust-lang.org/reference/destructors.html
 [drops]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
 [drops-shim]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_transform/src/shim.rs
-[drops-transform]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+[drops-transform]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_transform/src/elaborate_drops.rs


### PR DESCRIPTION
Make an implied internal link explicit, and fix the link for `elaborate_drop` transform.