### PR TITLE
Fix Typo and Remove Outdated Line About C Variadics

### DIFF
--- a/src/ast-validation.md
+++ b/src/ast-validation.md
@@ -26,7 +26,6 @@ example, when visiting a function declaration,
 `AstValidator` checks that the function has:
 
 * no more than `u16::MAX` parameters;
-* c-variadic functions are declared with at least one named argument;
 * c-variadic argument goes the last in the declaration;
 * documentation comments aren't applied to function parameters;
 * and other validations.

--- a/src/mir/passes.md
+++ b/src/mir/passes.md
@@ -31,7 +31,7 @@ where we can access the MIR dialect for type checking or other purposes:
 ## Implementing and registering a pass
 
 A `MirPass` is some bit of code that processes the MIR, typically transforming it along the way
-somehow. But it may also do other things like lingint (e.g., [`CheckPackedRef`][lint1],
+somehow. But it may also do other things like linting (e.g., [`CheckPackedRef`][lint1],
 [`CheckConstItemMutation`][lint2], [`FunctionItemReferences`][lint3], which implement `MirLint`) or
 optimization (e.g., [`SimplifyCfg`][opt1], [`RemoveUnneededDrops`][opt2]). While most MIR passes
 are defined in the [`rustc_mir_transform`][mirtransform] crate, the `MirPass` trait itself is


### PR DESCRIPTION
This PR does two minor fixes:
1. Removes the line "c-variadic functions are declared with at least one named argument" as this is no longer true since https://github.com/rust-lang/rust/pull/124048 got merged.

2. Fixes typo: "lingint" -> "linting".