### PR TITLE
Reflect `x.py test`'s `--rustc-args` option being renamed to `--compiletest-rustc-args`

### DIFF
--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -139,8 +139,8 @@ It can sometimes be useful to run some tests with specific compiler arguments,
 without using `RUSTFLAGS` (during development of unstable features, with `-Z`
 flags, for example).
 
-This can be done with `./x test`'s `--rustc-args` option, to pass additional
-arguments to the compiler when building the tests.
+This can be done with `./x test`'s `--compiletest-rustc-args` option, to pass
+additional arguments to the compiler when building the tests.
 
 ## Editing and updating the reference files
 


### PR DESCRIPTION
This brings the mention of `--rustc-args` in the "Running tests" chapter up to date with https://github.com/rust-lang/rust/pull/128841