### PR TITLE
Fix conditions lowering text for enums with no fields

### DIFF
--- a/src/mir/construction.md
+++ b/src/mir/construction.md
@@ -119,7 +119,7 @@ In [MIR] there is no difference between method calls and function calls anymore.
 
 ## Conditions
 
-`if` conditions and `match` statements for `enum`s without variants with fields are
+`if` conditions and `match` statements for `enum`s with variants that have no fields are
 lowered to `TerminatorKind::SwitchInt`. Each possible value (so `0` and `1` for `if`
 conditions) has a corresponding `BasicBlock` to which the code continues.
 The argument being branched on is (again) an `Operand` representing the value of


### PR DESCRIPTION
It's really enum's with variants without fields but wrote the text a little bit similar to what it's said in the following section.