### PR TITLE
Fix getting diagnostics example

### DIFF
--- a/examples/rustc-driver-getting-diagnostics.rs
+++ b/examples/rustc-driver-getting-diagnostics.rs
@@ -77,10 +77,10 @@ fn main() {
         locale_resources: rustc_driver::DEFAULT_LOCALE_RESOURCES,
         lint_caps: rustc_hash::FxHashMap::default(),
         psess_created: Some(Box::new(|parse_sess| {
-            parse_sess.dcx = DiagCtxt::new(Box::new(DebugEmitter {
+            parse_sess.set_dcx(DiagCtxt::new(Box::new(DebugEmitter {
                 source_map: parse_sess.clone_source_map(),
                 diagnostics,
-            }))
+            })));
         })),
         register_lints: None,
         override_queries: None,
@@ -98,6 +98,9 @@ fn main() {
                 let _ = tcx.analysis(());
             });
         });
+        // If the compiler has encountered errors when this closure returns, it will abort (!) the program.
+        // We avoid this by resetting the error count before returning
+        compiler.sess.dcx().reset_err_count();
     });
     // Read buffered diagnostics.
     buffer.lock().unwrap().iter().for_each(|diagnostic| {

--- a/src/rustc-driver-getting-diagnostics.md
+++ b/src/rustc-driver-getting-diagnostics.md
@@ -8,7 +8,7 @@ otherwise be printed to stderr.
 To get diagnostics from the compiler,
 configure [`rustc_interface::Config`] to output diagnostic to a buffer,
 and run [`TyCtxt.analysis`]. The following was tested
-with <!-- date-check: may 2024 --> `nightly-2024-05-09`:
+with <!-- date-check: september 2024 --> `nightly-2024-09-16`:
 
 ```rust
 {{#include ../examples/rustc-driver-getting-diagnostics.rs}}


### PR DESCRIPTION
This PR is motivated by [this PR](https://github.com/rust-lang/rust/pull/130299) over in the rust repo.

The example was broken as described in the aforementioned PR, but was also broken by [this PR](https://github.com/rust-lang/rust/pull/126834). I have 'fixed' that by calling `reset_err_count`, but I have no idea whether that actually is the appropriate way to handle the abort-on-error behavior.