### PR TITLE
Emphasize how to run a single tool test

### DIFF
--- a/src/tests/intro.md
+++ b/src/tests/intro.md
@@ -124,6 +124,10 @@ To run the tool's tests, just pass its path to `./x test`.
 
 Usually these tools involve running `cargo test` within the tool's directory.
 
+If you want to run only a specified set of tests, append `--test-args FILTER_NAME` to the command.
+
+> Example: `./x test src/tools/miri --test-args padding`
+
 In CI, some tools are allowed to fail.
 Failures send notifications to the corresponding teams, and is tracked on the [toolstate website].
 More information can be found in the [toolstate documentation].

--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -62,6 +62,13 @@ Likewise, you can test a single file by passing its path:
 ./x test tests/ui/const-generics/const-test.rs
 ```
 
+`x` doesn't support running a single tool test by passing its path yet.
+You'll have to use the `--test-args` argument as describled [below](#running-an-individual-test).
+
+```bash
+./x test src/tools/miri --test-args tests/fail/uninit/padding-enum.rs
+```
+
 ### Run only the tidy script
 
 ```bash


### PR DESCRIPTION
Currently `x` can run individual rustc tests by directly passing file paths to `./x test`.
But this doesn't work for tool tests.
This PR provides some guidance for people who are confused by this.