### PR TITLE
Small follow-up to my "internal `#[rustc_*]` TEST attributes" PR

### DIFF
--- a/src/compiler-debugging.md
+++ b/src/compiler-debugging.md
@@ -276,7 +276,7 @@ Here are some notable ones:
 | `rustc_dump_item_bounds` | Dumps the [`item_bounds`] of an item. |
 | `rustc_dump_predicates` | Dumps the [`predicates_of`] an item. |
 | `rustc_dump_vtable` |  |
-| `rustc_hidden_type_of_opaques` | Dumps the [hidden type of all opaque types][opaq] in the crate. |
+| `rustc_hidden_type_of_opaques` | Dumps the [hidden type of each opaque types][opaq] in the crate. |
 | `rustc_layout` | [See this section](#debugging-type-layouts). |
 | `rustc_object_lifetime_default` | Dumps the [object lifetime defaults] of an item. |
 | `rustc_outlives` | Dumps implied bounds of an item. More precisely, the [`inferred_outlives_of`] an item. |

--- a/src/tests/ui.md
+++ b/src/tests/ui.md
@@ -534,12 +534,12 @@ Currently none of the compare modes are checked in CI for UI tests.
 ## `rustc_*` TEST attributes
 
 The compiler defines several perma-unstable `#[rustc_*]` attributes gated behind the internal feature
-`rustc_attrs` that dump extra compiler-internal information. See the analogous subsection in
+`rustc_attrs` that dump extra compiler-internal information. See the corresponding subsection in
 [compiler debugging] for more details.
 
 They can be used in tests to more precisely, legibly and easily test internal compiler state in cases
 where it would otherwise be very hard to do the same with "user-facing" Rust alone. Indeed, one could
-say that this slightly abuses the term "UI" (*user* interfacing) and turns such UI tests from black-box
+say that this slightly abuses the term "UI" (*user* interface) and turns such UI tests from black-box
 tests into white-box ones. Use them carefully and sparingly.
 
-[compiler debugging]: ../compiler-debugging.md#rustc_-attributes
+[compiler debugging]: ../compiler-debugging.md#rustc_test-attributes


### PR DESCRIPTION
Follow-up to #2046.

Fixes a slightly broken hyperlink (broken URL fragment) and tweaks some wordings.