### PR TITLE
update `x install` documentation

### DIFF
--- a/src/building/build-install-distribution-artifacts.md
+++ b/src/building/build-install-distribution-artifacts.md
@@ -7,23 +7,25 @@ You’ll want to run this command to do it:
 ./x dist
 ```
 
-# Install distribution artifacts
+# Install from source
 
-If you’ve built a distribution artifact you might want to install it and
-test that it works on your target system. You’ll want to run this command:
+You might want to prefer installing Rust (and tools configured in your configuration)
+by building from source. If so, you want to run this command:
 
 ```bash
 ./x install
 ```
 
-   Note: If you are testing out a modification to a compiler, you
-   might want to use it to compile some project.
-   Usually, you do not want to use `./x install` for testing.
-   Rather, you should create a toolchain as discussed in
-   [here][create-rustup-toolchain].
+   Note: If you are testing out a modification to a compiler, you might
+   want to build the compiler (with `./x build`) then create a toolchain as
+   discussed in [here][create-rustup-toolchain].
 
-   For example, if the toolchain you created is called foo, you
-   would then invoke it with `rustc +foo ...` (where ... represents
-   the rest of the arguments).
+   For example, if the toolchain you created is called "foo", you would then
+   invoke it with `rustc +foo ...` (where ... represents the rest of the arguments).
+
+Instead of installing Rust (and tools in your config file) globally, you can set `DESTDIR`
+environment variable to change the installation path. If you want to set installation paths
+more dynamically, you should prefer [install options] in your config file to achieve that.
 
 [create-rustup-toolchain]: ./how-to-build-and-run.md#creating-a-rustup-toolchain
+[install options]: https://github.com/rust-lang/rust/blob/f7c8928f035370be33463bb7f1cd1aeca2c5f898/config.example.toml#L422-L442


### PR DESCRIPTION
`x install` documentation was quite outdated, so it needed an update. Also added instructions on how to install in custom paths.