### PR TITLE
Fix and update docs for `needs-force-clang-based-tests`

### DIFF
--- a/src/tests/directives.md
+++ b/src/tests/directives.md
@@ -203,7 +203,7 @@ ignoring debuggers.
 [remote testing]: running.md#running-tests-on-a-remote-machine
 [compare modes]: ui.md#compare-modes
 [`x86_64-gnu-debug`]: https://github.com/rust-lang/rust/blob/ab3dba92db355b8d97db915a2dca161a117e959c/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile#L32
-[`aarch64-gnu-debug`]: https://github.com/rust-lang/rust/blob/20c909ff9cdd88d33768a4ddb8952927a675b0ad/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+[`aarch64-gnu-debug`]: https://github.com/rust-lang/rust/blob/20c909ff9cdd88d33768a4ddb8952927a675b0ad/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile#L32
 
 ### Affecting how tests are built
 


### PR DESCRIPTION
Updates directive description for https://github.com/rust-lang/rust/pull/131207.