### PR TITLE
Ask folks to use the Oxford comma in diagnostics

### DIFF
--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -156,6 +156,8 @@ use an error-level lint instead of a fixed error.
   compiler messages are an important learning tool.
 - When talking about the compiler, call it `the compiler`, not `Rust` or
   `rustc`.
+- Use the [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma) when
+  writing lists of items.
 
 ### Lint naming
 


### PR DESCRIPTION
Hey there! In Rust, it seems that most user-facing types of content prefer unambiguous grammar. However, there currently isn't any instruction to use the Oxford comma when writing lists of items within diagnostics. 

I added that to avoid any ambiguity, such as that which I fixed in https://github.com/rust-lang/rust/pull/131038

Please let me know if any changes are necessary! :)
