### PR TITLE
Document compiletest directives `ignore-coverage-map` and `ignore-coverage-run`

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -464,8 +464,9 @@ Each mode also has an alias to run the coverage tests in just that mode:
 ./x test coverage-map -- tests/coverage/if.rs # runs the specified test in "coverage-map" mode only
 ```
 
-If a test cannot be exercised in a particular coverage mode for some reason, you
-can use e.g. `ignore-mode-coverage-map`.
+If a particular test should not be run in one of the coverage test modes for
+some reason, use the `//@ ignore-coverage-map` or `//@ ignore-coverage-run`
+directives.
 
 #### `coverage-map` suite
 

--- a/src/tests/directives.md
+++ b/src/tests/directives.md
@@ -145,6 +145,8 @@ Some examples of `X` in `ignore-X` or `only-X`:
 - When particular debugger versions are matched: `ignore-gdb-version`
 - Specific [compare modes]: `compare-mode-polonius`, `compare-mode-chalk`,
   `compare-mode-split-dwarf`, `compare-mode-split-dwarf-single`
+- The two different test modes used by coverage tests:
+  `ignore-coverage-map`, `ignore-coverage-run`
 
 The following directives will check rustc build settings and target
 settings:


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/131400, which renamed these directives.
