### PR TITLE
Rename `needs-profiler-support` to `needs-profiler-runtime`

### DIFF
--- a/src/llvm-coverage-instrumentation.md
+++ b/src/llvm-coverage-instrumentation.md
@@ -317,7 +317,7 @@ These tests compile and run a test program with coverage
 instrumentation, then use LLVM tools to convert the coverage data into a
 human-readable coverage report.
 
-> Tests in `coverage-run` mode have an implicit `// needs-profiler-support`
+> Tests in `coverage-run` mode have an implicit `//@ needs-profiler-runtime`
 > directive, so they will be skipped if the profiler runtime has not been
 > [enabled in `config.toml`](#recommended-configtoml-settings).
 

--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -676,7 +676,7 @@ also registered as an additional prefix for FileCheck directives:
 ```rust,ignore
 //@ revisions: NORMAL COVERAGE
 //@[COVERAGE] compile-flags: -Cinstrument-coverage
-//@[COVERAGE] needs-profiler-support
+//@[COVERAGE] needs-profiler-runtime
 
 // COVERAGE:   @__llvm_coverage_mapping
 // NORMAL-NOT: @__llvm_coverage_mapping

--- a/src/tests/directives.md
+++ b/src/tests/directives.md
@@ -153,8 +153,9 @@ settings:
 
 - `needs-asm-support` — ignores if it is running on a target that doesn't have
   stable support for `asm!`
-- `needs-profiler-support` — ignores if profiler support was not enabled for the
-  target (`profiler = true` in rustc's `config.toml`)
+- `needs-profiler-runtime` — ignores the test if the profiler runtime was not
+  enabled for the target
+  (`build.profiler = true` in rustc's `config.toml`)
 - `needs-sanitizer-support` — ignores if the sanitizer support was not enabled
   for the target (`sanitizers = true` in rustc's `config.toml`)
 - `needs-sanitizer-{address,hwaddress,leak,memory,thread}` — ignores if the


### PR DESCRIPTION
Dev-guide update to reflect https://github.com/rust-lang/rust/pull/131429.