### PR TITLE
Add a link for the `reference` compiletest header

### DIFF
--- a/src/tests/directives.md
+++ b/src/tests/directives.md
@@ -245,6 +245,9 @@ See [Pretty-printer](compiletest.md#pretty-printer-tests).
       output pattern
 - [`should-ice`](compiletest.md#incremental-tests) — incremental cfail should
       ICE
+- [`reference`] — an annotation linking to a rule in the reference
+
+[`reference`]: https://github.com/rust-lang/reference/blob/master/docs/authoring.md#test-rule-annotations
 
 ### Tool-specific directives
 


### PR DESCRIPTION
This adds a link for the `reference` compiletest header added in https://github.com/rust-lang/rust/pull/131382

This is a draft pending the reference side of things getting merged https://github.com/rust-lang/reference/pull/1646.