### PR TITLE
Note Rustfmt for separate rust-analyzer directory

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -57,6 +57,8 @@ To avoid these problems:
 - Add `--build-dir=build-rust-analyzer` to all of the custom `x` commands in
   your editor's rust-analyzer configuration.
   (Feel free to choose a different directory name if desired.)
+- Modify the `rust-analyzer.rustfmt.overrideCommand` setting so that it points
+  to the copy of `rustfmt` in that other build directory.
 - Modify the `rust-analyzer.procMacro.server` setting so that it points to the
   copy of `rust-analyzer-proc-macro-srv` in that other build directory.
 


### PR DESCRIPTION
The [Suggested Workflows section on using a separate rust-analyzer build directory](https://rustc-dev-guide.rust-lang.org/building/suggested.html#using-a-separate-build-directory-for-rust-analyzer) has a bullet point saying to modify the [`rust-analyzer.procMacro.server` setting](https://github.com/rust-lang/rust/blob/d4822c2d84c242cc7403118b50c571464f38ef8f/src/etc/rust_analyzer_settings.json#L23), but does not mention the [`rust-analyzer.rustfmt.overrideCommand` setting](https://github.com/rust-lang/rust/blob/d4822c2d84c242cc7403118b50c571464f38ef8f/src/etc/rust_analyzer_settings.json#L19-L22). This PR adds that missing bullet point.