### PR TITLE
Compiler rewrite document added for collaboration

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -226,6 +226,7 @@
 [Appendix C: Code Index](./appendix/code-index.md)
 [Appendix D: Compiler Lecture Series](./appendix/compiler-lecture.md)
 [Appendix E: Bibliography](./appendix/bibliography.md)
+[Appendix F: Compiler Rewrite](./appendix/compiler-rewrite.md)
 
 [Appendix Z: HumorRust](./appendix/humorust.md)
 

--- a/src/appendix/compiler-rewrite.md
+++ b/src/appendix/compiler-rewrite.md
@@ -1,0 +1,27 @@
+# Compiler Rewrite Discussion
+
+Some experienced Rust developers have floated the idea of a possible rewrite of the Rust compiler. Recording motivations, lessons learned, limitations, unexpected pros and cons etc. of the current compiler will be a useful historical document for the open source community regardless of whether a rewrite of the compiler happens. 
+
+---
+
+## [author name](https://github.com/author_name) Notes
+
+
+
+## [author name](https://github.com/author_name) Notes
+
+
+
+## [author name](https://github.com/author_name) Notes
+
+
+
+## Key Points 
+-
+-
+-
+-
+
+
+# Summary
+


### PR DESCRIPTION
Re. Zulip topic - https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Info.20re.2E.20compiler.20rewrite.20idea.20.28ncameron.2C.202023.29/near/481236544

## Description
I am opening this PR to try to establish a central document for experts in the Rust compiler community to write their thoughts about a potential rewrite of the compiler. 

## Changes Made
1. Document 'compiler-rewrite.md' added as an appendix to serve as a central document for authors to share their opinions and can then be synthesised into one piece of work as opposed to multiple separate blog posts or similar dispersed across the net.
2. A reference to 'compiler-rewrite.md' added in 'SUMMARY.md'.

## Additional Notes
This will undoubtedly require changes in formatting, location, etc. but I hope it serves as a starting point for contributors to use.