### PR TITLE
Make `Diag` a clickable link in Suggestion section

### DIFF
--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -387,10 +387,11 @@ example-example-error = oh no! this is an error!
 
 In addition to telling the user exactly _why_ their code is wrong, it's
 oftentimes furthermore possible to tell them how to fix it. To this end,
-`Diag` offers a structured suggestions API, which formats code
+[`Diag`][diag] offers a structured suggestions API, which formats code
 suggestions pleasingly in the terminal, or (when the `--error-format json` flag
 is passed) as JSON for consumption by tools like [`rustfix`][rustfix].
 
+[diag]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_errors/struct.Diag.html
 [rustfix]: https://github.com/rust-lang/rustfix
 
 Not all suggestions should be applied mechanically, they have a degree of


### PR DESCRIPTION
Since `Diag` struct  is the core struct in the Suggestions section, it would be better to make it a clickable link.
https://rustc-dev-guide.rust-lang.org/diagnostics.html#suggestions