### PR TITLE
completions: Zsh is now supported

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -376,11 +376,9 @@ pkgs.mkShell {
 
 ## Shell Completions
 
-If you use Bash, Fish or PowerShell, you can find automatically-generated shell
+If you use Bash, Zsh, Fish or PowerShell, you can find automatically-generated shell
 completion scripts for `x.py` in
 [`src/etc/completions`](https://github.com/rust-lang/rust/tree/master/src/etc/completions).
-Zsh support will also be included once issues with
-[`clap_complete`](https://crates.io/crates/clap_complete) have been resolved.
 
 You can use `source ./src/etc/completions/x.py.<extension>` to load completions
 for your shell of choice, or `& .\src\etc\completions\x.py.ps1` for PowerShell.


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/917bfa78478cbcc77406e5ea37b24c3eedefacf4/src/etc/completions/x.py.zsh