### PR TITLE
Add missing link for [Node]

### DIFF
--- a/src/hir.md
+++ b/src/hir.md
@@ -106,6 +106,7 @@ These identifiers can be converted into one another through the [HIR map][map].
 [`LocalDefId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.LocalDefId.html
 [`HirId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir_id/struct.HirId.html
 [`BodyId`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.BodyId.html
+[Node]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/enum.Node.html
 [`CrateNum`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.CrateNum.html
 [`DefIndex`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/def_id/struct.DefIndex.html
 [`Body`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/struct.Body.html


### PR DESCRIPTION
Fixes:

```
error: Potential incomplete link
   ┌─ hir.md:99:47
   │
99 │   Unlike [`DefId`]s, a [`HirId`] can refer to [fine-grained entities][Node] like expressions,
   │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Did you forget to define a URL for `Node`?
```