### PR TITLE
Add a CI workflow for performing rustc-pull automatically

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -1,0 +1,55 @@
+name: rustc-pull
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 04:00 UTC every Monday
+    - cron: '0 4 * * 1'
+
+jobs:
+  pull:
+    if: github.repository == 'rust-lang/rustc-dev-guide'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # We need the full history for josh to work
+          fetch-depth: '0'
+      - name: Install stable Rust toolchain
+        run: rustup update stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "josh-sync"
+          # Cache the josh directory with checked out rustc
+          cache-directories: "/home/runner/.cache/rustc-dev-guide-josh"
+      - name: Install josh
+        run: RUSTFLAGS="--cap-lints warn" cargo +stable install josh-proxy --git https://github.com/josh-project/josh --tag r24.10.04
+      - name: Setup bot git name and email
+        run: |
+          git config --global user.name 'The rustc-dev-guide Cronjob Bot'
+          git config --global user.email 'github-actions@github.com'
+      - name: Perform rustc-pull
+        run: cargo run --manifest-path josh-sync/Cargo.toml -- rustc-pull
+      - name: Push changes to a branch
+        run: |
+          # Update a sticky branch that is used only for rustc pulls
+          BRANCH="rustc-pull"
+          git switch -c $BRANCH
+          git push -u origin $BRANCH --force
+      - name: Create pull request
+        run: |
+          # Check if an open pull request for an rustc pull update already exists
+          # If it does, the previous push has just updated it
+          # If not, we create it now
+          RESULT=`gh pr list --author github-actions[bot] --state open -q 'map(select(.title=="Rustc pull update")) | length' --json title`
+          if [[ "$RESULT" -eq 0 ]]; then
+            echo "Creating new pull request"
+            gh pr create -B master --title 'Rustc pull update' --body 'Latest update from rustc.'
+          else
+            echo "Updated existing pull request"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/josh-sync/src/sync.rs
+++ b/josh-sync/src/sync.rs
@@ -45,6 +45,11 @@ impl GitSync {
         let josh_url =
             format!("http://localhost:{JOSH_PORT}/{UPSTREAM_REPO}.git@{commit}{JOSH_FILTER}.git");
 
+        let previous_base_commit = sh.read_file("rust-version")?.trim().to_string();
+        if previous_base_commit == commit {
+            return Err(anyhow::anyhow!("No changes since last pull"));
+        }
+
         // Update rust-version file. As a separate commit, since making it part of
         // the merge has confused the heck out of josh in the past.
         // We pass `--no-verify` to avoid running git hooks.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -6,3 +6,6 @@ allow-unauthenticated = [
     "waiting-on-author",
     "blocked",
 ]
+
+# Automatically close and reopen PRs made by bots to run CI on them
+[bot-pull-requests]


### PR DESCRIPTION
The CI workflow is configured to run weekly on Monday morning, and it can also be executed manually through `workflow_dispatch`. The workflow runs `rustc-pull`, and if it actually pulled something, it force pushes to the `rustc-pull` branch, which is a sticky branch that should only be used for rustc pull updates.

If there is an open PR created by the Github Actions bot, it will be updated by that push. If not, the workflow creates a new PR. This PR also opts this repo into the auto open/close PR functionality from triagebot, so that CI runs on pull requests opened by the GitHub Actions bot user.

The PR also adds explicit error messages if there is nothing to pull during `rustc-pull`.

[This](https://github.com/Kobzol/rustc-dev-guide/pull/11) is how such a PR looks like.