### PR TITLE
ci: Remove incorrect use of `continue-on-error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,10 @@ jobs:
 
       - name: Check build
         run: ENABLE_LINKCHECK=1 mdbook build
-        continue-on-error: true
 
       - name: Save cached Linkcheck
         id: cache-linkcheck-save
-        if: github.event_name == 'schedule'
+        if: ${{ !cancelled() && github.event_name == 'schedule' }}
         uses: actions/cache/save@v4
         with:
           path: book/linkcheck/cache.json


### PR DESCRIPTION
cc #2030

This will cause the CI build to be marked successful even if the build
failed. Instead, use `if: '!cancelled()'` to always save the cache
(except when the job is cancelled), even if the linkcheck failed.

See https://stackoverflow.com/a/58859404 for more.
