### PR TITLE
remove outdated text about wfx implies

### DIFF
--- a/src/solve/invariants.md
+++ b/src/solve/invariants.md
@@ -23,9 +23,6 @@ well-formed after normalizing said aliases. We rely on this as
 otherwise we would have to re-check for well-formedness for these
 types.
 
-This is unfortunately broken for `<fndef as FnOnce<..>>::Output` due to implied bounds,
-resulting in [#114936].
-
 ### Structural equality modulo regions implies semantic equality ✅
 
 If you have a some type and equate it to itself after replacing any regions with unique


### PR DESCRIPTION
This PR removes the outdated comment about  wfx implies, as the issue has been resolved.  

The issue was discussed in [rust-lang/rustc-dev-guide#2161](https://github.com/rust-lang/rustc-dev-guide/issues/2161), and @JohnTitor confirmed that it is fixed:  
> "Indeed it seems to be fixed, we can remove that text now."  

Fixes #2161 