### PR TITLE
Document how to install a suitable `josh-proxy` locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ including the `<!-- toc -->` marker at the place where you want the TOC.
 
 This repository is linked to `rust-lang/rust` as a [josh](https://josh-project.github.io/josh/intro.html) subtree. You can use the following commands to synchronize the subtree in both directions.
 
+You'll need to install `josh-proxy` locally via
+
+```
+cargo +stable install josh-proxy --git https://github.com/josh-project/josh --tag r24.10.04
+```
+Older versions of `josh-proxy` may not round trip commits losslessly so it is important to install this exact version.
+
 ### Pull changes from `rust-lang/rust` into this repository
 1) Checkout a new branch that will be used to create a PR into `rust-lang/rustc-dev-guide`
 2) Run the pull command


### PR DESCRIPTION
Stolen from https://github.com/rust-lang/rustc-dev-guide/blob/c1b4cfaa961f62c284868a8c248f62d5db21722f/.github/workflows/rustc-pull.yml#L28-L29

This might become outdated if the CI version ever gets bumped, but it's better than nothing.

r? @Kobzol 