### PR TITLE
Run schedule CI more often due to link cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - master
   pull_request:
   schedule:
-    # Run at 18:00 UTC every day
-    - cron: '0 18 * * *'
+    # Run 4 times a day so that the link expiration turn over is relatively small
+    - cron: '0 */6 * * *'
 
 jobs:
   ci:


### PR DESCRIPTION
This attempt runs CI job more often so that the chunk of expired links to github.com is relatively small and so it's going to prevent: `429 Too Many Requests` error.

CC: @camelid @Kobzol 