### PR TITLE
Revert "Add `@bors rollup=never` to rustc-push PR body"

### DIFF
--- a/josh-sync/src/sync.rs
+++ b/josh-sync/src/sync.rs
@@ -180,7 +180,7 @@ impl GitSync {
         );
         println!(
             // Open PR with `subtree update` title to silence the `no-merges` triagebot check
-            "    https://github.com/{UPSTREAM_REPO}/compare/{github_user}:{branch}?quick_pull=1&title=Rustc+dev+guide+subtree+update&body=@bors+rollup=never%0Ar?+@ghost"
+            "    https://github.com/{UPSTREAM_REPO}/compare/{github_user}:{branch}?quick_pull=1&title=Rustc+dev+guide+subtree+update&body=r?+@ghost"
         );
 
         drop(josh);


### PR DESCRIPTION
Reverts rust-lang/rustc-dev-guide#2217. Looks like it shouldn't [be needed](https://rust-lang.zulipchat.com/#narrow/channel/196385-t-compiler.2Fwg-rustc-dev-guide/topic/a.20move.20to.20main.20repo.20.28rust-lang.2Frust.29/near/495564127).