### PR TITLE
CI: use key-restore for cache GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: book/linkcheck/cache.json
-          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}
+          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}--${{ github.run_id }}
+          restore-keys: |
+            linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}--
 
       - name: Install latest nightly Rust toolchain
         if: steps.mdbook-cache.outputs.cache-hit != 'true'
@@ -66,7 +68,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: book/linkcheck/cache.json
-          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}
+          key: linkcheck--${{ env.MDBOOK_LINKCHECK2_VERSION }}--${{ github.run_id }}
 
       - name: Deploy to gh-pages
         if: github.event_name == 'push'


### PR DESCRIPTION
It seems one can't overwrite a cache entry:
```
Failed to save: Unable to reserve cache with key linkcheck--0.8.1, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: linkcheck--0.8.1, Version: 33f8fd511bed9c91c40778bc5c27cb58425caa894ab50f9c5705d83cb78660e0
Warning: Cache save failed.
```

A proper solution is to use `restore-keys`:
https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache

I tested that in the following Draft PR (#2222), with the following Action result:
https://github.com/rust-lang/rustc-dev-guide/actions/runs/12966946869/job/36168260759

@camelid