### PR TITLE
Correct information on dylib compression

### DIFF
--- a/src/backend/libs-and-metadata.md
+++ b/src/backend/libs-and-metadata.md
@@ -42,7 +42,7 @@ format is specific to `rustc`, and may change over time. This file contains:
 ### dylib
 
 A `dylib` is a platform-specific shared library. It includes the `rustc`
-[metadata] in a special link section called `.rustc` in a compressed format.
+[metadata] in a special link section called `.rustc`.
 
 ### rmeta
 


### PR DESCRIPTION
Compression of dylibs was removed in https://github.com/rust-lang/rust/pull/113695 (and decompression removed in https://github.com/rust-lang/rust/pull/132402).