### PR TITLE
Add "Writing tests" section in getting-started.md

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -137,6 +137,10 @@ pull request, continuing the work on the feature.
 
 [abandoned-prs]: https://github.com/rust-lang/rust/pulls?q=is%3Apr+label%3AS-inactive+is%3Aclosed
 
+### Writing tests
+
+Issues that have been resolved but do not have a regression test are marked with the `E-needs-test` label. Writing unit tests is a low-risk, lower-priority task that offers new contributors a great opportunity to familiarize themselves with the codebase.
+
 ### Contributing to std (standard library)
 
 See [std-dev-guide](https://std-dev-guide.rust-lang.org/).

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -139,7 +139,7 @@ pull request, continuing the work on the feature.
 
 ### Writing tests
 
-Issues that have been resolved but do not have a regression test are marked with the `E-needs-test` label. Writing unit tests is a low-risk, lower-priority task that offers new contributors a great opportunity to familiarize themselves with the codebase.
+Issues that have been resolved but do not have a regression test are marked with the `E-needs-test` label. Writing unit tests is a low-risk, lower-priority task that offers new contributors a great opportunity to familiarize themselves with the testing infrastructure and contribution workflow.
 
 ### Contributing to std (standard library)
 


### PR DESCRIPTION
This PR closes #2069. 
I added a short section mentioning `E-needs-test` label in getting-started.md