### PR TITLE
Add a link to declare_lint! macro doc in diagnostics.md

### DIFF
--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -602,7 +602,7 @@ as the linter walks the AST. You can then choose to emit lints in a
 very similar way to compile errors.
 
 You also declare the metadata of a particular lint via the `declare_lint!`
-macro. This includes the name, the default level, a short description, and some
+macro. [This macro](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint_defs/macro.declare_lint.html) includes the name, the default level, a short description, and some
 more details.
 
 Note that the lint and the lint pass must be registered with the compiler.


### PR DESCRIPTION
This PR closes #2114.
I added a link to the `declare_lint!` macro, which describes the format of a lint, including {{produces}} marker.