### PR TITLE
Checkout repository sources in rustc-pull CI action

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -82,6 +82,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Compute message
         id: create-message
         env:


### PR DESCRIPTION
This is needed for the `gh` command to work.