### PR TITLE
Remove "Port run-make tests from Make to Rust" tracking issue from Recurring work

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -101,7 +101,6 @@ it's easy to pick up work without a large time commitment:
 - [Rustdoc Askama Migration](https://github.com/rust-lang/rust/issues/108868)
 - [Diagnostic Translation](https://github.com/rust-lang/rust/issues/100717)
 - [Move UI tests to subdirectories](https://github.com/rust-lang/rust/issues/73494)
-- [Port run-make tests from Make to Rust](https://github.com/rust-lang/rust/issues/121876)
 
 If you find more recurring work, please feel free to add it here!
 


### PR DESCRIPTION
No new work is needed for https://github.com/rust-lang/rust/issues/121876 anymore.

The last pending task was claimed by @jieyouxu in https://github.com/rust-lang/rust/pull/135572, originally https://github.com/rust-lang/rust/pull/128754 by [Oneirical](https://github.com/Oneirical).

## Linked PRs
- Reverts #1992 