### PR TITLE
Make the rustc-pull workflow run less often

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -3,8 +3,8 @@ name: rustc-pull
 on:
   workflow_dispatch:
   schedule:
-    # Run at 04:00 UTC every day
-    - cron: '0 4 * * *'
+    # Run at 04:00 UTC every Monday and Thursday
+    - cron: '0 4 * * 1,4'
 
 jobs:
   pull:


### PR DESCRIPTION
Recently, I made the rustc-pull workflow run every day, with the idea that it would create a "rolling" PR that would be merged from tiem to time. However, it is not clear when should such a PR be merged, and merging it every day creates unnecessary churn and a lot of useless merge commits.

This PR changes the cron workflow so that it runs twice a week (Monday and Thursday), to give us a faster notice when there are merge conflicts, but doesn't create a new PR every day. If there is a PR that is more than a week old, the workflow will notify us on Zulip.