### PR TITLE
Run CI multiple times a day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - master
   pull_request:
   schedule:
-    # Run at 18:00 UTC every day
-    - cron: '0 18 * * *'
+    # Run multiple times a day as the successfull cached links are not checked every time.
+    - cron: '0 */3 * * *'
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   schedule:
     # Run multiple times a day as the successfull cached links are not checked every time.
-    - cron: '0 */3 * * *'
+    - cron: '0 */8 * * *'
 
 jobs:
   ci:


### PR DESCRIPTION
Right now, the cache is properly loaded and updated during each run of the CI. However, we still hit `429`s every time the big portion of cache entries (pointing to GH) are invalidated. Plus, sometimes there are volatile links that tend to fail occasionally. Thus I recommend running the CI multiple times a day, it would run fast (only invalidated cache entries + failing will be checked).

@camelid What do you think?