### PR TITLE
Fix examples to work with nightly-2025-02-13

### DIFF
--- a/examples/README
+++ b/examples/README
@@ -4,7 +4,10 @@ For each example to compile, you will need to first run the following:
 
 To create an executable:
 
-    rustc rustc-driver-example.rs
+    rustup run nightly rustc rustc-driver-example.rs
+
+You might need to be more specific about the exact nightly version. See the comments at the top of
+the examples for the version they were written for.
 
 To run an executable:
 

--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -1,3 +1,5 @@
+// Tested with nightly-2025-02-13
+
 #![feature(rustc_private)]
 
 extern crate rustc_ast;
@@ -73,7 +75,7 @@ impl rustc_driver::Callbacks for MyCallbacks {
             let hir = tcx.hir();
             let item = hir.item(id);
             match item.kind {
-                rustc_hir::ItemKind::Static(_, _, _) | rustc_hir::ItemKind::Fn(_, _, _) => {
+                rustc_hir::ItemKind::Static(_, _, _) | rustc_hir::ItemKind::Fn { .. } => {
                     let name = item.ident;
                     let ty = tcx.type_of(item.hir_id().owner.def_id);
                     println!("{name:?}:\t{ty:?}")
@@ -87,5 +89,13 @@ impl rustc_driver::Callbacks for MyCallbacks {
 }
 
 fn main() {
-    run_compiler(&["main.rs".to_string()], &mut MyCallbacks);
+    run_compiler(
+        &[
+            // The first argument, which in practice contains the name of the binary being executed
+            // (i.e. "rustc") is ignored by rustc.
+            "ignored".to_string(),
+            "main.rs".to_string(),
+        ],
+        &mut MyCallbacks,
+    );
 }

--- a/examples/rustc-driver-interacting-with-the-ast.rs
+++ b/examples/rustc-driver-interacting-with-the-ast.rs
@@ -1,3 +1,5 @@
+// Tested with nightly-2025-02-13
+
 #![feature(rustc_private)]
 
 extern crate rustc_ast;
@@ -74,8 +76,8 @@ impl rustc_driver::Callbacks for MyCallbacks {
         for id in hir_krate.items() {
             let item = hir_krate.item(id);
             // Use pattern-matching to find a specific node inside the main function.
-            if let rustc_hir::ItemKind::Fn(_, _, body_id) = item.kind {
-                let expr = &tcx.hir().body(body_id).value;
+            if let rustc_hir::ItemKind::Fn { body, .. } = item.kind {
+                let expr = &tcx.hir().body(body).value;
                 if let rustc_hir::ExprKind::Block(block, _) = expr.kind {
                     if let rustc_hir::StmtKind::Let(let_stmt) = block.stmts[0].kind {
                         if let Some(expr) = let_stmt.init {
@@ -94,5 +96,13 @@ impl rustc_driver::Callbacks for MyCallbacks {
 }
 
 fn main() {
-    run_compiler(&["main.rs".to_string()], &mut MyCallbacks);
+    run_compiler(
+        &[
+            // The first argument, which in practice contains the name of the binary being executed
+            // (i.e. "rustc") is ignored by rustc.
+            "ignored".to_string(),
+            "main.rs".to_string(),
+        ],
+        &mut MyCallbacks,
+    );
 }

--- a/examples/rustc-interface-example.rs
+++ b/examples/rustc-interface-example.rs
@@ -1,3 +1,5 @@
+// Tested with nightly-2025-02-13
+
 #![feature(rustc_private)]
 
 extern crate rustc_driver;
@@ -8,8 +10,6 @@ extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_session;
 extern crate rustc_span;
-
-use std::sync::Arc;
 
 use rustc_errors::registry;
 use rustc_hash::FxHashMap;
@@ -56,7 +56,7 @@ fn main() {
         expanded_args: Vec::new(),
         ice_file: None,
         hash_untracked_state: None,
-        using_internal_features: Arc::default(),
+        using_internal_features: &rustc_driver::USING_INTERNAL_FEATURES,
     };
     rustc_interface::run_compiler(config, |compiler| {
         // Parse the program and print the syntax tree.
@@ -68,7 +68,7 @@ fn main() {
                 let hir = tcx.hir();
                 let item = hir.item(id);
                 match item.kind {
-                    rustc_hir::ItemKind::Static(_, _, _) | rustc_hir::ItemKind::Fn(_, _, _) => {
+                    rustc_hir::ItemKind::Static(_, _, _) | rustc_hir::ItemKind::Fn { .. } => {
                         let name = item.ident;
                         let ty = tcx.type_of(item.hir_id().owner.def_id);
                         println!("{name:?}:\t{ty:?}")

--- a/examples/rustc-interface-getting-diagnostics.rs
+++ b/examples/rustc-interface-getting-diagnostics.rs
@@ -1,3 +1,5 @@
+// Tested with nightly-2025-02-13
+
 #![feature(rustc_private)]
 
 extern crate rustc_data_structures;
@@ -15,7 +17,7 @@ use std::sync::{Arc, Mutex};
 use rustc_errors::emitter::Emitter;
 use rustc_errors::registry::{self, Registry};
 use rustc_errors::translation::Translate;
-use rustc_errors::{DiagCtxt, DiagInner, FluentBundle};
+use rustc_errors::{DiagInner, FluentBundle};
 use rustc_session::config;
 use rustc_span::source_map::SourceMap;
 
@@ -79,7 +81,7 @@ fn main() {
         expanded_args: Vec::new(),
         ice_file: None,
         hash_untracked_state: None,
-        using_internal_features: Arc::default(),
+        using_internal_features: &rustc_driver::USING_INTERNAL_FEATURES,
     };
     rustc_interface::run_compiler(config, |compiler| {
         let krate = rustc_interface::passes::parse(&compiler.sess);

--- a/src/rustc-driver/getting-diagnostics.md
+++ b/src/rustc-driver/getting-diagnostics.md
@@ -8,7 +8,6 @@ otherwise be printed to stderr.
 To get diagnostics from the compiler,
 configure [`rustc_interface::Config`] to output diagnostic to a buffer,
 and run [`TyCtxt.analysis`].
-The following was tested with <!-- date-check: september 2024 --> `nightly-2024-09-16`:
 
 ```rust
 {{#include ../../examples/rustc-interface-getting-diagnostics.rs}}

--- a/src/rustc-driver/interacting-with-the-ast.md
+++ b/src/rustc-driver/interacting-with-the-ast.md
@@ -5,7 +5,6 @@
 ## Getting the type of an expression
 
 To get the type of an expression, use the [`after_analysis`] callback to get a [`TyCtxt`].
-The following was tested with <!-- date-check: december 2024 --> `nightly-2024-12-15`:
 
 ```rust
 {{#include ../../examples/rustc-driver-interacting-with-the-ast.rs}}


### PR DESCRIPTION
While there were comments indicating which nightly versions the examples were tested with, those versions did not work for me: neither did the examples compile, nor did they produce the expected output.

This commit fixes the compilation issues, using nightly-2025-02-13 for all examples (previously the version differed between the examples) and, in the case of the `rustc_driver` examples, also fixes the argument passing: rustc ignores the first argument, so we need to pass the filename as the second (otherwise we only get the help text printed).

Note that the `rustc-interface-getting-diagnostics.rs` example still does not produce any output, which I assume is not how it is intended. However, I don't know enough to fix it. I'd be happy to include a fix if somebody can point me towards it.

To avoid inconsistencies between the documented version and the actually required version I've moved the version comment from the Markdown into the Rust code where it hopefully won't be forgotten as easily.

Finally I've clarified in the examples' README that you also need to use the proper nightly version when compiling the examples, not just when running them.