### PR TITLE
Don't suggest explicitly `cfg`-gating `trace!` calls in bootstrap

### DIFF
--- a/src/building/bootstrapping/debugging-bootstrap.md
+++ b/src/building/bootstrapping/debugging-bootstrap.md
@@ -129,7 +129,7 @@ Both `tracing::*` macros and the `tracing::instrument` proc-macro attribute need
 
 ```rs
 #[cfg(feature = "tracing")]
-use tracing::{instrument, trace};
+use tracing::instrument;
 
 struct Foo;
 
@@ -138,7 +138,6 @@ impl Step for Foo {
 
     #[cfg_attr(feature = "tracing", instrument(level = "trace", name = "Foo::should_run", skip_all))]
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        #[cfg(feature = "tracing")]
         trace!(?run, "entered Foo::should_run");
 
         todo!()
@@ -154,7 +153,6 @@ impl Step for Foo {
         ),
     )]
     fn run(self, builder: &Builder<'_>) -> Self::Output {
-        #[cfg(feature = "tracing")]
         trace!(?run, "entered Foo::run");
 
         todo!()


### PR DESCRIPTION
I was trying to learn more about bootstrap, read about the tracing macros, thought they were cool, but also writing `#[cfg(tracing)] trace!` each time gets annoying.

So I thought I'd PR a shim macro that hides the `cfg` internally (and contribute to rustc finally),  but turns out @jieyouxu has already done that in https://github.com/rust-lang/rust/pull/136392

Well, guess I'll be content with just a doc change for now then 🙃 