### PR TITLE
Remove the doc for `no-system-llvm`

### DIFF
--- a/src/tests/directives.md
+++ b/src/tests/directives.md
@@ -197,7 +197,6 @@ settings:
 
 The following directives will check LLVM support:
 
-- `no-system-llvm` — ignores if the system llvm is used
 - `exact-llvm-major-version: 19` — ignores if the llvm major version does not
   match the specified llvm major version.
 - `min-llvm-version: 13.0` — ignored if the LLVM version is less than the given


### PR DESCRIPTION
This compiletest directive was removed in rust-lang/rust#120265.