### PR TITLE
Don't linkcheck external web links in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       MDBOOK_LINKCHECK2_VERSION: 0.9.1
       MDBOOK_MERMAID_VERSION: 0.12.6
       MDBOOK_TOC_VERSION: 0.11.2
+      MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS: ${{ github.event_name != 'pull_request' }}
       DEPLOY_DIR: book/html
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This can block PR CI yet remain unactionable for the contributor, since this is subject to network conditions and availability of the servers hosting the external web links.

~~I don't see a way for PR CI to override the linkcheck config to skip external web links yet let the cron job CI to perform external web link checks, so this PR does the sledgehammer approach of disabling external web link checks for both.~~ EDIT: apparently `MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS` is a thing.