### PR TITLE
doc: fix reference to #create-a-configtoml

### DIFF
--- a/src/building/prerequisites.md
+++ b/src/building/prerequisites.md
@@ -38,4 +38,4 @@ incremental compilation ([see here][config]). This will make compilation take
 longer (especially after a rebase), but will save a ton of space from the
 incremental caches.
 
-[config]: ./how-to-build-and-run.md#create-a-configtoml
+[config]: ./how-to-build-and-run.md#create-a-bootstraptoml


### PR DESCRIPTION
https://github.com/rust-lang/rustc-dev-guide/commit/e4ddc21c8ab4bee43c905b1d4621b4c657c5d0ef This commit renamed `config.toml` to `bootstrap.toml`.