### PR TITLE
example assumes a static exists

### DIFF
--- a/examples/rustc-driver-example.rs
+++ b/examples/rustc-driver-example.rs
@@ -34,9 +34,9 @@ impl rustc_span::source_map::FileLoader for MyFileLoader {
     fn read_file(&self, path: &Path) -> io::Result<String> {
         if path == Path::new("main.rs") {
             Ok(r#"
+static MESSAGE: &str = "Hello, World!";
 fn main() {
-    let message = "Hello, World!";
-    println!("{message}");
+    println!("{MESSAGE}");
 }
 "#
             .to_string())


### PR DESCRIPTION
This was removed, likely by mistake, during a refactor.