### PR TITLE
Align advice to discourage issue-number-only names

### DIFF
--- a/src/tests/best-practices.md
+++ b/src/tests/best-practices.md
@@ -70,6 +70,11 @@ related tests.
 > //!
 > //! Regression test for <https://github.com/rust-lang/rust/issues/123456>.
 > ```
+>
+> One exception to this rule is [crashes tests]: there it is canonical that
+> tests are named only after issue numbers because its purpose is to track
+> snippets from which issues no longer ICE/crash, and they would either be
+> removed or converted into proper ui/other tests in the fix PRs.
 
 ## Test organization
 
@@ -194,3 +199,4 @@ See [LLVM FileCheck guide][FileCheck] for details.
 [compiletest directives]: ./directives.md
 [`run-make`]: ./compiletest.md#run-make-tests
 [FileCheck]: https://llvm.org/docs/CommandGuide/FileCheck.html
+[crashes tests]: ./compiletest.md#crashes-tests


### PR DESCRIPTION
https://rustc-dev-guide.rust-lang.org/tests/best-practices.html#test-naming specifically asks devs to "Avoid using only issue numbers as test names".

This commit introduces a minor change to https://rustc-dev-guide.rust-lang.org/tests/compiletest.html#crashes-tests that changes the advice to use only issue numbers as names to the advice to append them at the end of the file name.