### PR TITLE
Enable `[canonicalize-issue-links]` and `[no-mentions]` in triagebot.toml

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -7,5 +7,9 @@ allow-unauthenticated = [
     "blocked",
 ]
 
+[no-mentions]
+
+[canonicalize-issue-links]
+
 # Automatically close and reopen PRs made by bots to run CI on them
 [bot-pull-requests]


### PR DESCRIPTION
This PR enables two new triagebot feature `[canonicalize-issue-links]` and `[no-mentions]`.

Documentation at https://forge.rust-lang.org/triagebot/canonicalize-issue-links.html and https://forge.rust-lang.org/triagebot/no-mentions.html.