### PR TITLE
Add a first version of autodiff docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -99,6 +99,11 @@
 - [Rustdoc internals](./rustdoc-internals.md)
     - [Search](./rustdoc-internals/search.md)
 	- [The `rustdoc` test suite](./rustdoc-internals/rustdoc-test-suite.md)
+- [Autodiff internals](./autodiff/internals.md)
+    - [How to debug](./autodiff/debugging.md)
+    - [Autodiff flags](./autodiff/flags.md)
+    - [Current limitations](./autodiff/limitations.md)
+
 # Source Code Representation
 
 - [Prologue](./part-3-intro.md)

--- a/src/autodiff/debugging.md
+++ b/src/autodiff/debugging.md
@@ -1,0 +1,113 @@
+# Reporting backend crashes
+
+If after a compilation failure you are greeted by a large amount of llvm-ir code, then our enzyme backend likely failed to compile your code. These cases are harder to debug, so your help is highly appreciated. Please also keep in mind that release builds are usually much more likely to work at the moment.
+
+The final goal here is to reproduce your bug in the enzyme [compiler explorer](https://enzyme.mit.edu/explorer/), in order to create a bug report in the [Enzyme](https://github.com/enzymead/enzyme/issues) repository.
+
+We have an `autodiff` flag which you can pass to `rustflags` to help with this. it will print the whole llvm-ir module, along with some `__enzyme_fwddiff` or `__enzyme_autodiff` calls. A potential workflow on linux could look like:  
+
+## Controlling llvm-ir generation
+
+Before generating the llvm-ir, keep in mind two techniques that can help ensure the relevant rust code is visible for debugging:
+
+- **`std::hint::black_box`**: wrap rust variables or expressions in `std::hint::black_box()` to prevent rust and llvm from optimizing them away. This is useful when you need to inspect or manually manipulate specific values in the llvm-ir.
+- **`extern "rust"` or `extern "c"`**: if you want to see how a specific function declaration is lowered to llvm-ir, you can declare it as `extern "rust"` or `extern "c"`. You can also look for existing `__enzyme_autodiff` or similar declarations within the generated module for examples.
+
+## 1) Generate an llvm-ir reproducer
+
+```sh
+rustflags="-z autodiff=enable,printmodbefore" cargo +enzyme build --release &> out.ll 
+```
+
+This also captures a few warnings and info messages above and below your module. open out.ll and remove every line above `; moduleid = <somehash>`. Now look at the end of the file and remove everything that's not part of llvm-ir, i.e. remove errors and warnings. The last line of your llvm-ir should now start with `!<somenumber> = `, i.e. `!40831 = !{i32 0, i32 1037508, i32 1037538, i32 1037559}` or `!43760 = !dilocation(line: 297, column: 5, scope: !43746)`.
+
+The actual numbers will depend on your code.  
+
+## 2) Check your llvm-ir reproducer
+
+To confirm that your previous step worked, we will use llvm's `opt` tool. find your path to the opt binary, with a path similar to `<some_dir>/rust/build/<x86/arm/...-target-tripple>/build/bin/opt`. also find `llvmenzyme-19.<so/dll/dylib>` path, similar to `/rust/build/target-tripple/enzyme/build/enzyme/llvmenzyme-19`. Please keep in mind that llvm frequently updates it's llvm backend, so the version number might be higher (20, 21, ...). Once you have both, run the following command:
+
+```sh
+<path/to/opt> out.ll -load-pass-plugin=/path/to/llvmenzyme-19.so -passes="enzyme" -s
+```
+
+If the previous step succeeded, you are going to see the same error that you saw when compiling your rust code with cargo. 
+
+If you fail to get the same error, please open an issue in the rust repository. If you succeed, congrats! the file is still huge, so let's automatically minimize it.
+
+## 3) Minimize your llvm-ir reproducer
+
+First find your `llvm-extract` binary, it's in the same folder as your opt binary. then run:
+
+```sh
+<path/to/llvm-extract> -s --func=<name> --recursive --rfunc="enzyme_autodiff*" --rfunc="enzyme_fwddiff*" --rfunc=<fnc_called_by_enzyme> out.ll -o mwe.ll 
+```
+
+This command creates `mwe.ll`, a minimal working example.
+
+Please adjust the name passed with the last `--func` flag. You can either apply the `#[no_mangle]` attribute to the function you differentiate, then you can replace it with the rust name. otherwise you will need to look up the mangled function name. To do that, open `out.ll` and search for `__enzyme_fwddiff` or `__enzyme_autodiff`. the first string in that function call is the name of your function. example:
+
+```llvm-ir 
+define double @enzyme_opt_helper_0(ptr %0, i64 %1, double %2) {
+  %4 = call double (...) @__enzyme_fwddiff(ptr @_zn2ad3_f217h3b3b1800bd39fde3e, metadata !"enzyme_const", ptr %0, metadata !"enzyme_const", i64 %1, metadata !"enzyme_dup", double %2, double %2)
+  ret double %4
+}
+```
+
+Here, `_zn2ad3_f217h3b3b1800bd39fde3e` is the correct name. make sure to not copy the leading `@`. redo step 2) by running the `opt` command again, but this time passing `mwe.ll` as the input file instead of `out.ll`. Check if this minimized example still reproduces the crash.
+
+## 4) (Optional) Minimize your llvm-ir reproducer further.
+
+After the previous step you should have an `mwe.ll` file with ~5k loc. let's try to get it down to 50. find your `llvm-reduce` binary next to `opt` and `llvm-extract`. Copy the first line of your error message, an example could be:
+
+```sh
+opt: /home/manuel/prog/rust/src/llvm-project/llvm/lib/ir/instructions.cpp:686: void llvm::callinst::init(llvm::functiontype*, llvm::value*, llvm::arrayref<llvm::value*>, llvm::arrayref<llvm::operandbundledeft<llvm::value*> >, const llvm::twine&): assertion `(args.size() == fty->getnumparams() || (fty->isvararg() && args.size() > fty->getnumparams())) && "calling a function with bad signature!"' failed.
+```
+
+If you just get a `segfault` there is no sensible error message and not much to do automatically, so continue to 5).  
+otherwise, create a `script.sh` file containing
+
+```sh
+#!/bin/bash
+<path/to/your/opt> $1 -load-pass-plugin=/path/to/llvmenzyme-19.so -passes="enzyme" \
+    |& grep "/some/path.cpp:686: void llvm::callinst::init"
+```
+
+Experiment a bit with which error message you pass to grep. it should be long enough to make sure that the error is unique. However, for longer errors including `(` or `)` you will need to escape them correctly which can become annoying. Run
+
+```sh 
+<path/to/llvm-reduce> --test=script.sh mwe.ll 
+```
+
+If you see `input isn't interesting! verify interesting-ness test`, you got the error message in script.sh wrong, you need to make sure that grep matches your actual error. If all works out, you will see a lot of iterations, ending with a new `reduced.ll` file. Verify with `opt` that you still get the same error.
+
+### Advanced debugging: manual llvm-ir investigation
+
+Once you have a minimized reproducer (`mwe.ll` or `reduced.ll`), you can delve deeper:
+
+- **manual editing:** try manually rewriting the llvm-ir. for certain issues, like those involving indirect calls, you might investigate enzyme-specific intrinsics like `__enzyme_virtualreverse`. Understanding how to use these might require consulting enzyme's documentation or source code.
+- **enzyme test cases:** look for relevant test cases within the [enzyme repository](https://github.com/enzymead/enzyme/tree/main/enzyme/test) that might demonstrate the correct usage of features or intrinsics related to your problem.
+
+## 5) Report your bug.
+
+Afterwards, you should be able to copy and paste your `mwe.ll` (or `reduced.ll`) example into our [compiler explorer](https://enzyme.mit.edu/explorer/).
+
+- Select `llvm ir` as language and `opt 20` as compiler.
+- Replace the field to the right of your compiler with `-passes="enzyme"`, if it is not already set.
+- Hopefully, you will see once again your now familiar error.
+- Please use the share button to copy links to them.
+- Please create an issue on [https://github.com/enzymead/enzyme/issues](https://github.com/enzymead/enzyme/issues) and share `mwe.ll` and (if you have it) `reduced.ll`, as well as links to the compiler explorer. Please feel free to also add your rust code or a link to it.
+
+#### Documenting findings
+
+some enzyme errors, like `"attempting to call an indirect active function whose runtime value is inactive"`, have historically caused confusion. If you investigate such an issue, even if you don't find a complete solution, please consider documenting your findings. If the insights are general to enzyme and not specific to its rust usage, contributing them to the main [enzyme documentation](https://github.com/enzymead/www) is often the best first step. You can also mention your findings in the relevant enzyme github issue or propose updates to these docs if appropriate. This helps prevent others from starting from scratch.
+
+With a clear reproducer and documentation, hopefully an enzyme developer will be able to fix your bug. Once that happens, the enzyme submodule inside the rust compiler will be updated, which should allow you to differentiate your rust code. Thanks for helping us to improve rust-ad.
+
+# Minimize rust code
+
+Beyond having a minimal llvm-ir reproducer, it is also helpful to have a minimal rust reproducer without dependencies. This allows us to add it as a test case to ci once we fix it, which avoids regressions for the future.
+
+There are a few solutions to help you with minimizing the rust reproducer. This is probably the most simple automated approach: [cargo-minimize](https://github.com/nilstrieb/cargo-minimize).
+
+Otherwise we have various alternatives, including [`treereduce`](https://github.com/langston-barrett/treereduce), [`halfempty`](https://github.com/googleprojectzero/halfempty), or [`picireny`](https://github.com/renatahodovan/picireny), potentially also [`creduce`](https://github.com/csmith-project/creduce).

--- a/src/autodiff/flags.md
+++ b/src/autodiff/flags.md
@@ -1,0 +1,42 @@
+# Supported `RUSTFLAGS`
+
+To support you while debugging or profiling, we have added support for an experimental `-Z autodiff` rustc flag (which can be passed to cargo via `RUSTFLAGS`), which allow changing the behaviour of Enzyme, without recompiling rustc. We currently support the following values for `autodiff`.
+
+### Debug Flags
+
+```text
+PrintTA // Print TypeAnalysis information
+PrintAA // Print ActivityAnalysis information
+Print // Print differentiated functions while they are being generated and optimized
+PrintPerf // Print AD related Performance warnings
+PrintModBefore // Print the whole LLVM-IR module directly before running AD
+PrintModAfter // Print the whole LLVM-IR module after running AD, before optimizations
+PrintModFinal // Print the whole LLVM-IR module after running optimizations and AD
+LooseTypes // Risk incorrect derivatives instead of aborting when missing Type Info 
+```
+
+<div class="warning">
+`LooseTypes` is often helpful to get rid of Enzyme errors stating `Can not deduce type of <X>` and to be able to run some code. But please keep in mind that this flag absolutely has the chance to cause incorrect gradients. Even worse, the gradients might be correct for certain input values, but not for others. So please create issues about such bugs and only use this flag temporarily while you wait for your bug to be fixed.
+</div>
+
+### Benchmark flags
+
+For performance experiments and benchmarking we also support
+
+```text
+NoPostopt // We won't optimize the LLVM-IR Module after AD
+RuntimeActivity // Enables the runtime activity feature from Enzyme 
+Inline // Instructs Enzyme to maximize inlining as far as possible, beyond LLVM's default
+```
+
+You can combine multiple `autodiff` values using a comma as separator:
+
+```bash
+RUSTFLAGS="-Z autodiff=Enable,LooseTypes,PrintPerf" cargo +enzyme build
+```
+
+Using `-Zautodiff=Enable` will allow using autodiff and update your normal rustc compilation pipeline:
+
+1. Run your selected compilation pipeline. If you selected a release build, we will disable vectorization and loop unrolling.
+2. Differentiate your functions.
+3. Run your selected compilation pipeline again on the whole module. This time we do not disable vectorization or loop unrolling.

--- a/src/autodiff/internals.md
+++ b/src/autodiff/internals.md
@@ -1,0 +1,27 @@
+The `std::autodiff` module in Rust allows differentiable programming:
+
+```rust
+#![feature(autodiff)]
+use std::autodiff::autodiff;
+
+// f(x) = x * x, f'(x) = 2.0 * x
+// bar therefore returns (x * x, 2.0 * x)
+#[autodiff(bar, Reverse, Active, Active)]
+fn foo(x: f32) -> f32 { x * x }
+
+fn main() {
+    assert_eq!(bar(3.0, 1.0), (9.0, 6.0));
+    assert_eq!(bar(4.0, 1.0), (16.0, 8.0));
+}
+```
+
+The detailed documentation for the `std::autodiff` module is available at [std::autodiff](https://doc.rust-lang.org/std/autodiff/index.html).
+
+Differentiable programing is used in various fields like numerical computing, [solid mechanics][ratel], [computational chemistry][molpipx], [fluid dynamics][waterlily] or for Neural Network training via Backpropagation, [ODE solver][diffsol], [differentiable rendering][libigl], [quantum computing][catalyst], and climate simulations.
+
+[ratel]: https://gitlab.com/micromorph/ratel
+[molpipx]: https://arxiv.org/abs/2411.17011v
+[waterlily]: https://github.com/WaterLily-jl/WaterLily.jl
+[diffsol]: https://github.com/martinjrobins/diffsol
+[libigl]: https://github.com/alecjacobson/libigl-enzyme-example?tab=readme-ov-file#run
+[catalyst]: https://github.com/PennyLaneAI/catalyst

--- a/src/autodiff/limitations.md
+++ b/src/autodiff/limitations.md
@@ -1,0 +1,27 @@
+# Current limitations
+ 
+## Safety and Soundness
+
+Enzyme currently assumes that the user passes shadow arguments (`dx`, `dy`, ...) of appropriate size. Under Reverse Mode, we additionally assume that shadow arguments are mutable. In Reverse Mode we adjust the outermost pointer or reference to be mutable. Therefore `&f32` will receive the shadow type `&mut f32`. However, we do not check length for other types than slices (e.g. enums, Vec). We also do not enforce mutability of inner references, but will warn if we recognize them. We do intend to add additional checks over time.
+
+## ABI adjustments
+
+In some cases, a function parameter might get lowered in a way that we currently don't handle correctly, leading to a compile time type mismatch in the `rustc_codegen_llvm` backend. Here are some [examples](https://github.com/EnzymeAD/rust/issues/105).
+
+## Compile Times
+
+Enzyme will often achieve excellent runtime performance, but might increase your compile time by a large factor. For Rust, we already have made significant improvements and have a list of further improvements planed - please reach out if you have time to help here.
+
+### Type Analysis
+
+Most of the times, Type Analysis (TA) is the reason of large (>5x) compile time increases when using Enzyme. This poster explains why we need to run Type Analysis in the bottom left part: [Poster Link](https://c.wsmoses.com/posters/Enzyme-llvmdev.pdf).
+
+We intend to increase the number of locations where we pass down Type information based on Rust types, which in turn will reduce the number of locations where Enzyme has to run Type Analysis, which will help compile times.
+
+### Duplicated Optimizations
+
+The key reason for Enzyme offering often excellent performance is that Enzyme differentiates already optimized LLVM-IR. However, we also (have to) run LLVM's optimization pipeline after differentiating, to make sure that the code which Enzyme generates is optimized properly. As a result you should have excellent runtime performance (please fill an issue if not), but at a compile time cost for running optimizations twice.
+
+### Fat-LTO 
+
+The usage of `#[autodiff(...)]` currently requires compiling your project with Fat-LTO. We technically only need LTO if the function being differentiated calls functions in other compilation units. Therefore, other solutions are possible, but this is the most simple one to get started. 


### PR DESCRIPTION
Upstreaming of std::autodiff got approved, so I want to get rid of my docs under https://enzyme.mit.edu/rust/
These are the first ones, I'll add a few more docs here and to the nightly docs.

r? @jieyouxu 