### PR TITLE
fix(docs): add newlines between prefix/suffix chapters

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Getting Started](./getting-started.md)
+
 [About this guide](./about-this-guide.md)
 
 ---
@@ -230,9 +231,13 @@
 ---
 
 [Appendix A: Background topics](./appendix/background.md)
+
 [Appendix B: Glossary](./appendix/glossary.md)
+
 [Appendix C: Code Index](./appendix/code-index.md)
+
 [Appendix D: Compiler Lecture Series](./appendix/compiler-lecture.md)
+
 [Appendix E: Bibliography](./appendix/bibliography.md)
 
 [Appendix Z: HumorRust](./appendix/humorust.md)


### PR DESCRIPTION
Close: rust-lang/rustc-dev-guide#2341