### PR TITLE
Enable [behind-upstream] triagebot option

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,3 +9,6 @@ allow-unauthenticated = [
 
 # Automatically close and reopen PRs made by bots to run CI on them
 [bot-pull-requests]
+
+[behind-upstream]
+days-threshold = 7


### PR DESCRIPTION
Let's try running it on a repository first.

Doc: https://forge.rust-lang.org/triagebot/behind-upstream.html

r? @Urgau 

cc @Kobzol 
