### PR TITLE
use repo name in push pr title

### DIFF
--- a/josh-sync/src/sync.rs
+++ b/josh-sync/src/sync.rs
@@ -194,7 +194,7 @@ impl GitSync {
         );
         println!(
             // Open PR with `subtree update` title to silence the `no-merges` triagebot check
-            "    https://github.com/{UPSTREAM_REPO}/compare/{github_user}:{branch}?quick_pull=1&title=Rustc+dev+guide+subtree+update&body=r?+@ghost"
+            "    https://github.com/{UPSTREAM_REPO}/compare/{github_user}:{branch}?quick_pull=1&title=rustc-dev-guide+subtree+update&body=r?+@ghost"
         );
 
         drop(josh);


### PR DESCRIPTION
~Also, remove `@ghost` in pr description, to avoid confusion... thought it was a real user.~
Heh, I see [it has utility](https://forge.rust-lang.org/triagebot/pr-assignment.html#ghost).