### PR TITLE
Adds 'with' to the bootstrapping docs to help clarify how to build a new compiler

### DIFF
--- a/src/building/bootstrapping/intro.md
+++ b/src/building/bootstrapping/intro.md
@@ -7,7 +7,7 @@ of the same compiler.
 This raises a chicken-and-egg paradox: where did the first compiler come from?
 It must have been written in a different language. In Rust's case it was
 [written in OCaml][ocaml-compiler]. However it was abandoned long ago and the
-only way to build a modern version of rustc is a slightly less modern
+only way to build a modern version of rustc is with a slightly less modern
 version.
 
 This is exactly how `x.py` works: it downloads the current beta release of

--- a/src/building/bootstrapping/intro.md
+++ b/src/building/bootstrapping/intro.md
@@ -6,7 +6,7 @@ of the same compiler.
 
 This raises a chicken-and-egg paradox: where did the first compiler come from?
 It must have been written in a different language. In Rust's case it was
-[written in OCaml][ocaml-compiler]. However it was abandoned long ago and the
+[written in OCaml][ocaml-compiler]. However, it was abandoned long ago, and the
 only way to build a modern version of rustc is with a slightly less modern
 version.
 

--- a/src/building/bootstrapping/what-bootstrapping-does.md
+++ b/src/building/bootstrapping/what-bootstrapping-does.md
@@ -8,7 +8,7 @@ the same compiler.
 
 This raises a chicken-and-egg paradox: where did the first compiler come from?
 It must have been written in a different language. In Rust's case it was
-[written in OCaml][ocaml-compiler]. However it was abandoned long ago and the
+[written in OCaml][ocaml-compiler]. However, it was abandoned long ago, and the
 only way to build a modern version of `rustc` is with a slightly less modern version.
 
 This is exactly how [`./x.py`] works: it downloads the current beta release of

--- a/src/building/bootstrapping/what-bootstrapping-does.md
+++ b/src/building/bootstrapping/what-bootstrapping-does.md
@@ -9,7 +9,7 @@ the same compiler.
 This raises a chicken-and-egg paradox: where did the first compiler come from?
 It must have been written in a different language. In Rust's case it was
 [written in OCaml][ocaml-compiler]. However it was abandoned long ago and the
-only way to build a modern version of `rustc` is a slightly less modern version.
+only way to build a modern version of `rustc` is with a slightly less modern version.
 
 This is exactly how [`./x.py`] works: it downloads the current beta release of
 `rustc`, then uses it to compile the new compiler.


### PR DESCRIPTION
The sentence

> However it was abandoned long ago and the only way to build a modern version of rustc is **a** slightly less modern version.

feels like it's grammatically missing the preposition 'with', as well as some commas around "However" etc.