### PR TITLE
Is the parser undergoing refactoring?

### DIFF
--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -2,7 +2,7 @@
 
 <!-- toc -->
 
-> N.B. [`rustc_ast`], [`rustc_expand`], and [`rustc_builtin_macros`] are all
+> N.B. as of Nov 2019 [`rustc_ast`], [`rustc_expand`], and [`rustc_builtin_macros`] are all
 > undergoing refactoring, so some of the links in this chapter may be broken.
 
 Rust has a very powerful macro system. In the previous chapter, we saw how


### PR DESCRIPTION
The suggested change is more of conversation starter. I could track the introduction of the message to https://github.com/rust-lang/rustc-dev-guide/commit/a50b8f144f554e8d56210ed064f77f2d7ec7d41f which is from Nov 2019.

Is the refactor still undergoing? Is there a tracking issue for it?

If not, the N.B. can just be deleted... but maybe the document would need to be updated with the changes from the refactor if that's the case?