### PR TITLE
Make it clear we talk about early bound params

### DIFF
--- a/src/early_late_parameters.md
+++ b/src/early_late_parameters.md
@@ -174,7 +174,8 @@ As mentioned previously, the distinction between early and late bound parameters
 - When naming a function (early)
 - When calling a function (late)
 
-There currently is no syntax for explicitly specifying generic arguments for late bound parameters as part of the call step, only specifying generic arguments when naming a function. The syntax `foo::<'static>();`, despite being part of a function call, behaves as `(foo::<'static>)();` and instantiates the early bound generic parameters on the function item type.
+There is currently no syntax for explicitly specifying generic arguments for late bound parameters during the call step; generic arguments can only be specified for early bound parameters when naming a function.
+The syntax `foo::<'static>();`, despite being part of a function call, behaves as `(foo::<'static>)();` and instantiates the early bound generic parameters on the function item type.
 
 See the following example:
 ```rust


### PR DESCRIPTION
While this is implicit, since "early bound params" are the ones that are bound when naming a function, for the non-expert (myself; most people motivated to read the manual) it helps to be explicit here.

Not feeling strongly about this one. Feel free to ignore/tell me to close PR.

Also let me know if I should rather not propose similar changes in the future.