### PR TITLE
Add LLVM link in appendix

### DIFF
--- a/src/appendix/compiler-lecture.md
+++ b/src/appendix/compiler-lecture.md
@@ -46,3 +46,4 @@ These are videos where various experts explain different parts of the compiler:
 
 ## Code Generation
 - [January 2019: Cranelift](https://www.youtube.com/watch?v=9OIA7DTFQWU)
+- [December 2024: LLVM Developers' Meeting - Rust ❤️ LLVM](https://www.youtube.com/watch?v=Kqz-umsAnk8)


### PR DESCRIPTION
A good talk to catch up with the status of Rust with LLVM.
