### PR TITLE
remove "Easy" and "good-first-issue" from help-wanted-search

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -89,7 +89,7 @@ filtering the search to areas you're interested in. For example:
 Not all important or beginner work has issue labels.
 See below for how to find work that isn't labelled.
 
-[help-wanted-search]: https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Arust-lang+no%3Aassignee+label%3AE-easy%2C%22good+first+issue%22%2Cgood-first-issue%2CE-medium%2CEasy%2CE-help-wanted%2CE-mentor+-label%3AS-blocked+-linked:pr+
+[help-wanted-search]: https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Arust-lang+no%3Aassignee+label%3AE-easy%2C%22good+first+issue%22%2CE-medium%2CE-help-wanted%2CE-mentor+-label%3AS-blocked+-linked:pr+
 [Triage]: ./contributing.md#issue-triage
 
 ### Recurring work


### PR DESCRIPTION
previously, they gavea a warning about being "invalid filters". that seems like a github bug, because they were definitely present in the clippy and reference repos, but i worked around it by asking clippy and the reference to change to `E-easy` and `good first issue` instead. update the search now, so that people don't see a warning.