### PR TITLE
Remove rustdoc askama migration from getting started

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -98,7 +98,6 @@ Some work is too large to be done by a single person. In this case, it's common 
 issues" to co-ordinate the work between contributors. Here are some example tracking issues where
 it's easy to pick up work without a large time commitment:
 
-- [Rustdoc Askama Migration](https://github.com/rust-lang/rust/issues/108868)
 - [Diagnostic Translation](https://github.com/rust-lang/rust/issues/100717)
 - [Move UI tests to subdirectories](https://github.com/rust-lang/rust/issues/73494)
 


### PR DESCRIPTION
This effort is blocked, so pointing new contributors here would be setting them up for failure.

https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/about.3A.20status.20of.20askama.20migration/with/497389045