### PR TITLE
Adjust triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,9 +2,20 @@
 
 [relabel]
 allow-unauthenticated = [
-    "waiting-on-review",
-    "waiting-on-author",
-    "blocked",
+    "-Z*",
+    "A-*",
+    "C-*",
+    "D-*",
+    "E-*",
+    "F-*",
+    "I-*",
+    "L-*",
+    "O-*",
+    "PG-*",
+    "S-*",
+    "T-*",
+    "WG-*",
+    "needs-triage",
 ]
 
 [no-mentions]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -29,6 +29,10 @@ add_labels = ["S-waiting-on-review"]
 [autolabel."S-waiting-on-review"]
 new_pr = true
 
+# Enable issue transfers within the org
+# Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
+[transfer]
+
 [relabel]
 allow-unauthenticated = [
     "-Z*",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -51,6 +51,10 @@ allow-unauthenticated = [
     "needs-triage",
 ]
 
+# Enable `@rustbot note` functionality
+# Documentation at: https://forge.rust-lang.org/triagebot/note.html
+[note]
+
 [no-mentions]
 
 [canonicalize-issue-links]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -55,6 +55,8 @@ allow-unauthenticated = [
 # Documentation at: https://forge.rust-lang.org/triagebot/note.html
 [note]
 
+# Prevents mentions in commits to avoid users being spammed
+# Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
 [no-mentions]
 
 [canonicalize-issue-links]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -59,7 +59,10 @@ allow-unauthenticated = [
 # Documentation at: https://forge.rust-lang.org/triagebot/no-mentions.html
 [no-mentions]
 
-[canonicalize-issue-links]
+# Canonicalize issue numbers to avoid closing the wrong issue
+# when commits are included in subtrees, as well as warning links in commits.
+# Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
+[issue-links]
 
 # Automatically close and reopen PRs made by bots to run CI on them
 [bot-pull-requests]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,4 +1,14 @@
+# This file's format is documented at
+# https://forge.rust-lang.org/triagebot/pr-assignment.html#configuration
+
 [assign]
+
+[autolabel."needs-triage"]
+new_issue = true
+exclude_labels = [
+    "A-diagnostics",
+    "C-tracking-issue",
+]
 
 [relabel]
 allow-unauthenticated = [

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,6 +10,25 @@ exclude_labels = [
     "C-tracking-issue",
 ]
 
+[review-submitted]
+# This label is added when a "request changes" review is submitted.
+reviewed_label = "S-waiting-on-author"
+# These labels are removed when a "request changes" review is submitted.
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+# Those labels are removed when PR author requests a review from an assignee
+remove_labels = ["S-waiting-on-author"]
+# Those labels are added when PR author requests a review from an assignee
+add_labels = ["S-waiting-on-review"]
+
+# Enable tracking of PR review assignment
+# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment-tracking.html
+[shortcut]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
 [relabel]
 allow-unauthenticated = [
     "-Z*",


### PR DESCRIPTION
Best reviewed commit-by-commit.
Closes rust-lang/rustc-dev-guide#2411. No `adhoc_groups` are set up yet, intended as follow-up.

cc @BoxyUwU
r? @Kobzol 