### PR TITLE
Setup basic `r? rustc-dev-guide` review group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -69,3 +69,12 @@ allow-unauthenticated = [
 
 [behind-upstream]
 days-threshold = 7
+
+# Keep members alphanumerically sorted.
+[assign.adhoc_groups]
+rustc-dev-guide = [
+    "@BoxyUwU",
+    "@jieyouxu",
+    "@jyn514",
+    "@tshepang",
+]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -22,8 +22,8 @@ remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
 
-# Enable tracking of PR review assignment
-# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment-tracking.html
+# Enable shortcuts like `@rustbot ready`
+# Documentation at: https://forge.rust-lang.org/triagebot/shortcuts.html
 [shortcut]
 
 [autolabel."S-waiting-on-review"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,8 +1,6 @@
 # This file's format is documented at
 # https://forge.rust-lang.org/triagebot/pr-assignment.html#configuration
 
-[assign]
-
 [autolabel."needs-triage"]
 new_issue = true
 exclude_labels = [
@@ -69,6 +67,10 @@ allow-unauthenticated = [
 
 [behind-upstream]
 days-threshold = 7
+
+# Enable triagebot (PR) assignment.
+# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment.html
+[assign]
 
 # Keep members alphanumerically sorted.
 [assign.adhoc_groups]


### PR DESCRIPTION
This is a set of **opt-in** reviewers that PR authors can request reviews from via `r? rustc-dev-guide` following discussions in [#t-compiler/rustc-dev-guide > Adjust triagebot configs @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/196385-t-compiler.2Frustc-dev-guide/topic/Adjust.20triagebot.20configs/near/521342052). I added initial WG members who indicated that they would like to be added to the opt-in review group.

No new PR messages are configured yet, as it is not yet a supported triagebot functionality.

Part of https://github.com/rust-lang/rustc-dev-guide/issues/2428.