### PR TITLE
Trivial: fix typo (change `foo` to `bar`)

### DIFF
--- a/src/return-position-impl-trait-in-trait.md
+++ b/src/return-position-impl-trait-in-trait.md
@@ -356,7 +356,7 @@ trait Foo {
 
 Failing because a down-stream impl could theoretically provide an
 implementation for `RPITIT` without providing an implementation of
-`foo`:
+`bar`:
 
 ```text
 error[E0308]: mismatched types


### PR DESCRIPTION
There is no `foo` symbol in the preceding example. I assume the method `bar` is meant.