### PR TITLE
update AST-to-HIR lowering examples for conditionals and loops

### DIFF
--- a/src/hir/lowering.md
+++ b/src/hir/lowering.md
@@ -7,10 +7,8 @@ of such structures include but are not limited to
 
 * Parenthesis
     * Removed without replacement, the tree structure makes order explicit
-* `for` loops and `while (let)` loops
-    * Converted to `loop` + `match` and some `let` bindings
-* `if let`
-    * Converted to `match`
+* `for` loops
+    * Converted to `match` + `loop` + `match`
 * Universal `impl Trait`
     * Converted to generic arguments
       (but with some flags, to know that the user didn't write them)


### PR DESCRIPTION
- `for` loops now use two `match`es for all of their bindings. I'm not sure this is the most helpful way of conveying that, but it's about as informative as before while staying brief. I'd be happy to make this clearer, if anyone has ideas.
- `while let` and `if let` don't use `match`; they use `let` expressions in their conditions. Since `if let` no longer has a significantly different desugaring and having a whole bullet point for `while` would feel redundant with `for`, I've removed those examples.