### PR TITLE
Migrate rustc-pull to CI workflow from `josh-sync`

### DIFF
--- a/.github/workflows/rustc-pull.yml
+++ b/.github/workflows/rustc-pull.yml
@@ -9,105 +9,12 @@ on:
 jobs:
   pull:
     if: github.repository == 'rust-lang/rustc-dev-guide'
-    runs-on: ubuntu-latest
-    outputs:
-      pr_url: ${{ steps.update-pr.outputs.pr_url }}
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # We need the full history for josh to work
-          fetch-depth: '0'
-      - name: Install stable Rust toolchain
-        run: rustup update stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Cache the josh directory with checked out rustc
-          cache-directories: "/home/runner/.cache/rustc-josh"
-      - name: Install rustc-josh-sync
-        run: cargo install --locked --git https://github.com/rust-lang/josh-sync
-      - name: Setup bot git name and email
-        run: |
-          git config --global user.name 'The rustc-dev-guide Cronjob Bot'
-          git config --global user.email 'github-actions@github.com'
-      - name: Perform rustc-pull
-        id: rustc-pull
-        # Turn off -e to disable early exit
-        shell: bash {0}
-        run: |
-          rustc-josh-sync pull
-          exitcode=$?
-
-          # If no pull was performed, we want to mark this job as successful,
-          # but we do not want to perform the follow-up steps.
-          if [ $exitcode -eq 0 ]; then
-            echo "pull_result=pull-finished" >> $GITHUB_OUTPUT
-          elif [ $exitcode -eq 2 ]; then
-            echo "pull_result=skipped" >> $GITHUB_OUTPUT
-            exitcode=0
-          fi
-
-          exit ${exitcode}
-      - name: Push changes to a branch
-        if: ${{ steps.rustc-pull.outputs.pull_result == 'pull-finished' }}
-        run: |
-          # Update a sticky branch that is used only for rustc pulls
-          BRANCH="rustc-pull"
-          git switch -c $BRANCH
-          git push -u origin $BRANCH --force
-      - name: Create pull request
-        id: update-pr
-        if: ${{ steps.rustc-pull.outputs.pull_result == 'pull-finished' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Check if an open pull request for an rustc pull update already exists
-          # If it does, the previous push has just updated it
-          # If not, we create it now
-          RESULT=`gh pr list --author github-actions[bot] --state open -q 'map(select(.title=="Rustc pull update")) | length' --json title`
-          if [[ "$RESULT" -eq 0 ]]; then
-            echo "Creating new pull request"
-            PR_URL=`gh pr create -B master --title 'Rustc pull update' --body 'Latest update from rustc.'`
-            echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          else
-            PR_URL=`gh pr list --author github-actions[bot] --state open -q 'map(select(.title=="Rustc pull update")) | .[0].url' --json url,title`
-            echo "Updating pull request ${PR_URL}"
-            echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
-          fi
-  send-zulip-message:
-    needs: [pull]
-    if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Compute message
-        id: create-message
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ needs.pull.result }}" == "failure" ]; then
-            WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            echo "message=Rustc pull sync failed. Check out the [workflow URL]($WORKFLOW_URL)." >> $GITHUB_OUTPUT
-          else
-            CREATED_AT=`gh pr list --author github-actions[bot] --state open -q 'map(select(.title=="Rustc pull update")) | .[0].createdAt' --json createdAt,title`
-            PR_URL=`gh pr list --author github-actions[bot] --state open -q 'map(select(.title=="Rustc pull update")) | .[0].url' --json url,title`
-            week_ago=$(date +%F -d '7 days ago')
-
-            # If there is an open PR that is at least a week old, post a message about it
-            if [[ -n $DATE_GH && $DATE_GH < $week_ago ]]; then
-              echo "message=A PR with a Rustc pull has been opened for more a week. Check out the [PR](${PR_URL})." >> $GITHUB_OUTPUT
-            fi
-          fi
-      - name: Send a Zulip message about updated PR
-        if: ${{ steps.create-message.outputs.message != '' }}
-        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
-        with:
-          api-key: ${{ secrets.ZULIP_API_TOKEN }}
-          email: "rustc-dev-guide-gha-notif-bot@rust-lang.zulipchat.com"
-          organization-url: "https://rust-lang.zulipchat.com"
-          to: 196385
-          type: "stream"
-          topic: "Subtree sync automation"
-          content: ${{ steps.create-message.outputs.message }}
+    uses: rust-lang/josh-sync/.github/workflows/rustc-pull.yml@main
+    with:
+      zulip-stream-id: 196385
+      zulip-bot-email:  "rustc-dev-guide-gha-notif-bot@rust-lang.zulipchat.com"
+      pr-base-branch: master
+      branch-name: rustc-pull
+    secrets:
+      zulip-api-token: ${{ secrets.ZULIP_API_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace the CI workflow in this repo with a generalized workflow from `josh-sync`. I tested this on my forks, but there's no other good way to test this than just merge it and see what happens on CI =D