### PR TITLE
Mention our policy on typofixes for internal docs

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -370,6 +370,9 @@ You can also use `rustdoc` directly to check small fixes. For example,
 `rustdoc src/doc/reference.md` will render reference to `doc/reference.html`.
 The CSS might be messed up, but you can verify that the HTML is right.
 
+Please notice that at this time we don't accept typography/spellcheck fixes to **internal documentation** (example:
+tests, library or compiler code) as it's usually not worth the churn or the review time.
+
 ### Contributing to rustc-dev-guide
 
 Contributions to the [rustc-dev-guide] are always welcome, and can be made directly at


### PR DESCRIPTION
Sister PR of [rust-forge#926](https://github.com/rust-lang/rust-forge/pull/926).

Add clearer wording about our "spellchecking / typos" contributing policy to discourage spellcheck patches on internal documentation.