### PR TITLE
stabilization_guide: fix macro name and syntax in gating example

### DIFF
--- a/src/stabilization_guide.md
+++ b/src/stabilization_guide.md
@@ -82,7 +82,7 @@ Most importantly, remove the code which flags an error if the feature-gate is no
 gate_all!(pub_restricted, "`pub(restricted)` syntax is experimental");
 ```
 
-This `gate_feature_post!` macro prints an error if the `pub_restricted` feature is not enabled. It is not needed now that `#[pub_restricted]` is stable.
+The `gate_all!` macro reports an error if the `pub_restricted` feature is not enabled. It is not needed now that `pub(restricted)` is stable.
 
 For more subtle features, you may find code like this:
 


### PR DESCRIPTION
- Use `gate_all!` consistently in both the example and the explanation.

- Fix `#[pub_restricted]` → `pub(restricted)`.

- No other example or API changes.


Fixes rust-lang/rustc-dev-guide#2401 