### PR TITLE
Remove myself from adhoc_group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -90,7 +90,6 @@ does not need reviews. You can request a review using `r? rustc-dev-guide` or \
 [assign.adhoc_groups]
 rustc-dev-guide = [
     "@BoxyUwU",
-    "@jieyouxu",
     "@jyn514",
     "@tshepang",
 ]


### PR DESCRIPTION
I can help with some reviews on a when-available basis, but I don't want to get rolled via the adhoc-group due to bandwidth.