### PR TITLE
dates: refresh query-system date annotations to 2025-08 (preserve style)

### DIFF
--- a/src/queries/query-evaluation-model-in-detail.md
+++ b/src/queries/query-evaluation-model-in-detail.md
@@ -74,7 +74,7 @@ executed, no results are cached. But the context already provides access to
 "input" data, i.e. pieces of immutable data that were computed before the
 context was created and that queries can access to do their computations.
 
-As of <!-- date-check --> January 2021, this input data consists mainly of
+As of <!-- date-check --> August 2025, this input data consists mainly of
 the HIR map, upstream crate metadata, and the command-line options the compiler
 was invoked with; but in the future inputs will just consist of command-line
 options and a list of source files -- the HIR map will itself be provided by a

--- a/src/queries/salsa.md
+++ b/src/queries/salsa.md
@@ -7,7 +7,7 @@ want to watch [Salsa In More
 Depth](https://www.youtube.com/watch?v=i_IhACacPRY), also by Niko
 Matsakis.
 
-> As of <!-- date-check --> November 2022, although Salsa is inspired by (among
+> As of <!-- date-check --> August 2025, although Salsa is inspired by (among
 > other things) rustc's query system, it is not used directly in rustc. It
 > _is_ used in [chalk], an implementation of  Rust's trait system, and
 > extensively in [`rust-analyzer`], the official implementation of the language

--- a/src/query.md
+++ b/src/query.md
@@ -1,7 +1,7 @@
 # Queries: demand-driven compilation
 
 As described in [Overview of the compiler], the Rust compiler
-is still (as of <!-- date-check --> July 2021) transitioning from a
+is still (as of <!-- date-check --> August 2025) transitioning from a
 traditional "pass-based" setup to a "demand-driven" system. The compiler query
 system is the key to rustc's demand-driven organization.
 The idea is pretty simple. Instead of entirely independent passes


### PR DESCRIPTION
Updated date-check annotations to **2025-08**, preserving the local format at each site.

**Addresses rust-lang/rustc-dev-guide#2528**