### PR TITLE
dates: refresh type system & traits date annotations to Aug/2025

### DIFF
--- a/src/borrow_check/region_inference/member_constraints.md
+++ b/src/borrow_check/region_inference/member_constraints.md
@@ -92,7 +92,7 @@ member constraints come in.
 ## Choices are always lifetime parameters
 
 At present, the "choice" regions from a member constraint are always lifetime
-parameters from the current function. As of <!-- date-check --> October 2021,
+parameters from the current function. As of <!-- date-check --> August 2025,
 this falls out from the placement of impl Trait, though in the future it may not
 be the case. We take some advantage of this fact, as it simplifies the current
 code. In particular, we don't have to consider a case like `'0 member of ['1,

--- a/src/opaque-types-type-alias-impl-trait.md
+++ b/src/opaque-types-type-alias-impl-trait.md
@@ -15,7 +15,7 @@ it implements `Bar`. Therefore, any of `Bar`'s interface can be used on a `Foo`,
 but nothing else (regardless of whether it implements any other traits).
 
 Since there needs to be a concrete background type,
-you can (as of <!-- date-check --> January 2021) express that type
+you can (as of <!-- date-check --> August 2025) express that type
 by using the opaque type in a "defining use site".
 
 ```rust,ignore

--- a/src/stability.md
+++ b/src/stability.md
@@ -30,7 +30,7 @@ unstable modules or vice versa.
 
 Previously, due to a [rustc bug], stable items inside unstable modules were
 available to stable code in that location.
-As of <!-- date-check --> September 2024, items with [accidentally stabilized
+As of <!-- date-check --> August 2025, items with [accidentally stabilized
 paths] are marked with the `#[rustc_allowed_through_unstable_modules]` attribute
 to prevent code dependent on those paths from breaking. Do *not* add this attribute
 to any more items unless that is needed to avoid breaking changes.

--- a/src/thir.md
+++ b/src/thir.md
@@ -2,7 +2,7 @@
 
 The THIR ("Typed High-Level Intermediate Representation"), previously called HAIR for
 "High-Level Abstract IR", is another IR used by rustc that is generated after
-[type checking]. It is (as of <!-- date-check --> January 2024) used for
+[type checking]. It is (as of <!-- date-check --> August 2025) used for
 [MIR construction], [exhaustiveness checking], and [unsafety checking].
 
 [type checking]: ./type-checking.md
@@ -52,7 +52,7 @@ fn main() {
 }
 ```
 
-Here is how that gets represented in THIR (as of <!-- date-check --> Aug 2022):
+Here is how that gets represented in THIR (as of <!-- date-check --> August 2025):
 
 ```rust,no_run
 Thir {

--- a/src/traits/chalk.md
+++ b/src/traits/chalk.md
@@ -1,7 +1,7 @@
 # Chalk-based trait solving
 
 [Chalk][chalk] is an experimental trait solver for Rust that is
-(as of <!-- date-check --> May 2022) under development by the [Types team].
+(as of <!-- date-check --> August 2025) under development by the [Types team].
 Its goal is to enable a lot of trait system features and bug fixes
 that are hard to implement (e.g. GATs or specialization). If you would like to
 help in hacking on the new solver, drop by on the rust-lang Zulip in the [`#t-types`]

--- a/src/traits/resolution.md
+++ b/src/traits/resolution.md
@@ -120,7 +120,7 @@ the obligation contains unbound inference variables.
 
 The subroutines that decide whether a particular impl/where-clause/etc applies
 to a particular obligation are collectively referred to as the process of
-_matching_. For `impl` candidates <!-- date-check: Oct 2022 -->,
+_matching_. For `impl` candidates <!-- date-check: Aug 2025 -->,
 this amounts to unifying the impl header (the `Self` type and the trait arguments)
 while ignoring  nested obligations. If matching succeeds then we add it
 to a set of candidates. There are other rules when assembling candidates for

--- a/src/ty-fold.md
+++ b/src/ty-fold.md
@@ -1,4 +1,4 @@
-<!-- date-check: may 2024 -->
+<!-- date-check: Aug 2025 -->
 # `TypeFoldable` and `TypeFolder`
 
 In [a previous chapter], we discussed instantiating binders.

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -66,7 +66,7 @@ inference works, or perhaps this blog post on
 [Unification in the Chalk project]: http://smallcultfollowing.com/babysteps/blog/2017/03/25/unification-in-chalk-part-1/
 
 All told, the inference context stores five kinds of inference variables
-(as of <!-- date-check --> March 2023):
+(as of <!-- date-check --> August 2025):
 
 - Type variables, which come in three varieties:
   - General type variables (the most common). These can be unified with any


### PR DESCRIPTION
Updated date-check annotations to the current month.

**Addresses rust-lang/rustc-dev-guide#2528**