### PR TITLE
make sentence more simple

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -90,7 +90,8 @@ The following test suites are available, with links for more information:
 | `rustdoc-ui`                         | Check terminal output of `rustdoc` ([see also](ui.md))                   |
 
 Some rustdoc-specific tests can also be found in `ui/rustdoc/`.
-These check rustdoc-related or -specific lints that (also) run as part of `rustc`, not (only) `rustdoc`.
+These check lints that are either related or specific to rustdoc,
+that also run as part of `rustc`, not (only) `rustdoc`.
 Run-make tests pertaining to rustdoc are typically named `run-make/rustdoc-*/`.
 
 [rustdoc-html-tests]: ../rustdoc-internals/rustdoc-test-suite.md


### PR DESCRIPTION
I don't understand what "not (only) `rustdoc`" means