### PR TITLE
rustdoc: document ESLint/TSC run via tidy in CI; add local reproduce commands

### DIFF
--- a/src/rustdoc-internals/rustdoc-gui-test-suite.md
+++ b/src/rustdoc-internals/rustdoc-gui-test-suite.md
@@ -34,6 +34,8 @@ On macOS you may see small pixel/position diffs that fail some rustdoc-gui tests
 
 Running `npx tsc` directly depends on your local TypeScript environment (DOM vs Node types). Prefer the suites above when in doubt.
 
+In CI, these checks run inside the dedicated "tidy" job (see the "tidy" job in GitHub Actions). It installs tidy and runs `./x.py test tidy -vv`, which triggers the ESLint/TypeScript steps described above.
+
 [Rustdoc test suites]: ../tests/compiletest.md#rustdoc-test-suites
 [`browser-UI-test`]: https://github.com/GuillaumeGomez/browser-UI-test/
 [puppeteer]: https://pptr.dev/

--- a/src/rustdoc-internals/rustdoc-gui-test-suite.md
+++ b/src/rustdoc-internals/rustdoc-gui-test-suite.md
@@ -7,6 +7,33 @@ For other rustdoc-specific test suites, see [Rustdoc test suites].
 
 These use a NodeJS-based tool called [`browser-UI-test`] that uses [puppeteer] to run tests in a headless browser and check rendering and interactivity. For information on how to write this form of test, see [`tests/rustdoc-gui/README.md`][rustdoc-gui-readme] as well as [the description of the `.goml` format][goml-script]
 
+### Rustdoc frontend checks in CI (ESLint & TypeScript)
+
+Rustdoc's JS/TS **linting and type-checking** are **not** performed by `compiletest`. In CI they run under the tidy "extra checks" step, which invokes ESLint and `tsc` on rustdoc's frontend sources.
+
+To reproduce locally (mirrors CI behavior for rustdoc's frontend suites):
+
+```bash
+./x.py test --stage 2 tests/rustdoc-js
+./x.py test --stage 2 tests/rustdoc-js-std
+./x.py test --stage 2 tests/rustdoc-gui
+```
+
+You can also run the linters directly in the frontend sources:
+
+```bash
+cd rust/src/librustdoc/html/static/js
+npm ci
+npx tsc -p tsconfig.json
+npx eslint .
+```
+
+**Notes**
+
+On macOS you may see small pixel/position diffs that fail some rustdoc-gui tests locally; CI's Linux baseline is authoritative.
+
+Running `npx tsc` directly depends on your local TypeScript environment (DOM vs Node types). Prefer the suites above when in doubt.
+
 [Rustdoc test suites]: ../tests/compiletest.md#rustdoc-test-suites
 [`browser-UI-test`]: https://github.com/GuillaumeGomez/browser-UI-test/
 [puppeteer]: https://pptr.dev/


### PR DESCRIPTION
This adds a small subsection to the rustdoc GUI test suite page explaining where the frontend checks (ESLint and TypeScript) actually run in CI and how to mirror that locally. The goal is to remove guesswork for contributors who run JS/TS checks or GUI tests and aren’t sure whether compiletest or tidy is responsible.

Evidence (paths in the rust repo):
- ESLint install (tidy image): src/ci/docker/host-x86_64/tidy/Dockerfile
- Tidy extra checks run ESLint/TSC:
  - src/tools/tidy/src/extra_checks/mod.rs (calls rustdoc_js::{lint, es_check, typecheck})
  - src/tools/tidy/src/extra_checks/rustdoc_js.rs (spawns eslint and `tsc -p src/librustdoc/html/static/js/tsconfig.json`)
- CI runs `tidy` as a dedicated job, so ESLint & TypeScript checks execute in CI:
  - Workflow installs tidy: `src/ci/scripts/install-tidy.sh`
  - Matrix includes a `tidy` builder (see `src/ci/github-actions/jobs.yml`)
  - That job runs `./x.py test tidy -vv`, which calls `rustdoc_js::{lint, es_check, typecheck}`
    → invokes `eslint` and `tsc -p src/librustdoc/html/static/js/tsconfig.json`

- TypeScript project used in CI: src/librustdoc/html/static/js/tsconfig.json

Local verification (macOS):
- `./x.py test --stage 2 tests/rustdoc-js` → ✅ 63 tests OK
- `./x.py test --stage 2 tests/rustdoc-js-std` → ✅ 61 tests OK
- `./x.py test --stage 2 tests/rustdoc-gui` → ⚠️ 141 ran; 5 small layout/pixel diffs (expected on macOS; CI baseline is Linux)
- `./x.py test tidy -vv` → ✅ tidy passes
- Direct checks in `rust/src/librustdoc/html/static/js`:
  - `npm ci` → ✅
  - `npx tsc -p tsconfig.json --noEmit` → ⚠️ one env-specific type error (confirms TSC runs)
  - `npx eslint .` → ✅ runs clean

Makes CI behavior discoverable (tidy runs ESLint/TSC; compiletest runs the GUI/JS suites).
Gives exact local commands plus two common caveats (macOS pixel diffs; DOM vs Node types with local TS).

Addresses #2364.
