### PR TITLE
Revert "dates: refresh infra/tooling date annotations to Aug 2025"

### DIFF
--- a/src/backend/updating-llvm.md
+++ b/src/backend/updating-llvm.md
@@ -1,6 +1,6 @@
 # Updating LLVM
 
-<!-- date-check: Aug 2025 -->
+<!-- date-check: Aug 2024 -->
 Rust supports building against multiple LLVM versions:
 
 * Tip-of-tree for the current LLVM development branch is usually supported
@@ -93,7 +93,7 @@ An example PR:
 
 ## New LLVM Release Updates
 
-<!-- date-check: Aug 2025 -->
+<!-- date-check: Jul 2023 -->
 
 Unlike bugfixes,
 updating to a new release of LLVM typically requires a lot more work.

--- a/src/fuzzing.md
+++ b/src/fuzzing.md
@@ -1,6 +1,6 @@
 # Fuzzing
 
-<!-- date-check: Aug 2025 -->
+<!-- date-check: Mar 2023 -->
 
 For the purposes of this guide, *fuzzing* is any testing methodology that
 involves compiling a wide variety of programs in an attempt to uncover bugs in

--- a/src/overview.md
+++ b/src/overview.md
@@ -304,7 +304,7 @@ Moreover, the compiler wasn't originally built to use a query system; the query
 system has been retrofitted into the compiler, so parts of it are not query-fied
 yet. Also, LLVM isn't our code, so that isn't querified either. The plan is to
 eventually query-fy all of the steps listed in the previous section,
-but as of <!-- date-check --> August 2025, only the steps between `HIR` and
+but as of <!-- date-check --> November 2022, only the steps between `HIR` and
 `LLVM-IR` are query-fied. That is, lexing, parsing, name resolution, and macro
 expansion are done all at once for the whole program.
 

--- a/src/parallel-rustc.md
+++ b/src/parallel-rustc.md
@@ -1,14 +1,14 @@
 # Parallel compilation
 
 <div class="warning">
-As of <!-- date-check --> August 2025,
+As of <!-- date-check --> November 2024,
 the parallel front-end is undergoing significant changes,
 so this page contains quite a bit of outdated information.
 
 Tracking issue: <https://github.com/rust-lang/rust/issues/113349>
 </div>
 
-As of <!-- date-check --> August 2025, most of the rust compiler is now
+As of <!-- date-check --> November 2024, most of the rust compiler is now
 parallelized.
 
 - The codegen part is executed concurrently by default. You can use the `-C
@@ -104,7 +104,7 @@ when `parallel-compiler` is true.
 | **ModuleItems::par_foreign_items**(&self, f: impl Fn(ForeignItemId)) | run `f` on all foreign items in the module                   | rustc_middle::hir          |
 
 There are a lot of loops in the compiler which can possibly be parallelized
-using these functions. As of <!-- date-check--> August 2025, scenarios where
+using these functions. As of <!-- date-check--> August 2022, scenarios where
 the parallel iterator function has been used are as follows:
 
 | caller                                                  | scenario                                                     | callee                   |
@@ -155,7 +155,7 @@ open feature tracking issue][tracking].
 
 ## Rustdoc
 
-As of <!-- date-check--> August 2025, there are still a number of steps to
+As of <!-- date-check--> November 2022, there are still a number of steps to
 complete before `rustdoc` rendering can be made parallel (see a open discussion
 of [parallel `rustdoc`][parallel-rustdoc]).
 

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -108,6 +108,6 @@ The llvm-lines output is affected by several options.
 
 MIR optimizations have little impact. Compared to the default `RUSTFLAGS="-Z
 mir-opt-level=1"`, level 0 adds 0.3GB and level 2 removes 0.2GB.
-As of <!-- date-check --> August 2025,
+As of <!-- date-check --> July 2022,
 inlining happens in LLVM and GCC codegen backends,
 missing only in the Cranelift one.

--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -99,7 +99,7 @@ regarding dropping private/hidden items can be bypassed by passing
 `--document-private-items` to `rustdoc`. Note that unlike the previous set of [`AST`][ast]
 transformations, the passes are run on the _cleaned_ crate.
 
-Here is the list of passes as of <!-- date-check --> August 2025:
+Here is the list of passes as of <!-- date-check --> March 2023:
 
 - `calculate-doc-coverage` calculates information used for the `--show-coverage`
   flag.
@@ -122,7 +122,7 @@ Here is the list of passes as of <!-- date-check --> August 2025:
   - `bare_urls` detects links that are not linkified, e.g., in Markdown such as
     `Go to https://example.com/.` It suggests wrapping the link with angle brackets:
     `Go to <https://example.com/>.` to linkify it. This is the code behind the <!--
-    date-check: Aug 2025 --> `rustdoc::bare_urls` `lint`.
+    date-check: may 2022 --> `rustdoc::bare_urls` `lint`.
 
   - `check_code_block_syntax` validates syntax inside Rust code blocks
     (<code>```rust</code>)
@@ -212,7 +212,7 @@ directly, even during `HTML` generation. This [didn't used to be the case], and
 a lot of `rustdoc`'s architecture was designed around not doing that, but a
 `TyCtxt` is now passed to `formats::renderer::run_format`, which is used to
 run generation for both `HTML` and the
-(unstable as of <!-- date-check --> August 2025) JSON format.
+(unstable as of <!-- date-check --> March 2023) JSON format.
 
 This change has allowed other changes to remove data from the "clean" [`AST`][ast]
 that can be easily derived from `TyCtxt` queries, and we'll usually accept


### PR DESCRIPTION
Reverts rust-lang/rustc-dev-guide#2557

See https://github.com/rust-lang/rustc-dev-guide/issues/2528#issuecomment-3239543008