### PR TITLE
Update renamed `take_region_var_origins`

### DIFF
--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -239,13 +239,13 @@ differently. It uses canonical queries for trait solving which use
 [`take_and_reset_region_constraints`] at the end. This extracts all of the
 outlives constraints added during the canonical query. This is required
 as the NLL solver must not only know *what* regions outlive each other,
-but also *where*. Finally, the NLL solver invokes [`take_region_var_origins`],
+but also *where*. Finally, the NLL solver invokes [`get_region_var_infos`],
 providing all region variables to the solver.
 
 [`resolve_regions_and_report_errors`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_trait_selection/traits/struct.ObligationCtxt.html#method.resolve_regions_and_report_errors
 [`lexical_region_resolve`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/lexical_region_resolve/index.html
 [`take_and_reset_region_constraints`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#method.take_and_reset_region_constraints
-[`take_region_var_origins`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#method.take_region_var_origins
+[`get_region_var_infos`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_infer/infer/struct.InferCtxt.html#method.get_region_var_infos
 
 ## Lexical region resolution
 


### PR DESCRIPTION
This was first renamed to `get_region_var_origins` in https://github.com/rust-lang/rust/pull/109753, and then to `get_region_var_infos` in https://github.com/rust-lang/rust/commit/b0fc1d47d5dcffb5d516059d4a5af3b6843132d5