### PR TITLE
remove untrue/contentious statement

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -52,9 +52,7 @@ channels: stable, beta, and nightly.
 
 - **Stable**: this is the latest stable release for general usage.
 - **Beta**: this is the next release (will be stable within 6 weeks).
-- **Nightly**: follows the `master` branch of the repo. This is the only
-  channel where unstable, incomplete, or experimental features are usable with
-  feature gates.
+- **Nightly**: follows the `master` branch of the repo.
 
 See [this chapter on implementing new features](./implementing_new_features.md) for more
 information.


### PR DESCRIPTION
One can use unstable features on stable too, like via an env var

r? ghost