### PR TITLE
Rename "crashes tests" to "crash tests"

### DIFF
--- a/src/fuzzing.md
+++ b/src/fuzzing.md
@@ -90,14 +90,15 @@ Here are a few things you can do to help the Rust project after filing an ICE.
   triggering the ICE, such as syntax errors or borrow-checking errors
 - Minimize the test case (see below). If successful, you can label the
   issue with `S-has-mcve`. Otherwise, you can apply `E-needs-mcve`.
-- Add the minimal test case to the rust-lang/rust repo as a [crashes test].
+- Add the minimal test case to the rust-lang/rust repo as a [crash test].
   While you're at it, consider including other "untracked" crashes in your PR.
-  Please don't forget to mark your issue with `S-bug-has-test` afterwards.
+  Please don't forget to mark all relevant issues with `S-bug-has-test` once
+  your PR is merged.
 
 See also [applying and removing labels][labeling].
 
 [bisect]: https://rust-lang.github.io/cargo-bisect-rustc/
-[crashes test]: tests/compiletest.html#crashes-tests
+[crash test]: tests/compiletest.html#crash-tests
 [labeling]: https://forge.rust-lang.org/release/issue-triaging.html#applying-and-removing-labels
 
 ## Minimization

--- a/src/tests/best-practices.md
+++ b/src/tests/best-practices.md
@@ -71,7 +71,7 @@ related tests.
 > //! Regression test for <https://github.com/rust-lang/rust/issues/123456>.
 > ```
 >
-> One exception to this rule is [crashes tests]: there it is canonical that
+> One exception to this rule is [crash tests]: there it is canonical that
 > tests are named only after issue numbers because its purpose is to track
 > snippets from which issues no longer ICE/crash, and they would either be
 > removed or converted into proper ui/other tests in the fix PRs.
@@ -199,4 +199,4 @@ See [LLVM FileCheck guide][FileCheck] for details.
 [compiletest directives]: ./directives.md
 [`run-make`]: ./compiletest.md#run-make-tests
 [FileCheck]: https://llvm.org/docs/CommandGuide/FileCheck.html
-[crashes tests]: ./compiletest.md#crashes-tests
+[crash tests]: ./compiletest.md#crash-tests

--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -72,7 +72,7 @@ The following test suites are available, with links for more information:
 | [`mir-opt`](#mir-opt-tests)               | Check MIR generation and optimizations                                                                              |
 | [`coverage`](#coverage-tests)             | Check coverage instrumentation                                                                                      |
 | [`coverage-run-rustdoc`](#coverage-tests) | `coverage` tests that also run instrumented doctests                                                                |
-| [`crashes`](#crashes-tests)               | Check that the compiler ICEs/panics/crashes on certain inputs to catch accidental fixes                             |
+| [`crashes`](#crash-tests)               | Check that the compiler ICEs/panics/crashes on certain inputs to catch accidental fixes                             |
 
 ### General purpose test suite
 
@@ -550,7 +550,7 @@ only running the main `coverage` suite.
 [`src/tools/coverage-dump`]: https://github.com/rust-lang/rust/tree/master/src/tools/coverage-dump
 [`tests/coverage-run-rustdoc`]: https://github.com/rust-lang/rust/tree/master/tests/coverage-run-rustdoc
 
-### Crashes tests
+### Crash tests
 
 [`tests/crashes`] serve as a collection of tests that are expected to cause the
 compiler to ICE, panic or crash in some other way, so that accidental fixes are
@@ -573,13 +573,13 @@ recommended to include test cases from several issues in a single PR.
 When you do so, each issue number should be noted in the file name (`12345.rs`
 should suffice) and also inside the file by means of a `//@ known-bug: #12345`
 directive. Please [label][labeling] the relevant issues with `S-bug-has-test`
-afterwards.
+once your PR is merged.
 
 If you happen to fix one of the crashes, please move it to a fitting
 subdirectory in `tests/ui` and give it a meaningful name. Please add a doc
 comment at the top of the file explaining why this test exists, even better if
 you can briefly explain how the example causes rustc to crash previously and
-what was done to prevent rustc to ICE/panic/crash.
+what was done to prevent rustc to ICE / panic / crash.
 
 Adding
 


### PR DESCRIPTION
"crashes tests" sounds really awkward in my ears and it doesn't roll off the tongue easily I feel like.
I'm L2 but my sprachgefühl tells me that "crash tests" is more digestible and natural.