### PR TITLE
Add debug assertions flag to `cg_gcc` invocation

### DIFF
--- a/src/tests/codegen-backend-tests/cg_gcc.md
+++ b/src/tests/codegen-backend-tests/cg_gcc.md
@@ -1,11 +1,16 @@
 # GCC codegen backend
 
 If you ran into an error related to tests executed with the GCC codegen backend on CI,
-you can use the following command to run tests locally using the GCC backend:
+you can use the following command to run UI tests locally using the GCC backend:
 
 ```bash
-./x test tests/ui --set 'rust.codegen-backends = ["llvm", "gcc"]' --test-codegen-backend gcc
+./x test tests/ui \
+  --set 'rust.codegen-backends = ["llvm", "gcc"]' \
+  --set 'rust.debug-assertions = false' \
+  --test-codegen-backend gcc
 ```
+
+If a different test suite has failed on CI, you will have to modify the `tests/ui` part.
 
 Below, you can find more information about how to configure the GCC backend in bootstrap.
 


### PR DESCRIPTION
Context: https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Run.20more.20tests.20for.20rustc_codegen_gcc.20in.20t.E2.80.A6.20compiler-team.23891/with/543584710
