### PR TITLE
debugging.md: Remove wrong claim that LLVM bitcode is not the same as LLVM IR

### DIFF
--- a/src/backend/debugging.md
+++ b/src/backend/debugging.md
@@ -77,7 +77,7 @@ llvm-ir`). `--build-type=debug` emits code for debug builds. There are also
 other useful options. Also, debug info in LLVM IR can clutter the output a lot:
 `RUSTFLAGS="-C debuginfo=0"` is really useful.
 
-`RUSTFLAGS="-C save-temps"` outputs LLVM bitcode (not the same as IR) at
+`RUSTFLAGS="-C save-temps"` outputs LLVM bitcode at
 different stages during compilation, which is sometimes useful. The output LLVM
 bitcode will be in `.bc` files in the compiler's output directory, set via the
 `--out-dir DIR` argument to `rustc`.


### PR DESCRIPTION
They are the same thing since they can be converted back and forth without loss.

We hint at that in the second bullet point two paragraphs down:

>  * To get human readable versions of the LLVM bitcode, one just needs to convert
>    the bitcode (`.bc`) files to `.ll` files using `llvm-dis`, which should be in
>    the target local compilation of rustc.

That is also claimed in the last paragraph in this SO answer: https://stackoverflow.com/a/12954198/287761