### PR TITLE
Add the gpu version of the kernel which was missing in the docs

### DIFF
--- a/src/offload/usage.md
+++ b/src/offload/usage.md
@@ -56,6 +56,13 @@ fn main() {
 unsafe extern "C" {
     pub fn kernel_1(array_b: *mut [f64; 256]);
 }
+
+#[cfg(not(target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[inline(never)]
+pub extern "gpu-kernel" fn kernel_1(x: *mut [f64; 256]) {
+    unsafe { (*x)[0] = 21.0 };
+}
 ```
 
 ## Compile instructions


### PR DESCRIPTION
Apparently, I managed to forget copying the GPU kernel for my GPU example into the docs...
