### PR TITLE
Give an overview of our stability guarantees

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -52,6 +52,7 @@
 - [Mastering @rustbot](./rustbot.md)
 - [Walkthrough: a typical contribution](./walkthrough.md)
 - [Implementing new language features](./implementing_new_features.md)
+- [Stability guarantees](./stability-guarantees.md)
 - [Stability attributes](./stability.md)
 - [Stabilizing language features](./stabilization_guide.md)
     - [Stabilization report template](./stabilization_report_template.md)

--- a/src/stability-guarantees.md
+++ b/src/stability-guarantees.md
@@ -1,0 +1,26 @@
+# Stability guarantees
+
+This page gives an overview of our stability guarantees.
+
+## RFCs
+
+* [RFC 1105 api evolution](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
+* [RFC 1122 language semver](https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md)
+
+## Blog posts
+
+* [Stability as a Deliverable](https://blog.rust-lang.org/2014/10/30/Stability/)
+
+## rustc-dev-guide links
+
+* [Stabilizing library features](./stability.md)
+* [Stabilizing language features](./stabilization_guide.md)
+* [What qualifies as a bug fix?](./bug-fix-procedure.md#what-qualifies-as-a-bug-fix)
+
+## Exemptions
+
+Even if some of our infrastructure can be used by others, it is still considered
+internal and comes without stability guarantees. This is a non-exhaustive list
+of components without stability guarantees:
+
+* The CLIs and environment variables used by `remote-test-client` / `remote-test-server`


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/147952#issuecomment-3536204283 I learned `remote-test-client` is considered fully internal and that we can change its "public interface" whenever we want to.

I couldn't find this documented anywhere and figured it would be useful to add a section to rustc-dev-guide that gives an overview of our stability guarantees.

cc @jieyouxu 
