### PR TITLE
Fix broken link for 'Uniqueness and Reference Immutability'

### DIFF
--- a/src/appendix/bibliography.md
+++ b/src/appendix/bibliography.md
@@ -15,7 +15,7 @@ Rust, as well as publications about Rust.
 * [Safe manual memory management in Cyclone](https://www.cs.umd.edu/projects/PL/cyclone/scp.pdf)
 * [Skolem Normal Form](https://en.wikipedia.org/wiki/Skolem_normal_form)
 * [Traits: composable units of behavior](http://scg.unibe.ch/archive/papers/Scha03aTraits.pdf)
-* [Uniqueness and Reference Immutability for Safe Parallelism](https://research.microsoft.com/pubs/170528/msr-tr-2012-79.pdf)
+* [Uniqueness and Reference Immutability for Safe Parallelism](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/msr-tr-2012-79.pdf)
 
 ## Concurrency
 


### PR DESCRIPTION
replace https://research.microsoft.com/pubs/170528/msr-tr-2012-79.pdf to https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/msr-tr-2012-79.pdf