### PR TITLE
make date-check entries clickable

### DIFF
--- a/ci/date-check/src/main.rs
+++ b/ci/date-check/src/main.rs
@@ -159,7 +159,7 @@ fn main() {
                 let url = format!(
                     "https://github.com/rust-lang/rustc-dev-guide/blob/main/{path}?plain=1#L{line}"
                 );
-                println!("  - [ ] [{date}]({url})");
+                println!("  - [ ] {date} [line {line}]({url})");
             }
         }
         println!();


### PR DESCRIPTION
current output

- backend/updating-llvm.md
  - [ ] line 3: 2024-08
  - [ ] line 96: 2023-07
  - [ ] line 176: 2025-03
- borrow_check/region_inference/member_constraints.md
  - [ ] line 95: 2021-10

proposed output

- src/backend/updating-llvm.md
  - [ ] [2024-08](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/backend/updating-llvm.md?plain=1#L3)
  - [ ] [2023-07](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/backend/updating-llvm.md?plain=1#L96)
  - [ ] [2025-03](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/backend/updating-llvm.md?plain=1#L176)
- src/borrow_check/region_inference/member_constraints.md
  - [ ] [2021-10](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/borrow_check/region_inference/member_constraints.md?plain=1#L95)
