### PR TITLE
Fix function formatting in src/overview.md

### DIFF
--- a/src/overview.md
+++ b/src/overview.md
@@ -50,10 +50,10 @@ preserves full fidelity information for both IDEs and procedural macros
 The *parser* [translates the token stream from the `lexer` into an Abstract Syntax
 Tree (AST)][parser]. It uses a recursive descent (top-down) approach to syntax
 analysis. The crate entry points for the `parser` are the
-[`Parser::parse_crate_mod()`][parse_crate_mod] and [`Parser::parse_mod()`][parse_mod]
+[`Parser::parse_crate_mod`][parse_crate_mod] and [`Parser::parse_mod`][parse_mod]
 methods found in [`rustc_parse::parser::Parser`]. The external module parsing
 entry point is [`rustc_expand::module::parse_external_mod`][parse_external_mod].
-And the macro-`parser` entry point is [`Parser::parse_nonterminal()`][parse_nonterminal].
+And the macro-`parser` entry point is [`Parser::parse_nonterminal`][parse_nonterminal].
 
 Parsing is performed with a set of [`parser`] utility methods including [`bump`],
 [`check`], [`eat`], [`expect`], [`look_ahead`].


### PR DESCRIPTION
rustc_expand::module::parse_external_mod a is a method, so `()` seems to be needed.