### PR TITLE
stop checking if PRs are behind main

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -58,9 +58,6 @@ allow-unauthenticated = [
 # Documentation at: https://forge.rust-lang.org/triagebot/issue-links.html
 [issue-links]
 
-[behind-upstream]
-days-threshold = 7
-
 # Enable triagebot (PR) assignment.
 # Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment.html
 [assign]


### PR DESCRIPTION
rust-lang/rustc-dev-guide#2352 was done as a test, and it was known at the time that it would not be so useful on a repo such as this