### PR TITLE
Add a description of how FileCheck is used for mir-opt tests

### DIFF
--- a/src/tests/compiletest.md
+++ b/src/tests/compiletest.md
@@ -411,6 +411,17 @@ problematic in the presence of pointers in constants or other bit width
 dependent things. In that case you can add `// EMIT_MIR_FOR_EACH_BIT_WIDTH` to
 your test, causing separate files to be generated for 32bit and 64bit systems.
 
+On top of the snapshot-based checks performed on the output requested by `EMIT_MIR`,
+the *final runtime MIR*, as emitted by `--emit=mir`, is checked with the LLVM
+[FileCheck] tool. For this purpose, your test should be annotated with
+`// CHECK` comments to verify the final emitted MIR is properly optimized.
+
+See the [FileCheck] documentation for a tutorial and more information.
+
+Note however, that in some cases, it can also make more sense to skip the FileCheck
+step. To do this, add a `// skip-filecheck` annotation instead of the `// CHECK`
+comments.
+
 [`tests/mir-opt`]: https://github.com/rust-lang/rust/tree/HEAD/tests/mir-opt
 
 


### PR DESCRIPTION
This had me quite confused until I figured out that, [as documented in the README of `tests/mir-opt`](https://github.com/rust-lang/rust/blob/HEAD/tests/mir-opt/README.md), the FileCheck runs on the runtime MIR, rather than the output of the `EMIT_MIR` directive. This PR documents this in the dev guide as well, to make this information easier to find.