### PR TITLE
Add rust-analyzer setup for out-of-tree rustc_private crates

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -140,7 +140,7 @@
 
 - [Command-line arguments](./cli.md)
 - [rustc_driver and rustc_interface](./rustc-driver/intro.md)
-    - [Remarks on perma-unstable features](./rustc-driver/remarks-on-perma-unstable-features.md)
+    - [External rustc_drivers](./rustc-driver/external-rustc-drivers.md)
     - [Example: Type checking](./rustc-driver/interacting-with-the-ast.md)
     - [Example: Getting diagnostics](./rustc-driver/getting-diagnostics.md)
 - [Errors and lints](diagnostics.md)

--- a/src/rustc-driver/external-rustc-drivers.md
+++ b/src/rustc-driver/external-rustc-drivers.md
@@ -1,4 +1,4 @@
-# Remarks on perma unstable features
+# External `rustc_driver`s
 
 ## `rustc_private`
 


### PR DESCRIPTION
close: rust-lang/rustc-dev-guide#1544
Is the document location okay?

r? jyn514

cc: @bjorn3