### PR TITLE
Add missing autodiff run-make tests to the install docs

### DIFF
--- a/src/autodiff/installation.md
+++ b/src/autodiff/installation.md
@@ -28,6 +28,7 @@ You can then run our test cases:
 ./x test --stage 1 tests/codegen-llvm/autodiff
 ./x test --stage 1 tests/pretty/autodiff
 ./x test --stage 1 tests/ui/autodiff
+./x test --stage 1 tests/run-make/autodiff
 ./x test --stage 1 tests/ui/feature-gates/feature-gate-autodiff.rs
 ```
 


### PR DESCRIPTION
So, I kind of completely forgot about this category, and now they are broken. xD
At least they all fail with the same error. I suspect that we'll need to update our lto logic due to bjorn's linker-plugin-lto refactorings. Bisect time.

@jieyouxu Did you ever consider adding aliases to the test suite?
`./x test --stage 1 autodiff` to run those 5 commands would be nice. But I also understand if that's too much logic for too little gain.
