### PR TITLE
Refer to debug-logging bootstrap config by its full path.

### DIFF
--- a/src/tracing.md
+++ b/src/tracing.md
@@ -183,7 +183,7 @@ rustc.
 
 While calls to `error!`, `warn!` and `info!` are included in every build of the compiler,
 calls to `debug!` and `trace!` are only included in the program if
-`debug-logging=true` is turned on in bootstrap.toml (it is
+`rust.debug-logging=true` is turned on in bootstrap.toml (it is
 turned off by default), so if you don't see `DEBUG` logs, especially
 if you run the compiler with `RUSTC_LOG=rustc rustc some.rs` and only see
 `INFO` logs, make sure that `debug-logging=true` is turned on in your


### PR DESCRIPTION
This way there's no need to double-check `bootstrap.example.toml` to see what section to put the option in.