### PR TITLE
fix adk installer link

### DIFF
--- a/src/profiling/wpa-profiling.md
+++ b/src/profiling/wpa-profiling.md
@@ -22,8 +22,8 @@ specifically designed to make analyzing rustc easier.
 
 You can install WPR and WPA as part of the Windows Performance Toolkit which itself is an option as
 part of downloading the Windows Assessment and Deployment Kit (ADK). You can download the ADK
-installer [here](https://go.microsoft.com/fwlink/?linkid=2086042). Make sure to select the Windows
-Performance Toolkit (you don't need to select anything else).
+installer [here](https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install). Make
+sure to select the Windows Performance Toolkit (you don't need to select anything else).
 
 ## Recording
 


### PR DESCRIPTION
The previous link was just redirecting to the main page.

https://go.microsoft.com/fwlink/?linkid=2086042

Since the link is different for each version, it would be better to change it to the link to the [download guide page](https://learn.microsoft.com/en-us/windows-hardware/get-started/adk-install).

https://go.microsoft.com/fwlink/?linkid=2289980
https://go.microsoft.com/fwlink/?linkid=2337875

