### PR TITLE
Fix typos and capitalization across documentation

### DIFF
--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -10,7 +10,7 @@ There are several parts to this guide:
    about building, debugging, profiling, etc.
 1. [Contributing to Rust][p2]:
    Contains information that should be useful no matter how you are contributing,
-   about procedures for contribution, using git and Github, stabilizing features, etc.
+   about procedures for contribution, using git and GitHub, stabilizing features, etc.
 1. [Bootstrapping][p3]:
    Describes how the Rust compiler builds itself using previous versions, including
    an introduction to the bootstrap process and debugging methods.

--- a/src/building/bootstrapping/what-bootstrapping-does.md
+++ b/src/building/bootstrapping/what-bootstrapping-does.md
@@ -342,7 +342,7 @@ This flag has the following effects:
 
 Code which does not use `-Z force-unstable-if-unmarked` should include the
 `#![feature(rustc_private)]` crate attribute to access these forced-unstable
-crates. This is needed for things which link `rustc` its self, such as `MIRI` or
+crates. This is needed for things which link `rustc` itself, such as `Miri` or
 `clippy`.
 
 You can find more discussion about sysroots in:

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -56,7 +56,7 @@ You can also include extensions within extensions recursively.
 **Note:** In the `include` field, the overriding logic follows a right-to-left order.
 For example,
 in `include = ["a.toml", "b.toml"]`, extension `b.toml` overrides `a.toml`.
-Also, parent extensions always overrides the inner ones.
+Also, parent extensions always override the inner ones.
 
 ## Configuring `rust-analyzer` for `rustc`
 

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -324,7 +324,7 @@ When you resolve them, you should use `@rustbot` to mark it as `S-waiting-on-rev
 GitHub allows [closing issues using keywords][closing-keywords].
 This feature should be used to keep the issue tracker tidy.
 However, it is generally preferred
-to put the "closes #123" text in the PR description rather than the issue commit;
+to put the "closes #123" text in the PR description rather than the commit message;
 particularly during rebasing, citing the issue number in the commit can "spam"
 the issue in question.
 

--- a/src/debugging-support-in-rustc.md
+++ b/src/debugging-support-in-rustc.md
@@ -216,7 +216,7 @@ trait for a type would be one of these interfaces (`DW_tag_interface` type). Als
 which it is implemented would describe all the interfaces this type implements. This requires a
 DWARF extension.
 
-Issue on Github: [https://github.com/rust-lang/rust/issues/33014]
+Issue on GitHub: [https://github.com/rust-lang/rust/issues/33014]
 
 ## Typical process for a Debug Info change (LLVM)
 

--- a/src/diagnostics.md
+++ b/src/diagnostics.md
@@ -228,7 +228,7 @@ Guidelines for different diagnostic levels:
   The error or warning portion should *not* suggest how to fix the problem,
   only the "help" sub-diagnostic should.
 
-- `note`: emitted to given more context and identify additional circumstances
+- `note`: emitted to give more context and identify additional circumstances
   and parts of the code that caused the warning or error. For example, the
   borrow checker will note any previous conflicting borrows.
 
@@ -788,7 +788,7 @@ add_lint_group!(sess,
 ```
 
 This defines the `nonstandard_style` group which turns on the listed lints. A
-user can turn on these lints with a `!#[warn(nonstandard_style)]` attribute in
+user can turn on these lints with a `#![warn(nonstandard_style)]` attribute in
 the source code, or by passing `-W nonstandard-style` on the command line.
 
 Some lint groups are created automatically in `LintStore::register_lints`. For instance,
@@ -944,7 +944,7 @@ You can filter on the following boolean flags:
  - `crate_local`: whether the code causing the trait bound to not be
    fulfilled is part of the user's crate. This is used to avoid suggesting
    code changes that would require modifying a dependency.
- - `direct`: whether this is an user-specified rather than derived obligation.
+ - `direct`: whether this is a user-specified rather than derived obligation.
  - `from_desugaring`: whether we are in some kind of desugaring, like `?`
    or a `try` block for example. This flag can also be matched on, see below.
 

--- a/src/git.md
+++ b/src/git.md
@@ -372,7 +372,7 @@ to ensure that Git doesn't create merge commits when `git pull`ing, without
 needing to pass `--ff-only` or `--rebase` every time.
 
 You can also `git push --force-with-lease` from main to double-check that your
-feature branches are in sync with their state on the Github side.
+feature branches are in sync with their state on the GitHub side.
 
 ## Advanced Rebasing
 
@@ -494,7 +494,7 @@ to follow and understand.
 
 ### Hiding whitespace
 
-Github has a button for disabling whitespace changes that may be useful.
+GitHub has a button for disabling whitespace changes that may be useful.
 You can also use `git diff -w origin/main` to view changes locally.
 
 ![hide whitespace](./img/github-whitespace-changes.png)
@@ -505,7 +505,7 @@ To checkout PRs locally, you can use `git fetch upstream pull/NNNNN/head && git 
 FETCH_HEAD`.
 
 You can also use github's cli tool.
-Github shows a button on PRs where you can copy-paste the command to check it out locally.
+GitHub shows a button on PRs where you can copy-paste the command to check it out locally.
 See <https://cli.github.com/> for more info.
 
 ![`gh` suggestion](./img/github-cli.png)
@@ -521,7 +521,7 @@ for more details.
 
 ### Moving large sections of code
 
-Git and Github's default diff view for large moves *within* a file is quite poor; it will show each
+Git and GitHub's default diff view for large moves *within* a file is quite poor; it will show each
 line as deleted and each line as added, forcing you to compare each line yourself.
 Git has an option to show moved lines in a different color:
 
@@ -562,7 +562,7 @@ Rust projects from within the `rust` repo.
 Examples include Rust's fork of
 `llvm-project`, `cargo`, and libraries like `stdarch` and `backtrace`.
 
-Those projects are developed and maintained in an separate Git (and GitHub)
+Those projects are developed and maintained in a separate Git (and GitHub)
 repository, and they have their own Git history/commits, issue tracker and PRs.
 Submodules allow us to create some sort of embedded sub-repository inside the
 `rust` repository and use them like they were directories in the `rust` repository.

--- a/src/macro-expansion.md
+++ b/src/macro-expansion.md
@@ -468,7 +468,7 @@ Here `$mvar` is called a _metavariable_. Unlike normal variables, rather than
 binding to a value _at runtime_, a metavariable binds _at compile time_ to a
 tree of _tokens_.  A _token_ is a single "unit" of the grammar, such as an
 identifier (e.g. `foo`) or punctuation (e.g. `=>`). There are also other
-special tokens, such as `EOF`, which its self indicates that there are no more
+special tokens, such as `EOF`, which itself indicates that there are no more
 tokens. There are token trees resulting from the paired parentheses-like
 characters (`(`...`)`, `[`...`]`, and `{`...`}`) – they include the open and
 close and all the tokens in between (Rust requires that parentheses-like

--- a/src/notification-groups/about.md
+++ b/src/notification-groups/about.md
@@ -11,7 +11,7 @@ that fits the notification group's criteria. If you are interested, you
 can then [claim the issue] and start working on it.
 
 Of course, you don't have to wait for new issues to be tagged! If you
-prefer, you can use the Github label for a notification group to
+prefer, you can use the GitHub label for a notification group to
 search for existing issues that haven't been claimed yet.
 
 [claim the issue]: https://forge.rust-lang.org/triagebot/issue-assignment.html
@@ -47,7 +47,7 @@ particularly those of **middle priority**:
 ## Joining a notification group
 
 To join a notification group, you just have to open a PR adding your
-Github username to the appropriate file in the Rust team repository.
+GitHub username to the appropriate file in the Rust team repository.
 See the "example PRs" below to get a precise idea and to identify the
 file to edit.
 

--- a/src/notification-groups/apple.md
+++ b/src/notification-groups/apple.md
@@ -1,6 +1,6 @@
 # Apple notification group
 
-**Github Labels:** [O-macos], [O-ios], [O-tvos], [O-watchos] and [O-visionos] <br>
+**GitHub Labels:** [O-macos], [O-ios], [O-tvos], [O-watchos] and [O-visionos] <br>
 **Ping command:** `@rustbot ping apple`
 
 This list will be used to ask for help both in diagnosing and testing

--- a/src/notification-groups/arm.md
+++ b/src/notification-groups/arm.md
@@ -1,6 +1,6 @@
 # ARM notification group
 
-**Github Label:** [O-ARM] <br>
+**GitHub Label:** [O-ARM] <br>
 **Ping command:** `@rustbot ping arm`
 
 [O-ARM]: https://github.com/rust-lang/rust/labels/O-ARM

--- a/src/notification-groups/emscripten.md
+++ b/src/notification-groups/emscripten.md
@@ -1,6 +1,6 @@
 # Emscripten notification group
 
-**Github Label:** [O-emscripten] <br>
+**GitHub Label:** [O-emscripten] <br>
 **Ping command:** `@rustbot ping emscripten`
 
 [O-emscripten]: https://github.com/rust-lang/rust/labels/O-emscripten

--- a/src/notification-groups/fuchsia.md
+++ b/src/notification-groups/fuchsia.md
@@ -1,6 +1,6 @@
 # Fuchsia notification group
 
-**Github Label:** [O-fuchsia] <br>
+**GitHub Label:** [O-fuchsia] <br>
 **Ping command:** `@rustbot ping fuchsia`
 
 [O-fuchsia]: https://github.com/rust-lang/rust/labels/O-fuchsia

--- a/src/notification-groups/loongarch.md
+++ b/src/notification-groups/loongarch.md
@@ -1,6 +1,6 @@
 # LoongArch notification group
 
-**Github Label:** [O-loongarch] <br>
+**GitHub Label:** [O-loongarch] <br>
 **Ping command:** `@rustbot ping loongarch`
 
 [O-loongarch]: https://github.com/rust-lang/rust/labels/O-loongarch

--- a/src/notification-groups/risc-v.md
+++ b/src/notification-groups/risc-v.md
@@ -1,6 +1,6 @@
 # RISC-V notification group
 
-**Github Label:** [O-riscv] <br>
+**GitHub Label:** [O-riscv] <br>
 **Ping command:** `@rustbot ping risc-v`
 
 [O-riscv]: https://github.com/rust-lang/rust/labels/O-riscv

--- a/src/notification-groups/rust-for-linux.md
+++ b/src/notification-groups/rust-for-linux.md
@@ -1,6 +1,6 @@
 # Rust for Linux notification group
 
-**Github Label:** [A-rust-for-linux] <br>
+**GitHub Label:** [A-rust-for-linux] <br>
 **Ping command:** `@rustbot ping rfl`
 
 [A-rust-for-linux]: https://github.com/rust-lang/rust/labels/A-rust-for-linux

--- a/src/notification-groups/wasi.md
+++ b/src/notification-groups/wasi.md
@@ -1,6 +1,6 @@
 # WASI notification group
 
-**Github Label:** [O-wasi] <br>
+**GitHub Label:** [O-wasi] <br>
 **Ping command:** `@rustbot ping wasi`
 
 [O-wasi]: https://github.com/rust-lang/rust/labels/O-wasi

--- a/src/notification-groups/wasm.md
+++ b/src/notification-groups/wasm.md
@@ -1,6 +1,6 @@
 # WebAssembly (WASM) notification group
 
-**Github Label:** [O-wasm] <br>
+**GitHub Label:** [O-wasm] <br>
 **Ping command:** `@rustbot ping wasm`
 
 [O-wasm]: https://github.com/rust-lang/rust/labels/O-wasm

--- a/src/notification-groups/windows.md
+++ b/src/notification-groups/windows.md
@@ -1,6 +1,6 @@
 # Windows notification group
 
-**Github Label:** [O-Windows] <br>
+**GitHub Label:** [O-Windows] <br>
 **Ping command:** `@rustbot ping windows`
 
 [O-Windows]: https://github.com/rust-lang/rust/labels/O-Windows

--- a/src/overview.md
+++ b/src/overview.md
@@ -198,7 +198,7 @@ satisfy/optimize for. For example,
   the input programs says they do, and should continue to do so despite the
   tremendous amount of change constantly going on.
 - Integration: a number of other tools need to use the compiler in
-  various ways (e.g. `cargo`, `clippy`, `MIRI`) that must be supported.
+  various ways (e.g. `cargo`, `clippy`, `Miri`) that must be supported.
 - Compiler stability: the compiler should not crash or fail ungracefully on the
   stable channel.
 - Rust stability: the compiler must respect Rust's stability guarantees by not
@@ -245,7 +245,7 @@ for different purposes:
   values). `MIR` is used for borrow checking and other
   important dataflow-based checks, such as checking for uninitialized values.
   It is also used for a series of optimizations and for constant evaluation (via
-  `MIRI`). Because `MIR` is still generic, we can do a lot of analyses here more
+  `Miri`). Because `MIR` is still generic, we can do a lot of analyses here more
   efficiently than after monomorphization.
 - `LLVM-IR`: This is the standard form of all input to the LLVM compiler. `LLVM-IR`
   is a sort of typed assembly language with lots of annotations. It's

--- a/src/ty.md
+++ b/src/ty.md
@@ -5,7 +5,7 @@ The `ty` module defines how the Rust compiler represents types internally. It al
 
 ## `ty::Ty`
 
-When we talk about how rustc represents types,  we usually refer to a type called `Ty` . There are
+When we talk about how rustc represents types, we usually refer to a type called `Ty`. There are
 quite a few modules and types for `Ty` in the compiler ([Ty documentation][ty]).
 
 [ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/index.html
@@ -46,7 +46,7 @@ That is, they have two different [`Span`s][span] (locations).
 In addition, HIR might have information left out. This type
 `&u32` is incomplete, since in the full Rust type there is actually a lifetime, but we didn’t need
 to write those lifetimes. There are also some elision rules that insert information. The result may
-look like  `fn foo<'a>(x: &'a u32) -> &'a u32`.
+look like `fn foo<'a>(x: &'a u32) -> &'a u32`.
 
 In the HIR level, these things are not spelled out and you can say the picture is rather incomplete.
 However, at the `ty::Ty` level, these details are added and it is complete. Moreover, we will have


### PR DESCRIPTION
## Summary

Fix various typos, grammar issues, and capitalization errors across 21 documentation files:

- **"Github" → "GitHub"** capitalization fix throughout (about.md, git.md, about-this-guide.md, debugging-support-in-rustc.md, and all notification-groups files)
- **"its self" → "itself"** (macro-expansion.md, what-bootstrapping-does.md)
- **"MIRI" → "Miri"** — correct project name capitalization (overview.md, what-bootstrapping-does.md)
- **Grammar fixes**: "to given" → "to give", "an user-specified" → "a user-specified", "an separate" → "a separate" (diagnostics.md, git.md)
- **Incorrect attribute syntax**: `!#[warn` → `#![warn` (diagnostics.md)
- **"overrides" → "override"** subject-verb agreement (suggested.md)
- **"issue commit" → "commit message"** (contributing.md)
- **Double space removal** (ty.md)