### PR TITLE
Update `try_green_mark` part

### DIFF
--- a/src/queries/incremental-compilation-in-detail.md
+++ b/src/queries/incremental-compilation-in-detail.md
@@ -178,7 +178,7 @@ fn try_mark_green(tcx, current_node) -> bool {
 
 > NOTE:
 > The actual implementation can be found in
-> [`compiler/rustc_query_system/src/dep_graph/graph.rs`][try_mark_green]
+> [`compiler/rustc_middle/src/dep_graph/graph.rs`][try_mark_green]
 
 By using red-green marking we can avoid the devastating cumulative effect of
 having false positives during change detection. Whenever a query is executed
@@ -534,4 +534,4 @@ information.
 
 
 [query-model]: ./query-evaluation-model-in-detail.html
-[try_mark_green]: https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_query_system/dep_graph/graph.rs.html
+[try_mark_green]: https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_middle/dep_graph/graph.rs.html


### PR DESCRIPTION
~~`try_green_mark` method has been moved~~

While I was looking at the code, I found that the existing one was from 7 years ago and is slightly different from the current structure, so I will update this as well.

Ah, the link has been fixed here https://github.com/rust-lang/rust/pull/152703