### PR TITLE
rustdoc.md: consistently use `./x` rather than `./x.py`

### DIFF
--- a/src/rustdoc.md
+++ b/src/rustdoc.md
@@ -57,8 +57,8 @@ Note that literally all that does is call the `main()` that's in this crate's `l
 * Use `./x test tests/rustdoc*` to run the tests using a stage1
   rustdoc.
   * See [Rustdoc internals] for more information about tests.
-* Use `./x.py test tidy --extra-checks=js` to run rustdoc’s JavaScript checks (`eslint`, `es-check`, and `tsc`).
-> **Note:** `./x.py test tidy` already runs these checks automatically when JS/TS sources changed; `--extra-checks=js` forces them explicitly.
+* Use `./x test tidy --extra-checks=js` to run rustdoc’s JavaScript checks (`eslint`, `es-check`, and `tsc`).
+> **Note:** `./x test tidy` already runs these checks automatically when JS/TS sources changed; `--extra-checks=js` forces them explicitly.
 
 ### JavaScript CI checks
 
@@ -66,7 +66,7 @@ Rustdoc’s JavaScript and TypeScript are checked during CI by `eslint`, `es-che
 These run as part of the `tidy` job.
 
 ```console
-./x.py test tidy --extra-checks=js
+./x test tidy --extra-checks=js
 ```
 
 The `--extra-checks=js` flag enables the frontend linting that runs in CI.


### PR DESCRIPTION
Most of the commands were specified with `./x`, but three of the commands were using `./x.py` without a clear reason - align with the guide's convention of using `./x`.