### PR TITLE
document 'x' command in nix-dev-shell

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -442,6 +442,9 @@ If you're using the flake, make sure to also update it with the following comman
 nix flake update --flake ./src/tools/nix-dev-shell
 ```
 
+The shell creates a command named `x` that runs the `./x.py` script with all dependencies
+set up correctly.
+
 ### Note
 
 Note that when using nix on a not-NixOS distribution, it may be necessary to set


### PR DESCRIPTION
I tripped over this while using the regular `./x` command to run the tests, which resulted in [some confusing errors](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/nix.20shell.20and.20run-make-cargo.20tests/near/574949006)