### PR TITLE
Fix GPU target notification group links

### DIFF
--- a/src/notification-groups/gpu-target.md
+++ b/src/notification-groups/gpu-target.md
@@ -6,13 +6,13 @@
 This notification group deals with linker related issues and their integration
 within the compiler.
 
-The group also has an associated Zulip stream ([`#t-compiler/linker`])
+The group also has an associated Zulip stream ([`#t-compiler/gpgpu-backend`])
 where people can go to ask questions and discuss GPU-related topics and issues.
 
 if you're interested in participating, feel free to sign up for this group! To
 do so, open a PR against the [rust-lang/team] repository and add your GitHub
 user to [this file][gpu-target-team].
 
-[`#t-compiler/linker`]: https://rust-lang.zulipchat.com/#narrow/channel/585172-t-compiler.2Flinker
+[`#t-compiler/gpgpu-backend`]: https://rust-lang.zulipchat.com/#narrow/channel/422870-t-compiler.2Fgpgpu-backend
 [rust-lang/team]: https://github.com/rust-lang/team
 [gpu-target-team]: https://github.com/rust-lang/team/blob/main/teams/gpu-target.toml


### PR DESCRIPTION
Fixes a lapsus when I authored rust-lang/rustc-dev-guide#2807 (put the wrong links to contact the group)

~Before merging, I'd like to wait for https://github.com/rust-lang/blog.rust-lang.org/pull/1833 first~

On a second thought, this doesn't need to wait.

Happy to get a review

r? rustc-dev-guide