### PR TITLE
rustc internals docs clarification

### DIFF
--- a/src/rustc-driver/external-rustc-drivers.md
+++ b/src/rustc-driver/external-rustc-drivers.md
@@ -71,6 +71,21 @@ When developing out-of-tree projects that use `rustc_private` crates, you can co
 
 This configuration allows `rust-analyzer` to properly recognize and provide IDE support for `rustc_private` crates in out-of-tree projects. 
 
+### Getting Specific Nightly Documentation for `rustc_private`
+
+The nightly-rustc internal crates' documentation is only available for the latest nightly. If you depend on compiler internals from an older nightly, you may want to refer to the internal documentation from that particular nightly. The only way to do this is to generate the documentation locally. For example, to get documentation for `nightly-2025-11-08`:
+
+Get the Git commit hash for that nightly:
+
+```sh
+rustup toolchain install nightly-2025-11-08
+rustup default nightly-2025-11-08
+rustc -Vv
+```
+
+The output will include a `commit-hash` line identifying the exact source revision. Check out `rust-lang/rust` at that commit, then follow the steps in [compiler documentation](../building/compiler-documenting.md).
+
+
 ### Additional Resources
 
 - [GitHub Issue #137421] explains that `rustc_private` linker failures often occur because `llvm-tools` is not installed

--- a/src/rustc-driver/external-rustc-drivers.md
+++ b/src/rustc-driver/external-rustc-drivers.md
@@ -79,8 +79,7 @@ Get the Git commit hash for that nightly:
 
 ```sh
 rustup toolchain install nightly-2025-11-08
-rustup default nightly-2025-11-08
-rustc -Vv
+rustc +nightly-2025-11-08 --version --verbose
 ```
 
 The output will include a `commit-hash` line identifying the exact source revision. Check out `rust-lang/rust` at that commit, then follow the steps in [compiler documentation](../building/compiler-documenting.md).

--- a/src/rustc-driver/external-rustc-drivers.md
+++ b/src/rustc-driver/external-rustc-drivers.md
@@ -6,7 +6,7 @@
 
 The `rustc_private` feature allows external crates to use compiler internals.
 
-### Using `rustc-private` with Official Toolchains
+### Using `rustc_private` with Official Toolchains
 
 When using the `rustc_private` feature with official Rust toolchains distributed via rustup, you need to install two additional components:
 


### PR DESCRIPTION
Ran into this recently, so thought maybe adding this to the dev guide makes it clearer and searchable/discoverable.

- Only latest nightly crates' docs are published
- How to get an old nightly docs