### PR TITLE
Add CI testing instructions for offload

### DIFF
--- a/src/offload/installation.md
+++ b/src/offload/installation.md
@@ -39,7 +39,15 @@ This gives you a working LLVM build.
 
 
 ## Testing
-run
+Run this test script for offload-specific tests:
 ```console
 ./x test --stage 1 tests/codegen-llvm/gpu_offload
 ```
+
+For testing the CI locally, you may use the commands outlined in [Testing with Docker](https://rustc-dev-guide.rust-lang.org/tests/docker.html):
+```console
+cargo run --manifest-path src/ci/citool/Cargo.toml run-local dist-x86_64-linux
+```
+This stores all compiler artifacts in the `obj` directory, however should you modify rustc-specific code, you may need to delete this directory as the Docker image will cache its state otherwise.
+
+Submodules should also be checked out at this point.


### PR DESCRIPTION
@ZuseZ4 thought, it'd be helpful since we currently have issues with getting offload to work in CI (https://github.com/rust-lang/rust/pull/153203) and this helps with testing it.