### PR TITLE
Replace `rustc_session::parse::feature*` with ``rustc_session::errors::feature*`

### DIFF
--- a/src/implementing-new-features.md
+++ b/src/implementing-new-features.md
@@ -191,7 +191,7 @@ The below steps needs to be followed in order to implement a new unstable featur
     If the feature gate is not set,
     you should either maintain the pre-feature behavior or raise an error,
     depending on what makes sense.
-    Errors should generally use [`rustc_session::parse::feature_err`].
+    Errors should generally use [`rustc_session::errors::feature_err`].
     For an example of adding an error, see [#81015].
 
    For features introducing new syntax, pre-expansion gating should be used instead.
@@ -221,7 +221,7 @@ The below steps needs to be followed in order to implement a new unstable featur
 
 [`GatedSpans`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/parse/struct.GatedSpans.html
 [#81015]: https://github.com/rust-lang/rust/pull/81015
-[`rustc_session::parse::feature_err`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/parse/fn.feature_err.html
+[`rustc_session::errors::feature_err`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/errors/fn.feature_err.html
 [`rustc_ast_passes::feature_gate::check_crate`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_passes/feature_gate/fn.check_crate.html
 [value the stability of Rust]: https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md
 [stability in code]: #stability-in-code


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/155980 moved feature* methods from parse mod to errors mod, so `rustc_session::parse::feature_err` no longer points to valid page.