### PR TITLE
Update date references for 2026-05 triage (#2861)

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -444,20 +444,20 @@ Just a few things to keep in mind:
     For the action to pick the date, add a special annotation before specifying the date:
 
     ```md
-    <!-- date-check --> May 2026
+    <!-- date-check --> Nov 2025
     ```
 
     Example:
 
     ```md
-    As of <!-- date-check --> May 2026, the foo did the bar.
+    As of <!-- date-check --> Nov 2025, the foo did the bar.
     ```
 
     For cases where the date should not be part of the visible rendered output,
     use the following instead:
 
     ```md
-    <!-- date-check: May 2026 -->
+    <!-- date-check: Nov 2025 -->
     ```
 
   - A link to a relevant WG, tracking issue, `rustc` rustdoc page, or similar, that may provide

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -444,20 +444,20 @@ Just a few things to keep in mind:
     For the action to pick the date, add a special annotation before specifying the date:
 
     ```md
-    <!-- date-check --> Nov 2025
+    <!-- date-check --> May 2026
     ```
 
     Example:
 
     ```md
-    As of <!-- date-check --> Nov 2025, the foo did the bar.
+    As of <!-- date-check --> May 2026, the foo did the bar.
     ```
 
     For cases where the date should not be part of the visible rendered output,
     use the following instead:
 
     ```md
-    <!-- date-check: Nov 2025 -->
+    <!-- date-check: May 2026 -->
     ```
 
   - A link to a relevant WG, tracking issue, `rustc` rustdoc page, or similar, that may provide

--- a/src/implementing-new-features.md
+++ b/src/implementing-new-features.md
@@ -1,4 +1,4 @@
-<!-- date-check: Jul 2025 -->
+<!-- date-check: May 2026 -->
 
 # Implementing new language features
 

--- a/src/implementing-new-features.md
+++ b/src/implementing-new-features.md
@@ -1,4 +1,3 @@
-<!-- date-check: May 2026 -->
 
 # Implementing new language features
 

--- a/src/normalization.md
+++ b/src/normalization.md
@@ -164,7 +164,7 @@ In this example:
 
 When interfacing with the type system it will often be the case that it's necessary to request a type be normalized. There are a number of different entry points to the underlying normalization logic and each entry point should only be used in specific parts of the compiler.
 
-<!-- date-check: May 2025 -->
+<!-- date-check: May 2026 -->
 An additional complication is that the compiler is currently undergoing a transition from the old trait solver to the new trait solver.
 As part of this transition our approach to normalization in the compiler has changed somewhat significantly, resulting in some normalization entry points being "old solver only" slated for removal in the long-term once the new solver has stabilized.
 The transition can be tracked via the [WG-trait-system-refactor](https://github.com/rust-lang/rust/labels/WG-trait-system-refactor) label in Github.

--- a/src/normalization.md
+++ b/src/normalization.md
@@ -164,7 +164,6 @@ In this example:
 
 When interfacing with the type system it will often be the case that it's necessary to request a type be normalized. There are a number of different entry points to the underlying normalization logic and each entry point should only be used in specific parts of the compiler.
 
-<!-- date-check: May 2026 -->
 An additional complication is that the compiler is currently undergoing a transition from the old trait solver to the new trait solver.
 As part of this transition our approach to normalization in the compiler has changed somewhat significantly, resulting in some normalization entry points being "old solver only" slated for removal in the long-term once the new solver has stabilized.
 The transition can be tracked via the [WG-trait-system-refactor](https://github.com/rust-lang/rust/labels/WG-trait-system-refactor) label in Github.

--- a/src/rustdoc-internals.md
+++ b/src/rustdoc-internals.md
@@ -222,7 +222,7 @@ directly, even during `HTML` generation.
 This [didn't used to be the case], and
 a lot of `rustdoc`'s architecture was designed around not doing that, but a
 `TyCtxt` is now passed to `formats::renderer::run_format`, which is used to
-run generation for both `HTML` and the (unstable as of <!-- date-check --> Nov 2025) JSON format.
+run generation for both `HTML` and the (unstable as of <!-- date-check --> May 2026) JSON format.
 
 This change has allowed other changes to remove data from the "clean" [`AST`][ast]
 that can be easily derived from `TyCtxt` queries, and we'll usually accept

--- a/src/tests/minicore.md
+++ b/src/tests/minicore.md
@@ -1,6 +1,5 @@
 # `minicore` test auxiliary: using `core` stubs
 
-<!-- date-check: May 2026 -->
 
 [`tests/auxiliary/minicore.rs`][`minicore`] is a test auxiliary for ui/codegen/assembly/mir-opt test suites.
 It provides `core` stubs for tests that need to

--- a/src/tests/minicore.md
+++ b/src/tests/minicore.md
@@ -1,6 +1,6 @@
 # `minicore` test auxiliary: using `core` stubs
 
-<!-- date-check: Oct 2025 -->
+<!-- date-check: May 2026 -->
 
 [`tests/auxiliary/minicore.rs`][`minicore`] is a test auxiliary for ui/codegen/assembly/mir-opt test suites.
 It provides `core` stubs for tests that need to

--- a/src/tests/misc.md
+++ b/src/tests/misc.md
@@ -2,7 +2,7 @@
 
 ## `RUSTC_BOOTSTRAP` and stability
 
-<!-- date-check: Nov 2024 -->
+<!-- date-check: May 2026 -->
 
 This is a bootstrap/compiler implementation detail, but it can also be useful
 for testing:

--- a/src/tests/misc.md
+++ b/src/tests/misc.md
@@ -2,7 +2,6 @@
 
 ## `RUSTC_BOOTSTRAP` and stability
 
-<!-- date-check: May 2026 -->
 
 This is a bootstrap/compiler implementation detail, but it can also be useful
 for testing:


### PR DESCRIPTION
Part of rust-lang/rustc-dev-guide#2861.

Updated date references to May 2026 in:
- src/contributing.md (×3)
- src/implementing-new-features.md
- src/normalization.md
- src/rustdoc-internals.md
- src/tests/minicore.md
- src/tests/misc.md

Skipped lldb-visualizers.md and opaque-types-type-alias-impl-trait.md
as those reference external dependencies needing deeper verification.

r? rust-lang/rustc-dev-guide