### PR TITLE
Fix sample code for std::offload at usage.md

### DIFF
--- a/src/offload/usage.md
+++ b/src/offload/usage.md
@@ -59,7 +59,7 @@ fn main() {
 
 #[inline(never)]
 unsafe fn kernel(x: *mut [f64; 256]) {
-    core::intrinsics::offload(_kernel_1, [256, 1, 1], [32, 1, 1], (x,))
+    core::intrinsics::offload(kernel_1, [256, 1, 1], [32, 1, 1], (x,))
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Sample code at src/doc/rustc-dev-guide/src/offload/usage.md did not work on an NVIDIA gpu server.
It seems it has a typo. _kernel_1 was not defined but referenced at core::intrinsics::offload.
I replaced it with kernel_1 and it worked.

r? @ZuseZ4