### PR TITLE
Document Windows antivirus checkout exclusion

### DIFF
--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -45,6 +45,12 @@ git clone https://github.com/rust-lang/rust.git
 cd rust
 ```
 
+> **NOTE**: On Windows, antivirus scanning can make Git and build commands
+> noticeably slower in a large checkout. If that happens, consider adding only
+> the Rust checkout directory to the
+> [Windows Security exclusion list][windows-security-exclusions].
+> Avoid adding broader exclusions than needed.
+
 ### Partial clone the repository
 
 Due to the size of the repository, cloning on a slower internet connection can take a long time,
@@ -97,6 +103,7 @@ This chapter focuses on the basics to be productive, but
 if you want to learn more about `x.py`, [read this chapter][bootstrap].
 
 [bootstrap]: ./bootstrapping/intro.md
+[windows-security-exclusions]: https://support.microsoft.com/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26
 
 Also, using `x` rather than `x.py` is recommended as:
 


### PR DESCRIPTION
Adds a short Windows note about excluding only the Rust checkout directory when antivirus scanning makes Git or build commands slow.

Fixes rust-lang/rustc-dev-guide#1533

Checks:\n- git diff --check\n- RUSTC_BOOTSTRAP=1 cargo run --release --manifest-path ci/sembr/Cargo.toml src/building/how-to-build-and-run.md