### PR TITLE
Avoid date-checking contributing examples

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -444,20 +444,20 @@ Just a few things to keep in mind:
     For the action to pick the date, add a special annotation before specifying the date:
 
     ```md
-    <!-- date-check --> Nov 2025
+    <!-- date-check --> Month YYYY
     ```
 
     Example:
 
     ```md
-    As of <!-- date-check --> Nov 2025, the foo did the bar.
+    As of <!-- date-check --> Month YYYY, the foo did the bar.
     ```
 
     For cases where the date should not be part of the visible rendered output,
     use the following instead:
 
     ```md
-    <!-- date-check: Nov 2025 -->
+    <!-- date-check: Month YYYY -->
     ```
 
   - A link to a relevant WG, tracking issue, `rustc` rustdoc page, or similar, that may provide


### PR DESCRIPTION
Fixes part of rust-lang/rustc-dev-guide#2887.

This updates the `src/contributing.md` date-check examples to use placeholders instead of real stale dates, so the examples do not keep appearing in monthly date triage output.

Check: `cargo run --manifest-path ci/date-check/Cargo.toml . | Select-String -Pattern 'src/contributing.md|Date Reference Triage'`