### PR TITLE
Update autodiff installation guide

### DIFF
--- a/src/autodiff/installation.md
+++ b/src/autodiff/installation.md
@@ -1,15 +1,12 @@
 # Installation
 
-In the near future, `std::autodiff` should become available for users via rustup.
-As a rustc/enzyme/autodiff contributor however, you will still need to build rustc from source.
-For the meantime, you can download up-to-date builds to enable `std::autodiff` on your latest nightly toolchain, if you are using one of:
+Most users can enable `std::autodiff` on their latest nightly toolchain by installing the `enzyme` component with rustup, if they are using one of these platforms:
 
 - **Linux**: with `x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-gnu`
 - **macOS**: with `aarch64-apple-darwin`
 - **Windows**: with `x86_64-llvm-mingw` or `aarch64-llvm-mingw`
 
-If you need any other platform, you can build rustc including autodiff from source.
-Please open an issue if you want to help enabling automatic builds for your prefered target.
+As a rustc/enzyme/autodiff contributor, or if you need any other platform, you can build rustc including autodiff from source. Please open an issue if you want help enabling automatic builds for your preferred target.
 
 ## Installation guide
 

--- a/src/autodiff/installation.md
+++ b/src/autodiff/installation.md
@@ -2,24 +2,22 @@
 
 In the near future, `std::autodiff` should become available for users via rustup.
 As a rustc/enzyme/autodiff contributor however, you will still need to build rustc from source.
-For the meantime, you can download up-to-date builds to enable `std::autodiff` on your latest nightly toolchain, if you are using either of:
-**Linux**, with `x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-gnu`
-**Windows**, with `x86_64-llvm-mingw` or `aarch64-llvm-mingw`
+For the meantime, you can download up-to-date builds to enable `std::autodiff` on your latest nightly toolchain, if you are using one of:
 
-In the past you could also download builds for **Apple** (aarch64-apple), however they are not usable at the moment.
+- **Linux**: with `x86_64-unknown-linux-gnu` or `aarch64-unknown-linux-gnu`
+- **macOS**: with `aarch64-apple-darwin`
+- **Windows**: with `x86_64-llvm-mingw` or `aarch64-llvm-mingw`
 
 If you need any other platform, you can build rustc including autodiff from source.
 Please open an issue if you want to help enabling automatic builds for your prefered target.
 
 ## Installation guide
 
-If you want to use `std::autodiff` on Linux or Windows and don't plan to contribute PR's to the project, then we recommend to just use your existing nightly installation and download the missing component. Please run:
+If you want to use `std::autodiff` on Linux, macOS, or Windows and don't plan to contribute PR's to the project, then we recommend to just use your existing nightly installation and download the missing component. Please run:
 
 ```console
 rustup +nightly component add enzyme
 ```
-
-Apple support was temporarily reverted, due to downstream breakages. Please build it from source till we can re-enable it.
 
 ## Installation guide for Nix user.
 


### PR DESCRIPTION
* Add aarch64-apple-darwin to the available platform list
* Remove outdated Apple support notes
* Format the platform list as bullets for better readability

| Before | After |
| --- | --- |
| <img width="1370" height="763" alt="スクリーンショット 2026-06-07 13 00 19" src="https://github.com/user-attachments/assets/fbe78364-d8c7-4f68-a797-a814c05a869d" /> | <img width="1387" height="834" alt="スクリーンショット 2026-06-07 13 33 08" src="https://github.com/user-attachments/assets/af313801-d46c-481b-a1f8-fb0540abc581" /> |

r? @ZuseZ4