### PR TITLE
Use new name for `custom_messages` in triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -67,12 +67,12 @@ allow-unauthenticated = [
 # reviewer model, as `[assign.owners]` will cause triagebot auto-reviewer
 # assignment to kick in.
 
-# Custom PR welcome message for when no auto reviewer assignment is performed
+# Set custom PR welcome message for when no auto reviewer assignment is performed
 # and no explicit manual reviewer selection is made.
-# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment.html#custom-welcome-messages
-[assign.custom_welcome_messages]
-welcome-message = ""
-welcome-message-no-reviewer = """\
+# Documentation at: https://forge.rust-lang.org/triagebot/pr-assignment.html#custom-messages
+[assign.custom_messages]
+auto-assign-someone = ""
+auto-assign-no-one = """\
 Thanks for the PR. If you have write access, feel free to merge this PR if it \
 does not need reviews. You can request a review using `r? rustc-dev-guide` or \
 `r? <username>`.


### PR DESCRIPTION
Context: https://github.com/rust-lang/rust/issues/157567
Fixes https://github.com/rust-lang/rust/issues/157567