### PR TITLE
Update stale GenericArgs example

### DIFF
--- a/src/queries/incremental-compilation-in-detail.md
+++ b/src/queries/incremental-compilation-in-detail.md
@@ -229,7 +229,7 @@ guarantee that anything will have the same ID as it had before.
 As a consequence we cannot represent the data in our on-disk cache the same
 way it is represented in memory.
 For example, if we just stored a piece
-of type information like `TyKind::FnDef(DefId, &'tcx Substs<'tcx>)` (as we do
+of type information like `TyKind::FnDef(DefId, GenericArgsRef<'tcx>)` (as we do
 in memory) and then the contained `DefId` points to a different function in
 a new compilation session we'd be in trouble.
 


### PR DESCRIPTION
This updates an outdated `Substs<'tcx>` example in the incremental compilation chapter to use the current `GenericArgsRef<'tcx>` terminology.

`Substs` has been replaced by `GenericArgs`/`GenericArgsRef` in rustc, so this keeps the guide aligned with the current compiler code.