### PR TITLE
Improve diagnostic argument wording

### DIFF
--- a/src/diagnostics/diagnostic-structs.md
+++ b/src/diagnostics/diagnostic-structs.md
@@ -276,19 +276,19 @@ However, when a subdiagnostic is added to a main diagnostic by implementing `#[d
 the following rules, introduced in [rust-lang/rust#142724](https://github.com/rust-lang/rust/pull/142724)
 apply to the handling of arguments (i.e., variables used in Fluent messages):
 
-**Argument isolation between sub diagnostics**:
+**Argument isolation between subdiagnostics**:
 Arguments set by a subdiagnostic are only available during the rendering of that subdiagnostic.
 After the subdiagnostic is rendered, all arguments it introduced are restored from the main diagnostic.
 This ensures that multiple subdiagnostics do not pollute each other's argument scope.
-For example, when using a `Vec<Subdiag>`, it iteratively adds the same argument over and over again.
+For example, when using a `Vec<Subdiag>`, each subdiagnostic may add the same argument repeatedly.
 
 **Same argument override between sub and main diagnostics**:
-If a subdiagnostic sets a argument with the same name as a arguments already in the main diagnostic,
+If a subdiagnostic sets an argument with the same name as an argument already in the main diagnostic,
 it will report an error at runtime unless both have exactly the same value.
-It has two benefits:
-- preserves the flexibility that arguments in the main diagnostic are allowed to appear in the attributes of the subdiagnostic.
-For example, There is an attribute `#[suggestion("...", code = "{new_vis}")]` in the subdiagnostic, but `new_vis` is the field in the main diagnostic struct.
-- prevents accidental overwriting or deletion of arguments required by the main diagnostic or other subdiagnostics.
+This has two benefits:
+- It preserves the flexibility for arguments in the main diagnostic to appear in attributes of the subdiagnostic.
+  For example, an attribute such as `#[suggestion("...", code = "{new_vis}")]` in the subdiagnostic can refer to `new_vis`, a field in the main diagnostic struct.
+- It prevents accidental overwriting or deletion of arguments required by the main diagnostic or other subdiagnostics.
 
 These rules guarantee that arguments injected by subdiagnostics are strictly scoped to their own rendering.
 The main diagnostic's arguments remain unaffected by subdiagnostic logic, even in the presence of name collisions.


### PR DESCRIPTION
This improves the wording in the diagnostic structs documentation for subdiagnostic argument handling.

The change fixes a few grammar issues and clarifies the example while keeping the existing technical meaning unchanged.