### PR TITLE
update autodiff install docs for nix

### DIFF
--- a/src/autodiff/installation.md
+++ b/src/autodiff/installation.md
@@ -18,30 +18,30 @@ Please run:
 rustup +nightly component add enzyme
 ```
 
-## Installation guide for Nix user.
+## Installation guide for Nix
 
-This setup was recommended by a nix and autodiff user.
-It uses [`Overlay`].
-Please verify for yourself if you are comfortable using that repository.
-In that case you might use the following nix configuration to get a rustc that supports `std::autodiff`.
+On [Nix], you can declare a nightly Rust toolchain with the Enzyme component using the [oxalica rust-overlay].
+
+For example:
+
 ```nix
-{
-  enzymeLib = pkgs.fetchzip {
-    url = "https://ci-artifacts.rust-lang.org/rustc-builds/ec818fda361ca216eb186f5cf45131bd9c776bb4/enzyme-nightly-x86_64-unknown-linux-gnu.tar.xz";
-    sha256 = "sha256-Rnrop44vzS+qmYNaRoMNNMFyAc3YsMnwdNGYMXpZ5VY=";
-  };
+rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
+  extensions = [ "enzyme" ];
+})
+```
 
-  rustToolchain = pkgs.symlinkJoin {
-    name = "rust-with-enzyme";
-    paths = [pkgs.rust-bin.nightly.latest.default];
-    nativeBuildInputs = [pkgs.makeWrapper];
-    postBuild = ''
-      libdir=$out/lib/rustlib/x86_64-unknown-linux-gnu/lib
-      cp ${enzymeLib}/enzyme-preview/lib/rustlib/x86_64-unknown-linux-gnu/lib/libEnzyme-22.so $libdir/
-      wrapProgram $out/bin/rustc --add-flags "--sysroot $out"
-    '';
-  };
-}
+Alternatively, you can create a [toolchain file] that declares the Enzyme component such as
+
+```toml
+[toolchain]
+channel = "nightly-2026-06-23"
+components = [ "enzyme" ]
+```
+
+and consume it in the overlay
+
+```nix
+rust-bin.fromRustupToolchainFile ./rust-toolchain.toml
 ```
 
 ## Build instructions
@@ -135,4 +135,6 @@ This will build Enzyme, and you can find it in `Enzyme/enzyme/build/lib/<LLD/Cla
 (Endings might differ based on your OS).
 
 [`Repo`]: https://github.com/rust-lang/rust/
-[`Overlay`]: https://github.com/oxalica/rust-overlay
+[Nix]: https://nixos.org/
+[oxalica rust-overlay]: https://github.com/oxalica/rust-overlay
+[toolchain file]: https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file


### PR DESCRIPTION
Now that the Enzyme component is in rustup, usage in Nix is much simpler and just requires declaring the component.
This PR updates the docs to reflect that. Alternatively, we could drop this block entirely as this is now "standard practice" for nix + rust with rustup components.