### PR TITLE
Fix typo in best-practices.md

### DIFF
--- a/src/tests/best-practices.md
+++ b/src/tests/best-practices.md
@@ -171,7 +171,7 @@ place.
   If a test suite can
   randomly spuriously fail due to flaky tests, did the whole test suite pass or
   did I just get lucky/unlucky?
-- Flaky tests can randomly fail in full CI, wasting precious full CI resources.
+- Flaky tests can randomly fail in full CI, wasting precious resources.
 
 ## Compiletest directives
 

--- a/src/tests/best-practices.md
+++ b/src/tests/best-practices.md
@@ -171,7 +171,7 @@ place.
   If a test suite can
   randomly spuriously fail due to flaky tests, did the whole test suite pass or
   did I just get lucky/unlucky?
-- Flaky tests can randomly fail in full CI, wasting previous full CI resources.
+- Flaky tests can randomly fail in full CI, wasting precious full CI resources.
 
 ## Compiletest directives
 


### PR DESCRIPTION
This is likely meant to be "precious full CI resources", it took me a while to work that out, so it seems like a typo that impacts meaning/readability.