### PR TITLE
Update date-check markers for July 2026

### DIFF
--- a/src/contributing.md
+++ b/src/contributing.md
@@ -444,20 +444,20 @@ Just a few things to keep in mind:
     For the action to pick the date, add a special annotation before specifying the date:
 
     ```md
-    <!-- date-check --> Nov 2025
+    <!-- date-check --> Jul 2026
     ```
 
     Example:
 
     ```md
-    As of <!-- date-check --> Nov 2025, the foo did the bar.
+    As of <!-- date-check --> Jul 2026, the foo did the bar.
     ```
 
     For cases where the date should not be part of the visible rendered output,
     use the following instead:
 
     ```md
-    <!-- date-check: Nov 2025 -->
+    <!-- date-check: Jul 2026 -->
     ```
 
   - A link to a relevant WG, tracking issue, `rustc` rustdoc page, or similar, that may provide


### PR DESCRIPTION
## Summary
- update date-check examples in the contributing guide to July 2026
- leave `src/diagnostics/translation.md` unchanged because it needs a broader content refresh before its date-check markers should be updated

Part of rust-lang/rustc-dev-guide#2914.

## Verification
- `CARGO_HOME=/tmp/rustc-date-check-cargo CARGO_TARGET_DIR=/tmp/rustc-date-check-target cargo run --manifest-path ci/date-check/Cargo.toml .`
- `git diff --check`

The temporary Cargo cache and target directories used for verification were removed after the check.