### PR TITLE
Refresh diagnostic items date check

### DIFF
--- a/src/diagnostics/diagnostic-items.md
+++ b/src/diagnostics/diagnostic-items.md
@@ -48,7 +48,7 @@ A new diagnostic item can be added with these two steps:
     For the naming conventions of diagnostic items, please refer to
     [*Naming Conventions*](#naming-conventions).
 
-2. <!-- date-check: Feb 2023 -->
+2. <!-- date-check: Jul 2026 -->
    Diagnostic items in code are accessed via symbols in
    [`rustc_span::symbol::sym`].
    To add your newly-created diagnostic item,


### PR DESCRIPTION
Refresh the date check for the diagnostic-items symbol-registration instructions after verifying them against current rustc.

The compiler still defines diagnostic-item symbols in `compiler/rustc_span/src/symbol.rs` through the `symbols!` list and exposes them through `rustc_span::symbol::sym`, so the surrounding guidance remains current.

Part of rust-lang/rustc-dev-guide#2914.

Validation:

- ran `cargo run --manifest-path ci/date-check/Cargo.toml .` and confirmed `src/diagnostics/diagnostic-items.md` is no longer reported
- `git diff --check`
