### PR TITLE
docs: Verify fuzzing guidance date

### DIFF
--- a/src/fuzzing.md
+++ b/src/fuzzing.md
@@ -1,6 +1,6 @@
 # Fuzzing
 
-<!-- date-check: Mar 2023 -->
+<!-- date-check: Jul 2026 -->
 
 For the purposes of this guide, *fuzzing* is any testing methodology that
 involves compiling a wide variety of programs in an attempt to uncover bugs in rustc.


### PR DESCRIPTION
Updates the `src/fuzzing.md` date-check marker after reviewing the guidance and its referenced resources for the July 2026 date-reference triage. The guidance remains current, so no surrounding content changes are needed.

Part of rust-lang/rustc-dev-guide#2914.

Validation: `git diff --check`