### PR TITLE
docs: Update profiling inlining guidance

### DIFF
--- a/src/profiling.md
+++ b/src/profiling.md
@@ -109,6 +109,6 @@ The llvm-lines output is affected by several options.
 MIR optimizations have little impact.
 Compared to the default `RUSTFLAGS="-Z
 mir-opt-level=1"`, level 0 adds 0.3GB and level 2 removes 0.2GB.
-As of <!-- date-check --> July 2022,
-inlining happens in LLVM and GCC codegen backends,
-missing only in the Cranelift one.
+As of <!-- date-check --> July 2026, Cranelift sysroot builds explicitly enable
+MIR inlining with `-Zinline-mir`, while the LLVM and GCC codegen backends may
+also perform inlining during code generation.


### PR DESCRIPTION
Refreshes the profiling date-reference and corrects its outdated statement that inlining was missing from Cranelift. Current `rustc_codegen_cranelift` sysroot builds explicitly enable MIR inlining with `-Zinline-mir`; LLVM and GCC may also inline during code generation.

Source checked: https://github.com/rust-lang/rustc_codegen_cranelift/blob/master/build_system/build_sysroot.rs

Part of rust-lang/rustc-dev-guide#2914.

Validation: `git diff --check`