### PR TITLE
docs: Clarify Neovim workspace path setup

### DIFF
--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -163,6 +163,8 @@ Steps for this can be [found here][r-a nvim lsp].
 2. Run `./x setup editor`, and select `vscode` to create a `.vscode/settings.json` file.
    `neoconf` is able to read and update
    rust-analyzer settings automatically when the project is opened when this file is detected.
+   Neovim does not expand VS Code's `${workspaceFolder}` variable, so replace each occurrence
+   in the generated file with the absolute path to your rust repository.
 
 #### coc.nvim
 


### PR DESCRIPTION
Fixes rust-lang/rustc-dev-guide#2473.

Clarify that Neovim/neoconf does not expand VS Code’s `${workspaceFolder}` variable in the generated `.vscode/settings.json`, and instruct users to replace it with the absolute path to their rust repository.

Validation:
- `git diff --check`
- Verified the current generated `rust_analyzer_settings.json` still contains `${workspaceFolder}` in rustfmt, proc-macro, rustc, and cargo paths

The local environment does not have Cargo or mdBook installed; repository CI will run the complete book and link checks.