### PR TITLE
fix: Date Reference Triage for 2026-08

### DIFF
--- a/src/parallel-rustc.md
+++ b/src/parallel-rustc.md
@@ -1,14 +1,14 @@
 # Parallel compilation
 
 <div class="warning">
-As of <!-- date-check --> November 2024,
+As of <!-- date-check --> August 2026,
 the parallel front-end is undergoing significant changes,
 so this page contains quite a bit of outdated information.
 
 Tracking issue: <https://github.com/rust-lang/rust/issues/113349>
 </div>
 
-As of <!-- date-check --> November 2024, most of the rust compiler is now
+As of <!-- date-check --> August 2026, most of the rust compiler is now
 parallelized.
 
 - The codegen part is executed concurrently by default.
@@ -111,7 +111,7 @@ when `parallel-compiler` is true.
 | **ModuleItems::par_foreign_items**(&self, f: impl Fn(ForeignItemId)) | run `f` on all foreign items in the module                   | rustc_middle::hir          |
 
 There are a lot of loops in the compiler which can possibly be parallelized
-using these functions. As of <!-- date-check--> August 2022, scenarios where
+using these functions. As of <!-- date-check--> August 2026, scenarios where
 the parallel iterator function has been used are as follows:
 
 | caller                                                  | scenario                                                     | callee                   |
@@ -164,7 +164,7 @@ See [this open feature tracking issue][tracking].
 
 ## Rustdoc
 
-As of <!-- date-check--> November 2022, there are still a number of steps to
+As of <!-- date-check--> August 2026, there are still a number of steps to
 complete before `rustdoc` rendering can be made parallel (see a open discussion
 of [parallel `rustdoc`][parallel-rustdoc]).
 


### PR DESCRIPTION
## Summary

Addresses rust-lang/rustc-dev-guide#2948: Date Reference Triage for 2026-08

## Changed files

- `src/parallel-rustc.md`

## Validation

- `git diff --check`: passed

Fixes rust-lang/rustc-dev-guide#2948
