### PR TITLE
derive(Diagnostic): #[note] etc also work on bool fields

### DIFF
--- a/src/diagnostics/diagnostic-structs.md
+++ b/src/diagnostics/diagnostic-structs.md
@@ -135,12 +135,12 @@ tcx.dcx().emit_err(FieldAlreadyDeclared {
   - `code = "..."` (_Optional_)
     - Specifies the error code.
 - `#[note("message")]` (_Optional_)
-  - _Applied to struct or struct fields of type `Span`, `Option<()>` or `()`._
+  - _Applied to struct or struct fields of type `Span`, `Option<()>`, `bool`, or `()`._
   - Adds a note subdiagnostic.
   - Value is the note's message.
   - If applied to a `Span` field, creates a spanned note.
 - `#[help("message")]` (_Optional_)
-  - _Applied to struct or struct fields of type `Span`, `Option<()>` or `()`._
+  - _Applied to struct or struct fields of type `Span`, `Option<()>`, `bool`, or `()`._
   - Adds a help subdiagnostic.
   - Value is the help message.
   - If applied to a `Span` field, creates a spanned help.
@@ -149,7 +149,7 @@ tcx.dcx().emit_err(FieldAlreadyDeclared {
   - Adds a label subdiagnostic.
   - Value is the label's message.
 - `#[warning("message")]` (_Optional_)
-  - _Applied to struct or struct fields of type `Span`, `Option<()>` or `()`._
+  - _Applied to struct or struct fields of type `Span`, `Option<()>`, `bool`, or `()`._
   - Adds a warning subdiagnostic.
   - Value is the warning's message.
 - `#[suggestion{,_hidden,_short,_verbose}("message", code = "...", applicability = "...")]`


### PR DESCRIPTION
At least it certainly looks like this works:
https://github.com/rust-lang/rust/blob/c82207c46e5cefe4ddb000232aec281c28f0f6a8/compiler/rustc_codegen_ssa/src/diagnostics.rs#L1240-L1246
and then I assume it works for all of them, not just `#[note]`.

There are also more attributes the docs don't mention: `help_once`, `note_once`.  I'm not sure what exactly those do. They were added in https://github.com/rust-lang/rust/pull/124417. Cc @Xiretza @fmaese