### PR TITLE
Fix mentions of "`ai-assisted`" label in llm guidance docs

### DIFF
--- a/src/llm-guidance/reviewing.md
+++ b/src/llm-guidance/reviewing.md
@@ -17,12 +17,12 @@
 
 ## Reviewing LLM-created code
 
-First, add the new `ai-assisted` label to the PR.
+First, add the new `llm-assisted` label to the PR.
 
 ### Rules
 
 We expect everyone to follow the new policy, not just authors.
-That means it is **your responsibility** to check whether an `ai-assisted` PR touches an area that's disallowed by the policy.
+That means it is **your responsibility** to check whether an `llm-assisted` PR touches an area that's disallowed by the policy.
 You may request that the author redo it without LLM-generated code, in which case this section doesn't apply.
 
 The following areas are currently banned:


### PR DESCRIPTION
The actual label we created is called `llm-assisted` now.

It's a dedicated PR for just a small change to the document, but IMO this was sufficiently confusing in practice that it's worth fixing sooner rather than later.

I've also opened a PR to fix the policy document itself: rust-lang/rust-forge#1089