### PR TITLE
Cleanup bootstrap references

### DIFF
--- a/src/building/bootstrapping/intro.md
+++ b/src/building/bootstrapping/intro.md
@@ -5,12 +5,12 @@ More accurately, it means using an older compiler to compile a newer version of 
 
 This raises a chicken-and-egg paradox: where did the first compiler come from?
 It must have been written in a different language.
-In Rust's case it was [written in OCaml].
+In Rust's case, it was [written in OCaml][ocaml-compiler].
 However, it was abandoned long ago, and the
-only way to build a modern version of rustc is with a slightly less modern version.
+only way to build a modern version of `rustc` is with a slightly less modern version.
 
-This is exactly how `x.py` works: it downloads the current beta release of
-rustc, then uses it to compile the new compiler.
+This is exactly how Rust's bootstrap build system works: it downloads the current beta release of
+`rustc`, then uses it to compile the new compiler.
 
 In this section, we give a high-level overview of
 [what Bootstrap does](./what-bootstrapping-does.md), followed by a high-level
@@ -19,4 +19,4 @@ introduction to [how Bootstrap does it](./how-bootstrap-does-it.md).
 Additionally, see [debugging bootstrap](./debugging-bootstrap.md) to learn about debugging methods.
 
 [*Bootstrapping*]: https://en.wikipedia.org/wiki/Bootstrapping_(compilers)
-[written in OCaml]: https://github.com/rust-lang/rust/tree/ef75860a0a72f79f97216f8aaa5b388d98da6480/src/boot
+[ocaml-compiler]: https://github.com/rust-lang/rust/tree/ef75860a0a72f79f97216f8aaa5b388d98da6480/src/boot

--- a/src/building/bootstrapping/what-bootstrapping-does.md
+++ b/src/building/bootstrapping/what-bootstrapping-does.md
@@ -1,20 +1,6 @@
 # What Bootstrapping does
 
-[*Bootstrapping*][boot] is the process of using a compiler to compile itself.
-More accurately, it means using an older compiler to compile a newer version of the same compiler.
-
-This raises a chicken-and-egg paradox: where did the first compiler come from?
-It must have been written in a different language.
-In Rust's case, it was [written in OCaml][ocaml-compiler].
-However, it was abandoned long ago, and the
-only way to build a modern version of `rustc` is with a slightly less modern version.
-
-This is exactly how [`./x.py`] works: it downloads the current beta release of
-`rustc`, then uses it to compile the new compiler.
-
-[`./x.py`]: https://github.com/rust-lang/rust/blob/HEAD/x.py
-
-Note that this documentation mostly covers user-facing information.
+NOTE: this documentation mostly covers user-facing information.
 See [bootstrap/README.md][bootstrap-internals] to read about bootstrap internals.
 
 [bootstrap-internals]: https://github.com/rust-lang/rust/blob/HEAD/src/bootstrap/README.md
@@ -61,8 +47,8 @@ graph TD
 ### Stage 0: the pre-compiled compiler
 
 The stage0 compiler is by default the very recent _beta_ `rustc` compiler and its
-associated dynamic libraries, which `./x.py` will download for you.
-(You can also configure `./x.py` to change stage0 to something else.)
+associated dynamic libraries, which bootstrap will download for you.
+(You can also configure this in `bootstrap.toml` to change stage0 to something else.)
 
 The precompiled stage0 compiler is then used only to compile [`src/bootstrap`] and [`compiler/rustc`]
 with precompiled stage0 std.
@@ -155,7 +141,6 @@ There are two methods used:
 
 [boot]: https://en.wikipedia.org/wiki/Bootstrapping_(compilers)
 [intrinsics]: ../../appendix/glossary.md#intrinsic
-[ocaml-compiler]: https://github.com/rust-lang/rust/tree/ef75860a0a72f79f97216f8aaa5b388d98da6480/src/boot
 
 ## Understanding stages of bootstrap
 

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -21,7 +21,7 @@ implementing a maintainable fix is taking some time.
 </div>
 
 
-The compiler is built using a tool called `x.py`.
+The compiler is built using a tool called `bootstrap`.
 You will need to have Python installed to run it.
 
 ## Quick Start
@@ -94,57 +94,32 @@ cd rust
 > For example, `git bisect` and `git blame` require access to the commit history,
 > so they don't work if the repository was cloned with `--depth 1`.
 
-## What is `x.py`?
+## What is bootstrap?
 
-`x.py` is the build tool for the `rust` repository.
+Bootstrap is the build tool for the `rust` repository.
 It can build docs, run tests, and build the compiler and standard library.
 
 This chapter focuses on the basics to be productive, but
-if you want to learn more about `x.py`, [read this chapter][bootstrap].
+if you want to learn more about bootstrap, [read this chapter][bootstrap].
 
 [bootstrap]: ./bootstrapping/intro.md
 [windows-security-exclusions]: https://support.microsoft.com/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26
 
-Also, using `x` rather than `x.py` is recommended as:
+### Running bootstrap
 
-> `./x` is the most likely to work on every system (on Unix it runs the shell script
-> that does python version detection, on Windows it will probably run the
-> powershell script - certainly less likely to break than `./x.py` which often just
-> opens the file in an editor).[^1]
-
-(You can find the platform related scripts around the `x.py`, like `x.ps1`)
-
-Notice that this is not absolute.
-For instance, using Nushell in VSCode on Win10,
-typing `x` or `./x` still opens `x.py` in an editor rather than invoking the program.
-
-In the rest of this guide, we use `x` rather than `x.py` directly.
-The following command:
-
-```bash
-./x check
-```
-
-could be replaced by:
-
-```bash
-./x.py check
-```
-
-### Running `x.py`
-
-The `x.py` command can be run on most systems (Unix, Windows if configured) in this way:
+Bootstrap can be run on most systems (Unix, Windows if configured) in this way:
 
 ```sh
 ./x <subcommand> [flags]
 ```
 
-This is how the documentation and examples assume you are running `x.py`.
+This is how the documentation and examples assume you are running bootstrap.
 Some alternative ways are:
 
 ```sh
 # In Windows PowerShell (if PowerShell is configured to run scripts)
 ./x <subcommand> [flags]
+# In NuShell (if PowerShell is configured to run scripts). `./x` does not work in NuShell if `.py` files are not configured to run Python.
 ./x.ps1 <subcommand> [flags]
 
 # On the Windows Command Prompt (if .py files are configured to run Python)
@@ -169,24 +144,18 @@ At line:1 char:1
     + FullyQualifiedErrorId : UnauthorizedAccess
 ```
 
-You can avoid this error by allowing powershell to run local scripts:
+You can avoid this error by allowing PowerShell to run local scripts:
 ```
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
-#### Running `x.py` slightly more conveniently
+#### Running bootstrap slightly more conveniently
 
-There is a binary that wraps `x.py` called `x` in `src/tools/x`.
-All it does is run `x.py`, but it can be installed system-wide and run from any subdirectory
-of a checkout.
-It also looks up the appropriate version of `python` to use.
+There is a binary that wraps bootstrap called `x`.
+All it does is run `./x`, but it can be installed system-wide and run from any subdirectory of a checkout.
+It also looks up the appropriate version of Python to use and avoids depending on which shell you're currently using.
 
 You can install it with `cargo install --path src/tools/x`.
-
-To clarify that this is another global installed binary util, which is
-similar to the one declared in section [What is `x.py`](#what-is-xpy), but
-it works as an independent process to execute the `x.py` rather than calling the
-shell to run the platform related scripts.
 
 ## Create a `bootstrap.toml`
 
@@ -441,5 +410,3 @@ Occasionally, you may need to:
 - Remove `build-rust-analyzer/` directory (if you have a separate rust-analyzer build directory).
 - Uninstall unnecessary toolchains if you use `cargo-bisect-rustc`.
   You can check which toolchains are installed with `rustup toolchain list`.
-
-[^1]: issue[#1707](https://github.com/rust-lang/rustc-dev-guide/issues/1707)

--- a/src/building/optimized-build.md
+++ b/src/building/optimized-build.md
@@ -120,7 +120,7 @@ Here is an example of how can `opt-dist` be used locally (outside of CI):
       --target-triple <target> \ # select target, e.g. "x86_64-unknown-linux-gnu"
       --checkout-dir <path>    \ # path to rust checkout, e.g. "."
       --llvm-dir <path>        \ # path to built LLVM toolchain, e.g. "/foo/bar/llvm/install"
-      -- python3 x.py dist       # pass the actual build command
+      -- ./x dist       # pass the actual build command
     ```
     You can run `--help` to see further parameters that you can modify.
 

--- a/src/building/suggested.md
+++ b/src/building/suggested.md
@@ -473,11 +473,11 @@ pkgs.mkShell {
 ## Shell Completions
 
 If you use Bash, Zsh, Fish or PowerShell, you can find automatically-generated shell
-completion scripts for `x.py` in
+completion scripts for `./x` in
 [`src/etc/completions`](https://github.com/rust-lang/rust/tree/HEAD/src/etc/completions).
 
-You can use `source ./src/etc/completions/x.py.<extension>` to load completions
-for your shell of choice, or `& .\src\etc\completions\x.py.ps1` for PowerShell.
+You can use `source ./src/etc/completions/x.<extension>` to load completions
+for your shell of choice, or `& .\src\etc\completions\x.ps1` for PowerShell.
 Adding this to your shell's startup script (e.g. `.bashrc`) will automatically
 load this completion.
 


### PR DESCRIPTION
- Remove duplicate "chicken-and-egg" explanation. It only needs to be in one place.
- Change most references from `x.py` to `./x`, "bootstrap", or `bootstrap.py` as appropriate. Keep the ones where `x.py` is load-bearing.
- Remove over-long and duplicated instructions around the bootstrap wrappers

Disclosure: I used an LLM to help me find the places that needed to be changed. I made all the edits.

r? rustc-dev-guide