### PR TITLE
Fix orphaned chapters

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -57,6 +57,7 @@ cache-timeout = 90000
 warning-policy = "error"
 
 [output.html.redirect]
+"/backend/inline-asm.html" = "/backend/asm.html"
 "/borrow_check.html" = "borrow-check.html"
 "/borrow_check/drop_check.html" = "/borrow-check/drop-check.html"
 "/borrow_check/moves_and_initialization.html" = "/borrow-check/moves-and-initialization.html"
@@ -77,6 +78,7 @@ warning-policy = "error"
 "/early_late_parameters.html" = "early-late-parameters.html"
 "/generic_parameters_summary.html" = "generic-parameters-summary.html"
 "/implementing_new_features.html" = "implementing-new-features.html"
+"/llm-guidance/index.html" = "/llm-guidance.html"
 "/miri.html" = "const-eval/interpret.html"
 "/profiling/with_perf.html" = "with-perf.html"
 "/profiling/with_rustc_perf.html" = "with-rustc-perf.html"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -37,6 +37,7 @@
     - [Performance testing](./tests/perf.md)
     - [Autodiff CI job](./tests/autodiff-ci-job.md)
     - [Pre-stabilization CI job for the next solver and polonius alpha](./tests/x86_64-gnu-next-trait-solver-polonius-ci-job.md)
+    - [Parallel frontend CI job](./tests/optional-x86_64-gnu-parallel-frontend.md)
     - [Standard library semver breakage test](./tests/stdlib-semver-check.md)
     - [Misc info](./tests/misc.md)
 - [Debugging the compiler](./compiler-debugging.md)

--- a/src/backend/inline-asm.md
+++ b/src/backend/inline-asm.md
@@ -1,5 +1,0 @@
-# Inline Assembly
-
-**TODO**: You can find more info 
-[here](https://github.com/rust-lang/rust/pull/69171#issue-375572066)
-[#1162](https://github.com/rust-lang/rustc-dev-guide/issues/1162)

--- a/src/tests/optional-x86_64-gnu-parallel-frontend.md
+++ b/src/tests/optional-x86_64-gnu-parallel-frontend.md
@@ -1,5 +1,7 @@
 # Parallel frontend testing on CI
 
+NOTE: this job is optional and allowed to fail.
+
 If you see any test failures in `tests/ui` from the CI job `x86_64-gnu-parallel-frontend`, please
 add `//@ ignore-parallel-frontend triage` to the failing test, even if your PR is otherwise
 entirely unrelated to parallel compiler or its testing.


### PR DESCRIPTION
- delete `inline-asm` and redirect it to `asm`
- rename `optional-x86_64-gnu-parallel-frontend` to include the `optional-`, matching rl/r. include it in the ToC.
- add a redirect from `/llm-guidance/` to `/llm-guidance`, i think there's some docs floating around that accidentally suggest the former.

cc @jieyouxu just in case you have thoughts, but this feels mechanical enough i'm just going to merge it. happy to make fixes in follow-ups.