### PR TITLE
bump `mdbook-linkcheck2` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MDBOOK_VERSION: 0.5.2
-      MDBOOK_LINKCHECK2_VERSION: 0.11.0
+      MDBOOK_LINKCHECK2_VERSION: 0.12.2
       MDBOOK_MERMAID_VERSION: 0.17.0
       MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS: ${{ github.event_name != 'pull_request' }}
       DEPLOY_DIR: book/html


### PR DESCRIPTION
Bumps CI `mdbook-linkcheck2` version to `0.12.2`. This allows [admonitions](https://rust-lang.github.io/mdBook/format/markdown.html#admonitions) (added to `mdbook` early this year) to pass in CI. `linkcheck2` [added support for admonitions in v0.10.0](https://github.com/marxin/linkcheck2/commit/619a59b02e26ba1e40e31847476c41408e2b0db0). `mdbook-linkcheck2` v0.12.0 [bumped to `linkcheck2` v0.10.0](https://github.com/marxin/mdbook-linkcheck2/commit/b2a9aa21d6144feea8bc776a5d4fd7556fff4ac6). 

unblocks https://github.com/rust-lang/rustc-dev-guide/pull/2947