### PR TITLE
Make README more complete and easier to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 [![CI](https://github.com/rust-lang/rustc-dev-guide/actions/workflows/ci.yml/badge.svg)](https://github.com/rust-lang/rustc-dev-guide/actions/workflows/ci.yml)
 
+## About the `rustc-dev-guide`
+
 This is a collaborative effort to build a guide that explains how rustc works.
 The aim of the guide is to help new contributors get oriented to rustc,
 as well as to help more experienced folks in figuring out
 some new part of the compiler that they haven't worked on before.
 
-You may also find the [rustc API docs] useful.
-
-Note that these are not intended as a guide; it's recommended that you search
-for the docs you're looking for instead of reading them top to bottom.
+For more information, see [About This Guide](./src/about-this-guide.md).
 
 For documentation on developing the standard library, see
 [`std-dev-guide`](https://std-dev-guide.rust-lang.org/).
 
-### Contributing to the guide
+## Contributing to the guide
 
 The guide is useful today, but it has a lot of work still to go.
 
@@ -24,21 +23,14 @@ Just post a comment on the issue you would like to work on to make sure that we 
 accidentally duplicate work.
 If you think something is missing, please open an issue about it!
 
-**In general, if you don't know how the compiler works, that is not a
-problem!** In that case, what we will do is to schedule a bit of time
-for you to talk with someone who **does** know the code, or who wants
-to pair with you and figure it out.
-Then you can work on writing up what you learned.
-
-In general, when writing about a particular part of the compiler's code, we
-recommend that you link to the relevant parts of the [rustc API docs].
+See below for instructions on [writing new docs](#editing-the-guide).
 
 The guide has a much lower bar for what it takes for a PR to be merged.
 Check out the forge documentation for [our policy][forge_policy].
 
 [forge_policy]: https://forge.rust-lang.org/rustc-dev-guide/index.html#review-policy
 
-### Build Instructions
+## Build Instructions
 
 To build a local static HTML site, install [`mdbook`](https://github.com/rust-lang/mdBook) with:
 
@@ -49,10 +41,10 @@ cargo install mdbook mdbook-linkcheck2 mdbook-mermaid
 and execute the following command in the root of the repository:
 
 ```
-mdbook build --open
+mdbook serve --open
 ```
 
-The build files are found in the `book/html` directory.
+For a one-off build, you can use `mdbook build`.
 
 ### Link Validations
 
@@ -65,7 +57,49 @@ following example.
 ENABLE_LINKCHECK=1 mdbook serve
 ```
 
-## Synchronizing josh subtree with rustc
+## Editing the guide
+
+### Where to start
+
+**In general, if you don't know how the compiler works, that is not a
+problem!** In that case, what we will do is to schedule a bit of time
+for you to talk with someone who **does** know the code, or who wants
+to pair with you and figure it out.
+Then you can work on writing up what you learned.
+
+### Layout
+
+The dev-guide is organized as a normal [mdBook](https://rust-lang.github.io/mdBook/):
+It has a `src/SUMMARY.md` table of contents, which links to individual pages under `src/`.
+Configuration lives in `book.toml`.
+Images are in `src/img`.
+The build files are found in the `book/html` directory.
+
+**NOTE: if you do not add a page to SUMMARY.md, it will not be shown!**
+
+### While writing
+
+When writing about a particular part of the compiler's code, we
+recommend that you link to the relevant parts of the [rustc API docs].
+
+We encourage, but do not enforce, "semantic line breaks": one line per sentence.
+This makes it easier to review diffs, since they avoid reflowing other unrelated prose.
+
+Links within the guide should use `.md` relative links, not `.html` links.
+CI will enforce this.
+
+## Maintaining the guide
+
+### CI
+
+Various tools are kept under `ci/`.
+Check links with `mdbook-linkcheck2 --standalone`.
+Check semantic line breaks with `cargo run --manifest-path ci/sembr/Cargo.toml src`.
+Triage `<!-- date-check -->` annotations with `cargo run --manifest-path ci/date-check/Cargo.toml .`.
+
+You can test those tools with `cargo test --manifest-path ci/<tool>/Cargo.toml`.
+
+### Synchronizing josh subtree with rustc
 
 This repository is linked to `rust-lang/rust` as a [josh](https://josh-project.github.io/josh/intro.html) subtree.
 You can use the [rustc-josh-sync](https://github.com/rust-lang/josh-sync) tool to perform synchronization.

--- a/README.md
+++ b/README.md
@@ -79,14 +79,9 @@ The build files are found in the `book/html` directory.
 
 ### While writing
 
-When writing about a particular part of the compiler's code, we
-recommend that you link to the relevant parts of the [rustc API docs].
+See the guide itself for instructions on [writing new docs].
 
-We encourage, but do not enforce, "semantic line breaks": one line per sentence.
-This makes it easier to review diffs, since they avoid reflowing other unrelated prose.
-
-Links within the guide should use `.md` relative links, not `.html` links.
-CI will enforce this.
+[writing new docs]: src/contributing.md#contributing-to-rustc-dev-guide
 
 ## Maintaining the guide
 
@@ -105,5 +100,3 @@ This repository is linked to `rust-lang/rust` as a [josh](https://josh-project.g
 You can use the [rustc-josh-sync](https://github.com/rust-lang/josh-sync) tool to perform synchronization.
 
 You can find a guide on how to perform the synchronization [here](./src/external-repos.md#synchronizing-a-josh-subtree).
-
-[rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle

--- a/src/about-this-guide.md
+++ b/src/about-this-guide.md
@@ -5,6 +5,9 @@
 This guide is meant to help document how rustc – the Rust compiler – works,
 as well as to help new contributors get involved in rustc development.
 
+Note that this guide is intended as a reference; it's recommended that you search
+for the docs you're looking for instead of reading them top to bottom.
+
 There are several parts to this guide:
 
 1. [Building and debugging `rustc`][p1]:

--- a/src/contributing.md
+++ b/src/contributing.md
@@ -412,7 +412,20 @@ There are issues for beginners and advanced compiler devs alike!
 
 Just a few things to keep in mind:
 
+[rustc API docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle
+
+- When writing about a particular part of the compiler's code, we
+  recommend that you link to the relevant parts of the [rustc API docs].
+
+- Use sentence case for chapter and sections titles.
+
+- Use dashes (`-`) to separate words in file names.
+
+- Links within the guide should use `.md` relative links, not `.html` links.
+  CI will enforce this.
+
 - Please try to avoid overly long lines and use semantic line breaks (where you break the line after each sentence).
+  This makes it easier to review diffs, since they avoid reflowing other unrelated prose.
   There is no strict limit on line lengths;
   let the sentence or part of the sentence flow to its proper end on the same line.
 
@@ -463,10 +476,6 @@ Just a few things to keep in mind:
   - A link to a relevant WG, tracking issue, `rustc` rustdoc page, or similar, that may provide
     further explanation for the change process or a way to verify that the information is not
     outdated.
-
-- Use sentence case for chapter and sections titles.
-
-- Use dashes (`-`) to separate words file names.
 
 #### ⚠️ Note: Where to contribute `rustc-dev-guide` changes
 


### PR DESCRIPTION
- Organize by "About" -> "Contributing" -> "Editing" -> "Maintaining" rather than mixing sections
- Deduplicate a few lines into the guide itself
- Recommend `mdbook serve` over `mdbook build`
- Document `mdbook` layout and link to the upstream docs
- Document sembr and that relative links must use `.md` extensions
- Add a section on testing the tools in `ci/`

Disclosure: I used an LLM to suggest what would be most helpful to put in the README. I wrote all the text myself.

r? rustc-dev-guide