### PR TITLE
Install cargo tools with locked dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Install Dependencies
         if: steps.mdbook-cache.outputs.cache-hit != 'true'
         run: |
-          cargo install mdbook --version ${{ env.MDBOOK_VERSION }}
-          cargo install mdbook-linkcheck2 --version ${{ env.MDBOOK_LINKCHECK2_VERSION }}
-          cargo install mdbook-mermaid --version ${{ env.MDBOOK_MERMAID_VERSION }}
+          cargo install --locked mdbook --version ${{ env.MDBOOK_VERSION }}
+          cargo install --locked mdbook-linkcheck2 --version ${{ env.MDBOOK_LINKCHECK2_VERSION }}
+          cargo install --locked mdbook-mermaid --version ${{ env.MDBOOK_MERMAID_VERSION }}
 
       - name: Check build
         run: ENABLE_LINKCHECK=1 mdbook build

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Check out the forge documentation for [our policy][forge_policy].
 To build a local static HTML site, install [`mdbook`](https://github.com/rust-lang/mdBook) with:
 
 ```
-cargo install mdbook mdbook-linkcheck2 mdbook-mermaid
+cargo install --locked mdbook mdbook-linkcheck2 mdbook-mermaid
 ```
 
 and execute the following command in the root of the repository:

--- a/src/backend/debugging.md
+++ b/src/backend/debugging.md
@@ -71,7 +71,7 @@ use the `RUSTFLAGS` environment variable (e.g. `RUSTFLAGS='--emit=llvm-ir'`).
 This causes rustc to spit out LLVM IR into the target directory.
 
 `cargo llvm-ir [options] path` spits out the LLVM IR for a particular function at `path`.
-(`cargo install cargo-asm` installs `cargo asm` and `cargo llvm-ir`).
+(`cargo install --locked cargo-asm` installs `cargo asm` and `cargo llvm-ir`).
 `--build-type=debug` emits code for debug builds.
 There are also other useful options.
 Also, debug info in LLVM IR can clutter the output a lot:

--- a/src/building/how-to-build-and-run.md
+++ b/src/building/how-to-build-and-run.md
@@ -155,7 +155,7 @@ There is a binary that wraps bootstrap called `x`.
 It runs `./x`, and can be installed system-wide and run from any subdirectory of a checkout.
 It also looks up the appropriate version of Python to use and avoids depending on which shell you're currently using.
 
-You can install it with `cargo install --path src/tools/x`.
+You can install it with `cargo install --locked --path src/tools/x`.
 
 ## Create a `bootstrap.toml`
 

--- a/src/debuginfo/intro.md
+++ b/src/debuginfo/intro.md
@@ -86,7 +86,7 @@ accurate, and has useful diagrams.
     * [pdb-rs](https://github.com/microsoft/pdb-rs/) - A Rust-based PDB reader and writer based on
     other publicly-available information.
     Does not guarantee stability or spec compliance.
-    Also contains `pdbtool`, which can dump PDB files (`cargo install pdbtool`)
+    Also contains `pdbtool`, which can dump PDB files (`cargo install --locked pdbtool`)
     * [Debug Interface Access SDK](https://learn.microsoft.com/en-us/visualstudio/debugger/debug-interface-access/getting-started-debug-interface-access-sdk).
     While it does not document the PDB format directly, details can be gleaned from the interface
     itself.

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -41,7 +41,7 @@ It is stored in files with `*.no-opt.bc` extension in LLVM bitcode format.
 
 Example usage:
 ```
-cargo install cargo-llvm-lines
+cargo install --locked cargo-llvm-lines
 # On a normal crate you could now run `cargo llvm-lines`, but `x` isn't normal :P
 
 # Do a clean before every run, to not mix in the results from previous runs.

--- a/src/profiling/with-perf.md
+++ b/src/profiling/with-perf.md
@@ -54,7 +54,7 @@ In case to avoid the issue of `addr2line xxx/elf: could not read first record` w
 collected data from `cargo`, you may need use the latest version of `addr2line`:
 
 ```bash
-cargo install addr2line --features="bin"
+cargo install --locked addr2line --features="bin"
 ```
 
 ### Gathering a perf profile from a `perf.rust-lang.org` test
@@ -161,7 +161,7 @@ It's probably easiest to explain by walking through how I would analyze NLL perf
 You can install perf-focus using `cargo install`:
 
 ```bash
-cargo install perf-focus
+cargo install --locked perf-focus
 ```
 
 ### Example: How much time is spent in MIR borrowck?


### PR DESCRIPTION
Installing cargo tools (`cargo install`) without locked dependencies exposes users to supply-chain attacks to all the dependencies of the tool (https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/). Using `cargo install --locked` reduces this risk to a compromise of the tool itself, while using the locked and hashed version of the dependencies.

I went through all `rg "cargo install"` hits in the repository and added `--locked` to all but explanatory examples (such as cargo's docs on `cargo install` itself). I validated that those tools publish functioning `Cargo.lock`s with https://gist.github.com/konstin/bcb1169c1c1120c259dca64e777a64d0.

See https://github.com/rust-lang/rust/pull/161428.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
