### PR TITLE
fix warnings when linkcheck is disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Check build
         run: ENABLE_LINKCHECK=1 mdbook build
 
+      - name: Check build with link checking disabled
+        run: |
+          output=$(mktemp)
+          mdbook build 2>&1 | tee "$output"
+          ! grep -F "Broken pipe" "$output"
+
       - name: Save cached Linkcheck
         id: cache-linkcheck-save
         if: ${{ !cancelled() && github.event_name == 'schedule' }}

--- a/ci/linkcheck.sh
+++ b/ci/linkcheck.sh
@@ -11,6 +11,9 @@ set_github_token() {
 
 if [ -z "$ENABLE_LINKCHECK" ] ; then
   echo "Skipping link check."
+  # mdBook writes the render context to extensions over stdin.
+  # Discard it so mdBook doesn't warn about a broken pipe.
+  cat > /dev/null
   exit 0
 fi
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/rustc-dev-guide/issues/2808

@apiraino does this fix your problem? i believe those are just warnings and not hard errors, i would expect the output to still show up in `book/html`.

disclosure: the code and test were generated by an LLM. i wrote the comments.