### PR TITLE
Fix rust.override-allocator mentions

### DIFF
--- a/src/building/optimized-build.md
+++ b/src/building/optimized-build.md
@@ -31,11 +31,11 @@ Enabling LTO on Linux has [produced] speed-ups by up to 10%.
 ## Memory allocator
 
 Using a different memory allocator for `rustc` can provide significant performance benefits.
-If you want to enable the `jemalloc` allocator, you can set the `rust.override-allocator` option to `jemalloc`
+If you want to enable the `jemalloc` allocator, you can set the `build.allocator` option to `jemalloc`
 in `bootstrap.toml`:
 
 ```toml
-rust.override-allocator = "jemalloc"
+build.allocator = "jemalloc"
 ```
 
 > Note that this option is currently only supported for Linux and macOS targets.

--- a/src/profiling/with-perf.md
+++ b/src/profiling/with-perf.md
@@ -7,7 +7,7 @@ This is a guide for how to profile rustc with [perf](https://perf.wiki.kernel.or
 - Get a clean checkout of rust-lang/rust
 - Set the following settings in your `bootstrap.toml`:
   - `rust.debuginfo-level = 1` - enables line debuginfo
-  - leave `rust.override-allocator` unset - lets you do memory use profiling with valgrind
+  - leave `build.allocator` unset - lets you do memory use profiling with valgrind
   - leave everything else the defaults
 - Run `./x build` to get a full build
 - Make a rustup toolchain pointing to that result


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/160100 changed it from rust.override-allocator to build.allocator

This changes mentions to the new field