### PR TITLE
Add heaptrack memory profiling docs

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -46,6 +46,7 @@
     - [with the linux perf tool](./profiling/with-perf.md)
     - [with Windows Performance Analyzer](./profiling/wpa-profiling.md)
     - [with the Rust benchmark suite](./profiling/with-rustc-perf.md)
+    - [with the Heaptrack memory profiler](./profiling/with-heaptrack.md)
 - [crates.io dependencies](./crates-io.md)
 
 # Contributing to Rust

--- a/src/profiling.md
+++ b/src/profiling.md
@@ -24,6 +24,7 @@ Depending on what you're trying to measure, there are several different approach
 - If you want to profile memory usage, you can use various tools depending on what operating system
   you are using.
   - For Windows, read our [WPA guide](profiling/wpa-profiling.md).
+  - For linux, [heaptrack](profiling/with-heaptrack.md) is one of the many options.
 
 ## Optimizing rustc's bootstrap times with `cargo-llvm-lines`
 

--- a/src/profiling/with-heaptrack.md
+++ b/src/profiling/with-heaptrack.md
@@ -127,5 +127,12 @@ You can open it multiple ways:
 
 Note that comparing 2 large profiles can take a very long time to load or even hang.
 
+In the GUI you can see overall memory stats, multiple graph views,
+multiple tables of the data, and a memory allocation flamegraph.
 
-
+Tips:
+- In the flamegraph view, enabling the "Bottom-Up View" checkbox is often more helpful
+  for identifying which small allocations add up.
+- You can select an interesting time span on any of the graphs over time
+  (Consumed, Allocations, Temporary Allocations tabs), right click, and filter
+  all views to that time span.

--- a/src/profiling/with-heaptrack.md
+++ b/src/profiling/with-heaptrack.md
@@ -1,0 +1,107 @@
+# Profiling with heaptrack
+
+This is a guide for how to profile rustc memory allocations
+with [heaptrack](https://invent.kde.org/sdk/heaptrack) on linux.
+
+## Installing heaptrack
+
+While heaptrack has support for demangling rust symbols,
+the last full release is older than this support.
+
+That means either you have to compile heaptrack from
+its [git repo](https://invent.kde.org/sdk/heaptrack/),
+your distro package maintainers applied the correct patches,
+or you deal with mangled symbol names.
+
+## Initial steps
+
+- Set the following settings in your `bootstrap.toml`:
+  - `rust.debuginfo-level = 1` - enables line debuginfo
+  - leave `build.allocator` unset - heaptrack doesn't track jemalloc
+- Run `./x build library` to get a full build
+- Make a rustup toolchain pointing to that result
+  - see [the "build and run" section for instructions][b-a-r]
+
+[b-a-r]: ../building/how-to-build-and-run.md#toolchain
+
+
+## Usage
+
+### Bare rustc
+Heaptrack can be used with rustc calls directly:
+
+```sh
+heaptrack rustc foo.rs
+```
+
+### Cargo
+
+When invoked naively, heaptrack will only collect data about
+the cargo invocation itself, not rustc.
+ 
+To use it to profile a specific crates compilation,
+the RUSTC_WRAPPER script from below can be used (make sure its executable).
+
+<details> <summary><b>RUSTC_WRAPPER bash script</b></summary> 
+
+```sh
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OUTDIR="${HEAPTRACK_OUT_DIR:-/tmp/heaptrack}"
+TARGET_PKG="${HEAPTRACK_PKG_NAME:?set HEAPTRACK_PKG_NAME to the package you want profiled}"
+
+if [[ -z "${RUSTC_WRAPPER}" ]]; then
+    echo "this script is intended as a RUSTC_WRAPPER" >&2
+    exit 1
+fi
+
+if ! command -v heaptrack >/dev/null 2>&1; then
+    echo "command heaptrack not found, ensure it's in PATH" >&2
+    exit 1
+fi
+
+REAL_RUSTC="$1"
+shift
+
+# anything thats not the target package is executed normally 
+if [[ "${CARGO_PKG_NAME:-}" != "$TARGET_PKG" ]]; then
+    exec "$REAL_RUSTC" "$@"
+fi
+
+mkdir -p "$OUTDIR"
+
+# heaptrack complains if DEBUGINFOD_URLS is set
+unset DEBUGINFOD_URLS
+
+exec heaptrack \
+    --record-only \
+    -o "$OUTDIR/heaptrack.rustc-${CARGO_PKG_NAME}-v${CARGO_PKG_VERSION}-$$" \
+    "$REAL_RUSTC" "$@"
+
+
+```
+
+</details>
+
+Usage, assuming you want to profile `hashbrown` which is in your projects dependency tree
+```sh
+cargo clean -p hashbrown
+HEAPTRACK_PKG_NAME="hashbrown" RUSTC_WRAPPER=./heaptrack_wrapper.sh cargo build -p hashbrown
+```
+
+The script is configured through env vars.
+- `HEAPTRACK_PKG_NAME` can be any crate from the dependency tree compiled by your cargo command
+- `HEAPTRACK_OUT_DIR` optionally changes the output directory, which defaults to `/tmp/heaptrack`
+
+## Analyzing in the GUI
+
+Heaptrack has a GUI to analyze profiles.
+You can open it multiple ways:
+- calling `heaptrack <command>` will open it after the command is finished
+- `heaptrack --analyze <saved_profile>` will directly open a saved profile file
+- `heaptrack` will open the GUI prompt you to open a file, and optionally a second one to compare
+
+Note that comparing 2 large profiles can take a very long time to load or even hang.
+

--- a/src/profiling/with-heaptrack.md
+++ b/src/profiling/with-heaptrack.md
@@ -13,6 +13,28 @@ its [git repo](https://invent.kde.org/sdk/heaptrack/),
 your distro package maintainers applied the correct patches,
 or you deal with mangled symbol names.
 
+When you have the correct version, it looks for the `rustc_demangle.so` C-abi library using
+the system dynamic linker at runtime. To check that `rustc_demangle` is visible,
+you can use `ldconfig -p | grep rustc_demangle`.
+
+<details> <summary>`rustc_demangle` installation example</summary> 
+
+
+Note: This may not apply to all systems.
+```sh
+git clone https://github.com/rust-lang/rustc-demangle
+cd rustc-demangle
+cargo build --release --frozen --package rustc-demangle-capi
+# install built library files
+sudo install -Dm755 "target/release/librustc_demangle."{a,so} --target-directory "/usr/lib/"
+# optional, heaptrack doesn't need this
+sudo install -Dm644 "crates/capi/include/rustc_demangle.h" --target-directory "/usr/include/"
+# refresh linker cache
+sudo ldconfig
+```
+
+</details>
+
 ## Initial steps
 
 - Set the following settings in your `bootstrap.toml`:
@@ -104,4 +126,6 @@ You can open it multiple ways:
 - `heaptrack` will open the GUI prompt you to open a file, and optionally a second one to compare
 
 Note that comparing 2 large profiles can take a very long time to load or even hang.
+
+
 


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/162031 i've been primarily using Heaptrack.

Alas, its not as easy as just running cargo with it. First, its nice to have rust symbol demangling which needs some work, and then it needs a RUSTC_WRAPPER script because it doesn't work on child processes.

Since thats a bit of a hassle, i thought documenting it would be nice.