### PR TITLE
fix: typo in thir.md

### DIFF
--- a/src/thir.md
+++ b/src/thir.md
@@ -136,7 +136,7 @@ Thir {
             kind: Scope {
                 region_scope: Node(5),
                 hir_id: HirId(DefId(0:3 ~ main[26fd]::main).5),
-                // reference to expression 0 above
+                // reference to expression 2 above
                 value: e2,
             },
             ty: i32,


### PR DESCRIPTION
Fixes a typo in \src/thir.md\.\n\nA more comprehensive update to \src/hir/lowering.md\ (addressing the architectural changes in rust-lang/rust#157296 and rust-lang/rust#142830) will follow in a separate PR.

---

edit: 
close: https://github.com/rust-lang/rustc-dev-guide/issues/3004