### PR TITLE
Update CI date reference

### DIFF
--- a/src/tests/ci.md
+++ b/src/tests/ci.md
@@ -21,7 +21,7 @@ If you want to modify what gets executed on CI, see [Modifying CI jobs](#modifyi
 
 ## CI workflow
 
-<!-- date-check: Oct 2024 -->
+<!-- date-check: September 2026 -->
 
 Our CI is primarily executed on [GitHub Actions], with a single workflow defined
 in [`.github/workflows/ci.yml`], which contains a bunch of steps that are


### PR DESCRIPTION
### Change

- Check the date reference in `src/tests/ci.md` and update it to `September 2026`.

### Reason

- The related scripts are still in place, and `rust/.github/workflows/ci.yml` still describes the behavior documented in `rustc-dev-guide/src/tests/ci.md`.